### PR TITLE
feat: add up/down arrows to navigate between games

### DIFF
--- a/apps/web/src/components/game/game-nav-arrows.tsx
+++ b/apps/web/src/components/game/game-nav-arrows.tsx
@@ -8,7 +8,7 @@ export const GameNavArrows = () => {
   const { game, view } = Route.useSearch();
   const navigate = useNavigate({ from: "/" });
 
-  const currentIndex = Math.max(0, featuredGames.findIndex((g) => g.url === game));
+  const currentIndex = featuredGames.findIndex((g) => g.url === game);
   const len = featuredGames.length;
 
   const goTo = (index: number) => {
@@ -18,7 +18,7 @@ export const GameNavArrows = () => {
     }
   };
 
-  if (view !== "play") return null;
+  if (view !== "play" || currentIndex === -1) return null;
 
   return (
     <div className="fixed right-4 top-1/2 z-10 hidden -translate-y-1/2 flex-col gap-1 md:flex">

--- a/apps/web/src/components/game/game-nav-arrows.tsx
+++ b/apps/web/src/components/game/game-nav-arrows.tsx
@@ -1,0 +1,44 @@
+import { useNavigate } from "@tanstack/react-router";
+import { ChevronUpIcon, ChevronDownIcon } from "lucide-react";
+
+import { Route } from "@/routes/index";
+import { featuredGames } from "./data";
+
+export const GameNavArrows = () => {
+  const { game, view } = Route.useSearch();
+  const navigate = useNavigate({ from: "/" });
+
+  const currentIndex = featuredGames.findIndex((g) => g.url === game);
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex < featuredGames.length - 1;
+
+  const goTo = (index: number) => {
+    const target = featuredGames[index];
+    if (target) {
+      navigate({ search: { view: "play", game: target.url } });
+    }
+  };
+
+  if (view !== "play") return null;
+
+  return (
+    <div className="fixed right-4 top-1/2 z-10 flex -translate-y-1/2 flex-col gap-1">
+      <button
+        onClick={() => hasPrev && goTo(currentIndex - 1)}
+        disabled={!hasPrev}
+        className="text-muted-foreground hover:text-foreground rounded-full p-2 transition disabled:opacity-20 disabled:hover:text-muted-foreground"
+        aria-label="Previous game"
+      >
+        <ChevronUpIcon className="size-5" />
+      </button>
+      <button
+        onClick={() => hasNext && goTo(currentIndex + 1)}
+        disabled={!hasNext}
+        className="text-muted-foreground hover:text-foreground rounded-full p-2 transition disabled:opacity-20 disabled:hover:text-muted-foreground"
+        aria-label="Next game"
+      >
+        <ChevronDownIcon className="size-5" />
+      </button>
+    </div>
+  );
+};

--- a/apps/web/src/components/game/game-nav-arrows.tsx
+++ b/apps/web/src/components/game/game-nav-arrows.tsx
@@ -8,7 +8,7 @@ export const GameNavArrows = () => {
   const { game, view } = Route.useSearch();
   const navigate = useNavigate({ from: "/" });
 
-  const currentIndex = featuredGames.findIndex((g) => g.url === game);
+  const currentIndex = Math.max(0, featuredGames.findIndex((g) => g.url === game));
   const len = featuredGames.length;
 
   const goTo = (index: number) => {

--- a/apps/web/src/components/game/game-nav-arrows.tsx
+++ b/apps/web/src/components/game/game-nav-arrows.tsx
@@ -21,7 +21,7 @@ export const GameNavArrows = () => {
   if (view !== "play") return null;
 
   return (
-    <div className="fixed right-4 top-1/2 z-10 flex -translate-y-1/2 flex-col gap-1">
+    <div className="fixed right-4 top-1/2 z-10 hidden -translate-y-1/2 flex-col gap-1 md:flex">
       <button
         onClick={() => goTo(currentIndex - 1)}
         className="text-muted-foreground hover:text-foreground rounded-full p-2 transition"

--- a/apps/web/src/components/game/game-nav-arrows.tsx
+++ b/apps/web/src/components/game/game-nav-arrows.tsx
@@ -9,11 +9,10 @@ export const GameNavArrows = () => {
   const navigate = useNavigate({ from: "/" });
 
   const currentIndex = featuredGames.findIndex((g) => g.url === game);
-  const hasPrev = currentIndex > 0;
-  const hasNext = currentIndex < featuredGames.length - 1;
+  const len = featuredGames.length;
 
   const goTo = (index: number) => {
-    const target = featuredGames[index];
+    const target = featuredGames[((index % len) + len) % len];
     if (target) {
       navigate({ search: { view: "play", game: target.url } });
     }
@@ -24,17 +23,15 @@ export const GameNavArrows = () => {
   return (
     <div className="fixed right-4 top-1/2 z-10 flex -translate-y-1/2 flex-col gap-1">
       <button
-        onClick={() => hasPrev && goTo(currentIndex - 1)}
-        disabled={!hasPrev}
-        className="text-muted-foreground hover:text-foreground rounded-full p-2 transition disabled:opacity-20 disabled:hover:text-muted-foreground"
+        onClick={() => goTo(currentIndex - 1)}
+        className="text-muted-foreground hover:text-foreground rounded-full p-2 transition"
         aria-label="Previous game"
       >
         <ChevronUpIcon className="size-5" />
       </button>
       <button
-        onClick={() => hasNext && goTo(currentIndex + 1)}
-        disabled={!hasNext}
-        className="text-muted-foreground hover:text-foreground rounded-full p-2 transition disabled:opacity-20 disabled:hover:text-muted-foreground"
+        onClick={() => goTo(currentIndex + 1)}
+        className="text-muted-foreground hover:text-foreground rounded-full p-2 transition"
         aria-label="Next game"
       >
         <ChevronDownIcon className="size-5" />

--- a/apps/web/src/components/game/page.tsx
+++ b/apps/web/src/components/game/page.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { featuredGames } from "./data";
 import { Canvas } from "./canvas";
 import { Composer } from "./composer";
+import { GameNavArrows } from "./game-nav-arrows";
 
 export const PageClient = () => {
   const [previewUrl, setPreviewUrl] = useState(featuredGames[0]?.url ?? "");
@@ -13,6 +14,7 @@ export const PageClient = () => {
         <Composer onHover={setPreviewUrl} />
       </header>
       <Canvas previewUrl={previewUrl} />
+      <GameNavArrows />
     </main>
   );
 };


### PR DESCRIPTION
Adds chevron arrows fixed to the center-right of the page that let
users move through the featured games list. Only visible in play view.

https://claude.ai/code/session_01QGX2GkpU8GK2NzGM1vDMYb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation change that updates client-side search params; minimal impact aside from potential edge cases when `game` isn’t in `featuredGames`.
> 
> **Overview**
> Adds a new `GameNavArrows` overlay that appears only in `view=play` and lets users navigate to the previous/next item in `featuredGames` via up/down chevron buttons (wrapping at the ends) by updating TanStack Router search params.
> 
> Wires the new navigation component into the game page layout so it renders alongside the existing canvas/composer UI, and hides it on mobile (`md`+ only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5812508707a57b0678d356c728a34ee91aa880b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add up/down chevron arrows fixed at the center-right in play view to navigate `featuredGames` (hidden on mobile). Clicks update search params (`view`, `game`) via `@tanstack/react-router`, loop at the ends, and the arrows are hidden if the current game isn’t in `featuredGames` (no full reload).

<sup>Written for commit 5812508707a57b0678d356c728a34ee91aa880b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

