### PR TITLE
Deploy all apps (web, party, games) on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.check.outputs.web }}
+      party: ${{ steps.check.outputs.party }}
+      games: ${{ steps.check.outputs.games }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Detect changed apps
+        id: check
+        run: |
+          BASE="${{ github.event.before }}"
+          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            echo "party=true" >> "$GITHUB_OUTPUT"
+            echo "games=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          for app in web party games; do
+            count=$(pnpm turbo build --dry-run=json --filter="@repo/${app}...[${BASE}]" | jq '.tasks | length')
+            if [ "$count" -gt 0 ]; then
+              echo "${app}=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "${app}=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
+
   deploy-web:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +71,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   deploy-party:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.party == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +92,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   deploy-games:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.games == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,8 @@ jobs:
           fi
 
           for app in web party games; do
-            if pnpm turbo ls --filter="@repo/${app}...[${BASE}]" 2>/dev/null | grep -q "@repo/"; then
+            output=$(pnpm turbo ls --filter="@repo/${app}...[${BASE}]") || { echo "${app}=true" >> "$GITHUB_OUTPUT"; continue; }
+            if echo "$output" | grep -q "@repo/"; then
               echo "${app}=true" >> "$GITHUB_OUTPUT"
             else
               echo "${app}=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,8 +41,7 @@ jobs:
           fi
 
           for app in web party games; do
-            count=$(pnpm turbo build --dry-run=json --filter="@repo/${app}...[${BASE}]" | jq '.tasks | length')
-            if [ "$count" -gt 0 ]; then
+            if pnpm turbo ls --filter="@repo/${app}...[${BASE}]" 2>/dev/null | grep -q "@repo/"; then
               echo "${app}=true" >> "$GITHUB_OUTPUT"
             else
               echo "${app}=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
 
 concurrency:
   group: deploy-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   detect-changes:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,3 +27,41 @@ jobs:
         run: pnpm turbo run build --filter=@repo/web... && pnpm -F @repo/web exec wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-party:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build & deploy party
+        run: pnpm turbo run build --filter=@repo/party... && pnpm -F @repo/party exec wrangler deploy --name vibedgames-party
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-games:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build & deploy games
+        run: pnpm turbo run build --filter=@repo/games... && pnpm -F @repo/games exec wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Add parallel deploy jobs for party server and games worker alongside the
existing web deploy. All three Cloudflare Workers now deploy automatically
on push to main.

https://claude.ai/code/session_01JwQwo9kUzebttRu2HEZtG2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the main-branch deployment workflow and introduces conditional deploy logic; mis-detection or workflow errors could skip or unexpectedly trigger deployments.
> 
> **Overview**
> Adds a new `detect-changes` job that uses `pnpm turbo ls` against `github.event.before` to decide which apps (`web`, `party`, `games`) changed, defaulting to deploy on first push and when detection fails.
> 
> Splits deployment into three conditional jobs (`deploy-web`, `deploy-party`, `deploy-games`) that build via Turbo and deploy via `wrangler` (with `party` deployed as `vibedgames-party`), enabling parallel per-app deploys on pushes to `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a24860d54127c376dd8c5bb7f244180d25a40b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploy all Cloudflare Workers (`@repo/web`, `@repo/party`, `@repo/games`) on merge to main with parallel jobs and per-app change detection via `turbo ls`. Adds safe fallbacks and queues runs to prevent skipped deploys.

- **New Features**
  - Added `detect-changes` job using `pnpm turbo ls --filter=@repo/<app>...[<ref>]` to decide which apps deploy, including dependency-only changes; first push deploys all when no base ref.
  - Conditional, parallel deploy jobs for `@repo/web`, `@repo/party` (`--name vibedgames-party`), and `@repo/games` using `turbo` + `wrangler`.

- **Bug Fixes**
  - If `turbo ls` fails, deploy the app and show the error in logs.
  - Removed `cancel-in-progress` so runs queue instead of cancel, preventing missed deploys when different apps change across pushes.

<sup>Written for commit 57a24860d54127c376dd8c5bb7f244180d25a40b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

