### PR TITLE
feat: add 5 build page design variations

### DIFF
--- a/apps/web/src/components/game/composer.tsx
+++ b/apps/web/src/components/game/composer.tsx
@@ -1,24 +1,21 @@
-import { useState } from "react";
 import { cn } from "@repo/ui/utils";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { motion } from "motion/react";
 
 import { Route } from "@/routes/index";
 import { DiscoverView } from "./discover-view";
 import { PlayView } from "./play-view";
-import { WaitlistDailog } from "./waitlist-form";
 
 type Props = {
   onHover: (url: string) => void;
 };
 
 export const Composer = ({ onHover }: Props) => {
-  const [waitlistOpen, setWaitlistOpen] = useState(false);
   const { view } = Route.useSearch();
   const navigate = useNavigate({ from: "/" });
 
   const setView = (v: "play" | "discover") =>
-    navigate({ search: (prev) => ({ ...prev, view: v }) });
+    navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, view: v }) });
 
   return (
     <>
@@ -55,16 +52,15 @@ export const Composer = ({ onHover }: Props) => {
             />
           )}
         </button>
-        <button
+        <Link
+          to="/build-1"
           className={cn(
             "text-muted-foreground hover:text-foreground relative px-3 py-1.5 transition",
           )}
-          onClick={() => setWaitlistOpen(true)}
         >
           Build
-        </button>
+        </Link>
       </div>
-      <WaitlistDailog waitlistOpen={waitlistOpen} setWaitlistOpen={setWaitlistOpen} />
     </>
   );
 };

--- a/apps/web/src/components/game/composer.tsx
+++ b/apps/web/src/components/game/composer.tsx
@@ -1,16 +1,19 @@
+import { useState } from "react";
 import { cn } from "@repo/ui/utils";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { motion } from "motion/react";
 
 import { Route } from "@/routes/index";
 import { DiscoverView } from "./discover-view";
 import { PlayView } from "./play-view";
+import { WaitlistDailog } from "./waitlist-form";
 
 type Props = {
   onHover: (url: string) => void;
 };
 
 export const Composer = ({ onHover }: Props) => {
+  const [waitlistOpen, setWaitlistOpen] = useState(false);
   const { view } = Route.useSearch();
   const navigate = useNavigate({ from: "/" });
 
@@ -52,15 +55,16 @@ export const Composer = ({ onHover }: Props) => {
             />
           )}
         </button>
-        <Link
-          to="/build-1"
+        <button
           className={cn(
             "text-muted-foreground hover:text-foreground relative px-3 py-1.5 transition",
           )}
+          onClick={() => setWaitlistOpen(true)}
         >
           Build
-        </Link>
+        </button>
       </div>
+      <WaitlistDailog waitlistOpen={waitlistOpen} setWaitlistOpen={setWaitlistOpen} />
     </>
   );
 };

--- a/apps/web/src/routes/build-1.tsx
+++ b/apps/web/src/routes/build-1.tsx
@@ -1,8 +1,5 @@
-import { useState } from "react";
 import { Logo } from "@repo/ui/logo";
 import { createFileRoute, Link } from "@tanstack/react-router";
-
-import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
 
 export const Route = createFileRoute("/build-1")({
   head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
@@ -10,6 +7,12 @@ export const Route = createFileRoute("/build-1")({
 });
 
 const steps = [
+  {
+    prompt: "$",
+    command: "npx vibedgames skills .",
+    description:
+      "Add vibedgames skills to your project. Your LLM gets deploy, multiplayer, and more — ready to use.",
+  },
   {
     prompt: "you",
     command: "make me a flappy bird clone with pixel art",
@@ -31,8 +34,6 @@ const steps = [
 ];
 
 function Build1Page() {
-  const [waitlistOpen, setWaitlistOpen] = useState(false);
-
   return (
     <div className="relative min-h-dvh overflow-y-auto">
       <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
@@ -44,9 +45,6 @@ function Build1Page() {
 
       <main className="mx-auto max-w-2xl px-6 pt-28 pb-20 font-mono">
         <div className="mb-16">
-          <p className="text-muted-foreground mb-2 text-xs uppercase tracking-widest">
-            Currently in private beta
-          </p>
           <h1 className="mb-4 text-2xl font-light tracking-tight sm:text-3xl">
             Vibe a game. Ship it. Play it.
           </h1>
@@ -85,22 +83,20 @@ function Build1Page() {
             <span className="text-muted-foreground select-none">
               your-game &gt;
             </span>
-            <span className="text-foreground animate-pulse">live at your-game.vibedgames.com</span>
+            <span className="text-foreground animate-pulse">
+              live at your-game.vibedgames.com
+            </span>
           </div>
         </div>
 
         <div className="mt-12 flex flex-col items-center gap-4">
-          <p className="text-muted-foreground text-xs">
-            Get early access
-          </p>
-          <WaitlistForm />
+          <p className="text-muted-foreground text-xs">Get started</p>
+          <div className="bg-secondary/50 rounded-lg border border-white/5 px-5 py-3 text-sm">
+            <span className="text-muted-foreground select-none">$ </span>
+            <span className="text-foreground">npx vibedgames skills .</span>
+          </div>
         </div>
       </main>
-
-      <WaitlistDailog
-        waitlistOpen={waitlistOpen}
-        setWaitlistOpen={setWaitlistOpen}
-      />
     </div>
   );
 }

--- a/apps/web/src/routes/build-1.tsx
+++ b/apps/web/src/routes/build-1.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Logo } from "@repo/ui/logo";
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
+
+export const Route = createFileRoute("/build-1")({
+  head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
+  component: Build1Page,
+});
+
+const steps = [
+  {
+    prompt: "you",
+    command: "make me a flappy bird clone with pixel art",
+    description:
+      "Describe your game to any LLM. No boilerplate, no setup, no config files. Just say what you want.",
+  },
+  {
+    prompt: "you",
+    command: "now add multiplayer so my friends can race",
+    description:
+      "Real-time multiplayer is one sentence away. The LLM wires up host-authoritative state sync using our SDK. No servers to manage.",
+  },
+  {
+    prompt: "you",
+    command: "/deploy",
+    description:
+      "One slash command. Your game is built, uploaded, and live at your-game.vibedgames.com. Done.",
+  },
+];
+
+function Build1Page() {
+  const [waitlistOpen, setWaitlistOpen] = useState(false);
+
+  return (
+    <div className="relative min-h-dvh overflow-y-auto">
+      <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
+        <Link to="/" className="flex items-center gap-2">
+          <Logo className="w-6" />
+          <span className="font-mono text-sm">vibedgames</span>
+        </Link>
+      </nav>
+
+      <main className="mx-auto max-w-2xl px-6 pt-28 pb-20 font-mono">
+        <div className="mb-16">
+          <p className="text-muted-foreground mb-2 text-xs uppercase tracking-widest">
+            Currently in private beta
+          </p>
+          <h1 className="mb-4 text-2xl font-light tracking-tight sm:text-3xl">
+            Vibe a game. Ship it. Play it.
+          </h1>
+          <p className="text-muted-foreground max-w-md text-sm leading-relaxed">
+            You talk to your LLM. It builds the game, adds multiplayer, and
+            deploys it — all through skills that just work.
+          </p>
+        </div>
+
+        <div className="space-y-12">
+          {steps.map((step, i) => (
+            <div key={i} className="group relative">
+              <div className="text-muted-foreground mb-1 text-[10px] uppercase tracking-widest">
+                Step {i + 1}
+              </div>
+              <div className="bg-secondary/50 rounded-lg border border-white/5 p-4">
+                <div className="flex items-start gap-2">
+                  <span className="text-muted-foreground select-none">
+                    {step.prompt} &gt;
+                  </span>
+                  <span className="text-foreground">{step.command}</span>
+                </div>
+              </div>
+              <p className="text-muted-foreground mt-3 text-xs leading-relaxed">
+                {step.description}
+              </p>
+              {i < steps.length - 1 && (
+                <div className="border-muted ml-4 mt-4 h-8 border-l" />
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-16 text-center">
+          <div className="bg-secondary/50 mx-auto inline-flex items-center gap-2 rounded-lg border border-white/5 px-4 py-3">
+            <span className="text-muted-foreground select-none">
+              your-game &gt;
+            </span>
+            <span className="text-foreground animate-pulse">live at your-game.vibedgames.com</span>
+          </div>
+        </div>
+
+        <div className="mt-12 flex flex-col items-center gap-4">
+          <p className="text-muted-foreground text-xs">
+            Get early access
+          </p>
+          <WaitlistForm />
+        </div>
+      </main>
+
+      <WaitlistDailog
+        waitlistOpen={waitlistOpen}
+        setWaitlistOpen={setWaitlistOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/routes/build-2.tsx
+++ b/apps/web/src/routes/build-2.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { Logo } from "@repo/ui/logo";
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
+
+export const Route = createFileRoute("/build-2")({
+  head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
+  component: Build2Page,
+});
+
+const features = [
+  {
+    icon: "⌘",
+    title: "Deploy",
+    description:
+      "Say /deploy to your LLM. Your game is built and live in seconds at your-game.vibedgames.com.",
+  },
+  {
+    icon: "⚡",
+    title: "Multiplayer",
+    description:
+      "Ask for multiplayer and it's wired up. Real-time state sync, host authority, player management — handled.",
+  },
+  {
+    icon: "◈",
+    title: "Hosting",
+    description:
+      "Every game gets a subdomain. Global CDN, instant loads, no infra to think about.",
+  },
+  {
+    icon: "▣",
+    title: "Discovery",
+    description:
+      "Your game appears on vibedgames.com. Players find it, play it, share it.",
+  },
+  {
+    icon: "⊘",
+    title: "No Config",
+    description:
+      "No build configs, no server setup, no CI pipelines. The LLM handles all of it through skills.",
+  },
+  {
+    icon: "◉",
+    title: "LLM-Native",
+    description:
+      "Every feature is a skill your LLM already knows. You describe, it executes.",
+  },
+];
+
+function Build2Page() {
+  const [waitlistOpen, setWaitlistOpen] = useState(false);
+
+  return (
+    <div className="relative min-h-dvh overflow-y-auto">
+      <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
+        <Link to="/" className="flex items-center gap-2">
+          <Logo className="w-6" />
+          <span className="font-mono text-sm">vibedgames</span>
+        </Link>
+      </nav>
+
+      <main className="mx-auto max-w-4xl px-6 pt-28 pb-20 font-mono">
+        <div className="mb-16 text-center">
+          <p className="text-muted-foreground mb-3 text-xs uppercase tracking-widest">
+            Currently in private beta
+          </p>
+          <h1 className="mb-4 text-3xl font-light tracking-tight sm:text-4xl">
+            Everything you need to ship a game
+          </h1>
+          <p className="text-muted-foreground mx-auto max-w-lg text-sm leading-relaxed">
+            You talk to your LLM. We give it the tools to build, deploy, and add
+            multiplayer to your game — no config, no setup, no infra.
+          </p>
+        </div>
+
+        <div className="mb-16 flex justify-center">
+          <WaitlistForm />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((feature) => (
+            <div
+              key={feature.title}
+              className="group rounded-lg border border-white/5 bg-white/[0.02] p-5 transition hover:border-white/10 hover:bg-white/[0.04]"
+            >
+              <div className="text-muted-foreground mb-3 text-lg">
+                {feature.icon}
+              </div>
+              <h3 className="mb-1.5 text-sm font-medium">{feature.title}</h3>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                {feature.description}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-16 text-center">
+          <button
+            onClick={() => setWaitlistOpen(true)}
+            className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-4 transition"
+          >
+            Join the waitlist
+          </button>
+        </div>
+      </main>
+
+      <WaitlistDailog
+        waitlistOpen={waitlistOpen}
+        setWaitlistOpen={setWaitlistOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/routes/build-2.tsx
+++ b/apps/web/src/routes/build-2.tsx
@@ -1,8 +1,5 @@
-import { useState } from "react";
 import { Logo } from "@repo/ui/logo";
 import { createFileRoute, Link } from "@tanstack/react-router";
-
-import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
 
 export const Route = createFileRoute("/build-2")({
   head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
@@ -49,8 +46,6 @@ const features = [
 ];
 
 function Build2Page() {
-  const [waitlistOpen, setWaitlistOpen] = useState(false);
-
   return (
     <div className="relative min-h-dvh overflow-y-auto">
       <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
@@ -62,9 +57,6 @@ function Build2Page() {
 
       <main className="mx-auto max-w-4xl px-6 pt-28 pb-20 font-mono">
         <div className="mb-16 text-center">
-          <p className="text-muted-foreground mb-3 text-xs uppercase tracking-widest">
-            Currently in private beta
-          </p>
           <h1 className="mb-4 text-3xl font-light tracking-tight sm:text-4xl">
             Everything you need to ship a game
           </h1>
@@ -75,7 +67,10 @@ function Build2Page() {
         </div>
 
         <div className="mb-16 flex justify-center">
-          <WaitlistForm />
+          <div className="bg-secondary/50 rounded-lg border border-white/5 px-5 py-3 text-sm">
+            <span className="text-muted-foreground select-none">$ </span>
+            <span className="text-foreground">npx vibedgames skills .</span>
+          </div>
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -94,21 +89,7 @@ function Build2Page() {
             </div>
           ))}
         </div>
-
-        <div className="mt-16 text-center">
-          <button
-            onClick={() => setWaitlistOpen(true)}
-            className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-4 transition"
-          >
-            Join the waitlist
-          </button>
-        </div>
       </main>
-
-      <WaitlistDailog
-        waitlistOpen={waitlistOpen}
-        setWaitlistOpen={setWaitlistOpen}
-      />
     </div>
   );
 }

--- a/apps/web/src/routes/build-3.tsx
+++ b/apps/web/src/routes/build-3.tsx
@@ -1,9 +1,6 @@
-import { useState } from "react";
 import { Logo } from "@repo/ui/logo";
 import { cn } from "@repo/ui/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
-
-import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
 
 export const Route = createFileRoute("/build-3")({
   head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
@@ -12,18 +9,44 @@ export const Route = createFileRoute("/build-3")({
 
 const timeline = [
   {
+    label: "Install",
+    title: "Add skills to your project",
+    description:
+      "One command gives your LLM superpowers. Deploy, multiplayer, and more — all wired up as skills it can use.",
+    visual: (
+      <div className="bg-secondary/50 space-y-2 rounded-lg border border-white/5 p-4 text-xs">
+        <div className="text-muted-foreground">
+          <span className="text-muted-foreground/50">$</span> npx vibedgames
+          skills .
+        </div>
+        <div className="text-muted-foreground/50 mt-2">
+          <div>Downloading vibedgames skills...</div>
+          <div>Installing 15 skills...</div>
+          <div className="text-foreground mt-1">
+            ✓ Skills installed to .claude/skills/
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
     label: "Describe",
     title: "Tell your LLM what to build",
     description:
       'Just describe the game you want. "Make me a space shooter with retro pixel art." Your LLM generates the code, sets up the project, and gets it running locally.',
     visual: (
       <div className="bg-secondary/50 space-y-2 rounded-lg border border-white/5 p-4 text-xs">
-        <div className="text-muted-foreground">you &gt; make me a space shooter with retro pixel art and power-ups</div>
+        <div className="text-muted-foreground">
+          <span className="text-muted-foreground/50">you &gt;</span> make me a
+          space shooter with retro pixel art and power-ups
+        </div>
         <div className="text-muted-foreground/50 mt-2">
           <div>Creating game project...</div>
           <div>Setting up Phaser 3 with pixel art config...</div>
           <div>Adding player ship, enemies, power-up system...</div>
-          <div className="text-foreground mt-1">✓ Game running at localhost:5173</div>
+          <div className="text-foreground mt-1">
+            ✓ Game running at localhost:5173
+          </div>
         </div>
       </div>
     ),
@@ -35,12 +58,17 @@ const timeline = [
       "Say \"add multiplayer\" and your LLM wires up real-time state sync using our SDK. Host-authoritative, automatic host migration, player management — all handled.",
     visual: (
       <div className="bg-secondary/50 space-y-2 rounded-lg border border-white/5 p-4 text-xs">
-        <div className="text-muted-foreground">you &gt; add co-op multiplayer so friends can join</div>
+        <div className="text-muted-foreground">
+          <span className="text-muted-foreground/50">you &gt;</span> add co-op
+          multiplayer so friends can join
+        </div>
         <div className="text-muted-foreground/50 mt-2">
           <div>Installing @vibedgames/multiplayer...</div>
           <div>Adding player state sync...</div>
           <div>Setting up host authority...</div>
-          <div className="text-foreground mt-1">✓ Multiplayer ready — share link to invite players</div>
+          <div className="text-foreground mt-1">
+            ✓ Multiplayer ready — share link to invite players
+          </div>
         </div>
       </div>
     ),
@@ -52,11 +80,15 @@ const timeline = [
       "Tell your LLM to deploy, or just type /deploy. Your game is built, uploaded to our CDN, and live at your-game.vibedgames.com in seconds.",
     visual: (
       <div className="bg-secondary/50 space-y-2 rounded-lg border border-white/5 p-4 text-xs">
-        <div className="text-muted-foreground">you &gt; /deploy</div>
+        <div className="text-muted-foreground">
+          <span className="text-muted-foreground/50">you &gt;</span> /deploy
+        </div>
         <div className="text-muted-foreground/50 mt-2">
           <div>Building for production...</div>
           <div>Uploading to vibedgames CDN...</div>
-          <div className="text-foreground mt-1">✓ Live at space-shooter.vibedgames.com</div>
+          <div className="text-foreground mt-1">
+            ✓ Live at space-shooter.vibedgames.com
+          </div>
         </div>
       </div>
     ),
@@ -73,8 +105,12 @@ const timeline = [
         </div>
         <div>
           <div className="text-foreground font-medium">Space Shooter</div>
-          <div className="text-muted-foreground">space-shooter.vibedgames.com</div>
-          <div className="text-muted-foreground/50 mt-0.5">multiplayer · 2 players online</div>
+          <div className="text-muted-foreground">
+            space-shooter.vibedgames.com
+          </div>
+          <div className="text-muted-foreground/50 mt-0.5">
+            multiplayer · 2 players online
+          </div>
         </div>
       </div>
     ),
@@ -82,8 +118,6 @@ const timeline = [
 ];
 
 function Build3Page() {
-  const [waitlistOpen, setWaitlistOpen] = useState(false);
-
   return (
     <div className="relative min-h-dvh overflow-y-auto">
       <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
@@ -95,9 +129,6 @@ function Build3Page() {
 
       <main className="mx-auto max-w-3xl px-6 pt-28 pb-20 font-mono">
         <div className="mb-20 text-center">
-          <p className="text-muted-foreground mb-3 text-xs uppercase tracking-widest">
-            Currently in private beta
-          </p>
           <h1 className="mb-4 text-2xl font-light tracking-tight sm:text-3xl">
             From idea to live game in minutes
           </h1>
@@ -125,17 +156,13 @@ function Build3Page() {
                   <div
                     className={cn(
                       "sm:direction-ltr",
-                      i % 2 === 0
-                        ? "sm:pr-10"
-                        : "sm:order-2 sm:pl-10",
+                      i % 2 === 0 ? "sm:pr-10" : "sm:order-2 sm:pl-10",
                     )}
                   >
                     <div className="text-muted-foreground mb-1 text-[10px] uppercase tracking-widest">
                       {item.label}
                     </div>
-                    <h3 className="mb-2 text-sm font-medium">
-                      {item.title}
-                    </h3>
+                    <h3 className="mb-2 text-sm font-medium">{item.title}</h3>
                     <p className="text-muted-foreground text-xs leading-relaxed">
                       {item.description}
                     </p>
@@ -143,9 +170,7 @@ function Build3Page() {
                   <div
                     className={cn(
                       "sm:direction-ltr",
-                      i % 2 === 0
-                        ? "sm:order-2 sm:pl-10"
-                        : "sm:pr-10",
+                      i % 2 === 0 ? "sm:order-2 sm:pl-10" : "sm:pr-10",
                     )}
                   >
                     {item.visual}
@@ -157,15 +182,13 @@ function Build3Page() {
         </div>
 
         <div className="mt-20 flex flex-col items-center gap-4">
-          <p className="text-muted-foreground text-xs">Get early access</p>
-          <WaitlistForm />
+          <p className="text-muted-foreground text-xs">Get started</p>
+          <div className="bg-secondary/50 rounded-lg border border-white/5 px-5 py-3 text-sm">
+            <span className="text-muted-foreground select-none">$ </span>
+            <span className="text-foreground">npx vibedgames skills .</span>
+          </div>
         </div>
       </main>
-
-      <WaitlistDailog
-        waitlistOpen={waitlistOpen}
-        setWaitlistOpen={setWaitlistOpen}
-      />
     </div>
   );
 }

--- a/apps/web/src/routes/build-3.tsx
+++ b/apps/web/src/routes/build-3.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { Logo } from "@repo/ui/logo";
+import { cn } from "@repo/ui/utils";
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
+
+export const Route = createFileRoute("/build-3")({
+  head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
+  component: Build3Page,
+});
+
+const timeline = [
+  {
+    label: "Describe",
+    title: "Tell your LLM what to build",
+    description:
+      'Just describe the game you want. "Make me a space shooter with retro pixel art." Your LLM generates the code, sets up the project, and gets it running locally.',
+    visual: (
+      <div className="bg-secondary/50 space-y-2 rounded-lg border border-white/5 p-4 text-xs">
+        <div className="text-muted-foreground">you &gt; make me a space shooter with retro pixel art and power-ups</div>
+        <div className="text-muted-foreground/50 mt-2">
+          <div>Creating game project...</div>
+          <div>Setting up Phaser 3 with pixel art config...</div>
+          <div>Adding player ship, enemies, power-up system...</div>
+          <div className="text-foreground mt-1">✓ Game running at localhost:5173</div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    label: "Multiplayer",
+    title: "Add multiplayer in one sentence",
+    description:
+      "Say \"add multiplayer\" and your LLM wires up real-time state sync using our SDK. Host-authoritative, automatic host migration, player management — all handled.",
+    visual: (
+      <div className="bg-secondary/50 space-y-2 rounded-lg border border-white/5 p-4 text-xs">
+        <div className="text-muted-foreground">you &gt; add co-op multiplayer so friends can join</div>
+        <div className="text-muted-foreground/50 mt-2">
+          <div>Installing @vibedgames/multiplayer...</div>
+          <div>Adding player state sync...</div>
+          <div>Setting up host authority...</div>
+          <div className="text-foreground mt-1">✓ Multiplayer ready — share link to invite players</div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    label: "Deploy",
+    title: "Ship with one command",
+    description:
+      "Tell your LLM to deploy, or just type /deploy. Your game is built, uploaded to our CDN, and live at your-game.vibedgames.com in seconds.",
+    visual: (
+      <div className="bg-secondary/50 space-y-2 rounded-lg border border-white/5 p-4 text-xs">
+        <div className="text-muted-foreground">you &gt; /deploy</div>
+        <div className="text-muted-foreground/50 mt-2">
+          <div>Building for production...</div>
+          <div>Uploading to vibedgames CDN...</div>
+          <div className="text-foreground mt-1">✓ Live at space-shooter.vibedgames.com</div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    label: "Play",
+    title: "Your game is on the platform",
+    description:
+      "Players discover your game on vibedgames.com. Global CDN, instant loads, zero maintenance. Just share the link.",
+    visual: (
+      <div className="bg-secondary/50 flex items-center gap-3 rounded-lg border border-white/5 p-4 text-xs">
+        <div className="bg-muted flex h-12 w-12 shrink-0 items-center justify-center rounded border border-white/5 text-lg">
+          🚀
+        </div>
+        <div>
+          <div className="text-foreground font-medium">Space Shooter</div>
+          <div className="text-muted-foreground">space-shooter.vibedgames.com</div>
+          <div className="text-muted-foreground/50 mt-0.5">multiplayer · 2 players online</div>
+        </div>
+      </div>
+    ),
+  },
+];
+
+function Build3Page() {
+  const [waitlistOpen, setWaitlistOpen] = useState(false);
+
+  return (
+    <div className="relative min-h-dvh overflow-y-auto">
+      <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
+        <Link to="/" className="flex items-center gap-2">
+          <Logo className="w-6" />
+          <span className="font-mono text-sm">vibedgames</span>
+        </Link>
+      </nav>
+
+      <main className="mx-auto max-w-3xl px-6 pt-28 pb-20 font-mono">
+        <div className="mb-20 text-center">
+          <p className="text-muted-foreground mb-3 text-xs uppercase tracking-widest">
+            Currently in private beta
+          </p>
+          <h1 className="mb-4 text-2xl font-light tracking-tight sm:text-3xl">
+            From idea to live game in minutes
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Talk to your LLM. It does the rest.
+          </p>
+        </div>
+
+        <div className="relative">
+          {/* Timeline line */}
+          <div className="absolute top-0 bottom-0 left-[15px] w-px bg-white/10 sm:left-1/2 sm:-translate-x-px" />
+
+          <div className="space-y-16">
+            {timeline.map((item, i) => (
+              <div key={item.label} className="relative">
+                {/* Timeline dot */}
+                <div className="absolute left-[11px] top-1 z-10 flex h-[9px] w-[9px] items-center justify-center rounded-full border border-white/20 bg-white/10 sm:left-1/2 sm:-translate-x-1/2" />
+
+                <div
+                  className={cn(
+                    "grid gap-6 pl-10 sm:grid-cols-2 sm:gap-10 sm:pl-0",
+                    i % 2 === 0 ? "sm:text-right" : "sm:direction-rtl",
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "sm:direction-ltr",
+                      i % 2 === 0
+                        ? "sm:pr-10"
+                        : "sm:order-2 sm:pl-10",
+                    )}
+                  >
+                    <div className="text-muted-foreground mb-1 text-[10px] uppercase tracking-widest">
+                      {item.label}
+                    </div>
+                    <h3 className="mb-2 text-sm font-medium">
+                      {item.title}
+                    </h3>
+                    <p className="text-muted-foreground text-xs leading-relaxed">
+                      {item.description}
+                    </p>
+                  </div>
+                  <div
+                    className={cn(
+                      "sm:direction-ltr",
+                      i % 2 === 0
+                        ? "sm:order-2 sm:pl-10"
+                        : "sm:pr-10",
+                    )}
+                  >
+                    {item.visual}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-20 flex flex-col items-center gap-4">
+          <p className="text-muted-foreground text-xs">Get early access</p>
+          <WaitlistForm />
+        </div>
+      </main>
+
+      <WaitlistDailog
+        waitlistOpen={waitlistOpen}
+        setWaitlistOpen={setWaitlistOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/routes/build-4.tsx
+++ b/apps/web/src/routes/build-4.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { Logo } from "@repo/ui/logo";
+import { cn } from "@repo/ui/utils";
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
+
+export const Route = createFileRoute("/build-4")({
+  head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
+  component: Build4Page,
+});
+
+const faqs = [
+  {
+    question: "How do I build a game?",
+    answer:
+      'Describe what you want to any LLM — Claude, ChatGPT, whatever you use. "Make me a platformer with double jump and pixel art." The LLM generates the code, scaffolds the project, and runs it locally. You iterate by talking to it.',
+  },
+  {
+    question: "How does deployment work?",
+    answer:
+      'Tell your LLM to deploy, or type /deploy. It builds your game for production, uploads it to our global CDN, and your game is live at your-game.vibedgames.com. No CI pipeline, no Docker, no config. One command.',
+  },
+  {
+    question: "How do I add multiplayer?",
+    answer:
+      '"Add multiplayer so my friends can play together." That\'s it. Your LLM installs our multiplayer SDK (@vibedgames/multiplayer) and wires up real-time state sync. We handle host authority, player management, and automatic host migration.',
+  },
+  {
+    question: "What frameworks are supported?",
+    answer:
+      "Any browser game that builds to static HTML/JS. Phaser, Three.js, Pixi.js, p5.js, plain canvas — if it runs in a browser, it deploys to vibedgames. Your LLM picks the best framework for what you're building.",
+  },
+  {
+    question: "Where does my game live?",
+    answer:
+      "Every game gets a subdomain: your-game.vibedgames.com. Served from a global CDN with instant loads. Games also appear on the vibedgames.com discover page where players can find and play them.",
+  },
+  {
+    question: "Do I need to know how to code?",
+    answer:
+      "No. The whole point is that your LLM handles the code. You describe, iterate, and ship. If you do know how to code, you can always jump into the source — it's your project, running locally.",
+  },
+];
+
+function Build4Page() {
+  const [waitlistOpen, setWaitlistOpen] = useState(false);
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <div className="relative min-h-dvh overflow-y-auto">
+      <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
+        <Link to="/" className="flex items-center gap-2">
+          <Logo className="w-6" />
+          <span className="font-mono text-sm">vibedgames</span>
+        </Link>
+      </nav>
+
+      <main className="mx-auto max-w-xl px-6 pt-28 pb-20 font-mono">
+        <div className="mb-10 text-center">
+          <h1 className="mb-3 text-3xl font-light tracking-tight sm:text-4xl">
+            Build. Deploy. Play.
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            All from a chat with your LLM.
+          </p>
+        </div>
+
+        <div className="mb-12 flex justify-center">
+          <WaitlistForm />
+        </div>
+
+        <div className="text-muted-foreground mb-6 text-center text-[10px] uppercase tracking-widest">
+          How it works
+        </div>
+
+        <div className="divide-y divide-white/5">
+          {faqs.map((faq, i) => (
+            <div key={i}>
+              <button
+                onClick={() => setOpenIndex(openIndex === i ? null : i)}
+                className="hover:text-foreground text-muted-foreground flex w-full items-center justify-between py-4 text-left text-sm transition"
+              >
+                <span>{faq.question}</span>
+                <span
+                  className={cn(
+                    "ml-4 shrink-0 text-xs transition-transform duration-200",
+                    openIndex === i && "rotate-45",
+                  )}
+                >
+                  +
+                </span>
+              </button>
+              <div
+                className={cn(
+                  "grid transition-all duration-200 ease-in-out",
+                  openIndex === i
+                    ? "grid-rows-[1fr] opacity-100"
+                    : "grid-rows-[0fr] opacity-0",
+                )}
+              >
+                <div className="overflow-hidden">
+                  <p className="text-muted-foreground pb-4 text-xs leading-relaxed">
+                    {faq.answer}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-12 text-center">
+          <button
+            onClick={() => setWaitlistOpen(true)}
+            className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-4 transition"
+          >
+            Join the waitlist
+          </button>
+        </div>
+      </main>
+
+      <WaitlistDailog
+        waitlistOpen={waitlistOpen}
+        setWaitlistOpen={setWaitlistOpen}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/routes/build-4.tsx
+++ b/apps/web/src/routes/build-4.tsx
@@ -3,8 +3,6 @@ import { Logo } from "@repo/ui/logo";
 import { cn } from "@repo/ui/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 
-import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
-
 export const Route = createFileRoute("/build-4")({
   head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
   component: Build4Page,
@@ -12,9 +10,14 @@ export const Route = createFileRoute("/build-4")({
 
 const faqs = [
   {
+    question: "How do I get started?",
+    answer:
+      'Run "npx vibedgames skills ." in your project directory. This installs skills that your LLM (Claude, etc.) can use — deploy, multiplayer, game dev helpers, and more. Then just start talking to your LLM.',
+  },
+  {
     question: "How do I build a game?",
     answer:
-      'Describe what you want to any LLM — Claude, ChatGPT, whatever you use. "Make me a platformer with double jump and pixel art." The LLM generates the code, scaffolds the project, and runs it locally. You iterate by talking to it.',
+      'Describe what you want to any LLM. "Make me a platformer with double jump and pixel art." The LLM generates the code, scaffolds the project, and runs it locally. You iterate by talking to it.',
   },
   {
     question: "How does deployment work?",
@@ -36,15 +39,9 @@ const faqs = [
     answer:
       "Every game gets a subdomain: your-game.vibedgames.com. Served from a global CDN with instant loads. Games also appear on the vibedgames.com discover page where players can find and play them.",
   },
-  {
-    question: "Do I need to know how to code?",
-    answer:
-      "No. The whole point is that your LLM handles the code. You describe, iterate, and ship. If you do know how to code, you can always jump into the source — it's your project, running locally.",
-  },
 ];
 
 function Build4Page() {
-  const [waitlistOpen, setWaitlistOpen] = useState(false);
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   return (
@@ -67,7 +64,10 @@ function Build4Page() {
         </div>
 
         <div className="mb-12 flex justify-center">
-          <WaitlistForm />
+          <div className="bg-secondary/50 rounded-lg border border-white/5 px-5 py-3 text-sm">
+            <span className="text-muted-foreground select-none">$ </span>
+            <span className="text-foreground">npx vibedgames skills .</span>
+          </div>
         </div>
 
         <div className="text-muted-foreground mb-6 text-center text-[10px] uppercase tracking-widest">
@@ -108,21 +108,7 @@ function Build4Page() {
             </div>
           ))}
         </div>
-
-        <div className="mt-12 text-center">
-          <button
-            onClick={() => setWaitlistOpen(true)}
-            className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-4 transition"
-          >
-            Join the waitlist
-          </button>
-        </div>
       </main>
-
-      <WaitlistDailog
-        waitlistOpen={waitlistOpen}
-        setWaitlistOpen={setWaitlistOpen}
-      />
     </div>
   );
 }

--- a/apps/web/src/routes/build-5.tsx
+++ b/apps/web/src/routes/build-5.tsx
@@ -1,10 +1,7 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import { Logo } from "@repo/ui/logo";
-import { cn } from "@repo/ui/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { motion, useInView } from "motion/react";
-
-import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
 
 export const Route = createFileRoute("/build-5")({
   head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
@@ -52,8 +49,6 @@ function TypingLine({ text, delay = 0 }: { text: string; delay?: number }) {
 }
 
 function Build5Page() {
-  const [waitlistOpen, setWaitlistOpen] = useState(false);
-
   return (
     <div className="relative min-h-dvh overflow-y-auto">
       <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
@@ -71,9 +66,6 @@ function Build5Page() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, ease: [0.21, 0.47, 0.32, 0.98] }}
           >
-            <p className="text-muted-foreground mb-4 text-xs uppercase tracking-widest">
-              Currently in private beta
-            </p>
             <h1 className="mb-4 text-3xl font-light tracking-tight sm:text-5xl">
               Your LLM builds the game.
               <br />
@@ -84,7 +76,12 @@ function Build5Page() {
               hosting — all through skills your LLM already knows.
             </p>
             <div className="flex justify-center">
-              <WaitlistForm />
+              <div className="bg-secondary/50 rounded-lg border border-white/5 px-5 py-3 text-sm">
+                <span className="text-muted-foreground select-none">$ </span>
+                <span className="text-foreground">
+                  npx vibedgames skills .
+                </span>
+              </div>
             </div>
           </motion.div>
           <motion.div
@@ -97,12 +94,52 @@ function Build5Page() {
           </motion.div>
         </section>
 
-        {/* Section: Describe */}
+        {/* Section: Install */}
         <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
           <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
             <div>
               <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                01 — Describe
+                01 — Install
+              </div>
+              <h2 className="mb-3 text-xl font-light sm:text-2xl">
+                Add skills to your project
+              </h2>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                One command installs vibedgames skills into your project. Your
+                LLM gets deploy, multiplayer, asset generation, and more — ready
+                to use in any conversation.
+              </p>
+            </div>
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
+              <div className="space-y-3 text-xs">
+                <div className="text-muted-foreground">
+                  <span className="text-muted-foreground/50">$</span> npx
+                  vibedgames skills .
+                </div>
+                <div className="border-t border-white/5 pt-3">
+                  <TypingLine
+                    delay={0.3}
+                    text="Downloading vibedgames skills..."
+                  />
+                  <TypingLine delay={0.6} text="Installing 15 skills..." />
+                  <div className="mt-2">
+                    <TypingLine
+                      delay={0.9}
+                      text="✓ Skills installed to .claude/skills/"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </AnimatedSection>
+
+        {/* Section: Describe */}
+        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
+          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
+            <div className="sm:order-2">
+              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
+                02 — Describe
               </div>
               <h2 className="mb-3 text-xl font-light sm:text-2xl">
                 Say what you want
@@ -113,19 +150,34 @@ function Build5Page() {
                 picks the right framework, and runs it locally.
               </p>
             </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5 sm:order-1">
               <div className="space-y-3 text-xs">
                 <div className="text-muted-foreground">
                   <span className="text-muted-foreground/50">you &gt;</span>{" "}
                   build me an asteroid mining game with physics
                 </div>
                 <div className="border-t border-white/5 pt-3">
-                  <TypingLine delay={0.3} text="Setting up project with Matter.js physics..." />
-                  <TypingLine delay={0.6} text="Creating asteroid field generator..." />
-                  <TypingLine delay={0.9} text="Adding mining beam mechanics..." />
-                  <TypingLine delay={1.2} text="Implementing resource collection UI..." />
+                  <TypingLine
+                    delay={0.3}
+                    text="Setting up project with Matter.js physics..."
+                  />
+                  <TypingLine
+                    delay={0.6}
+                    text="Creating asteroid field generator..."
+                  />
+                  <TypingLine
+                    delay={0.9}
+                    text="Adding mining beam mechanics..."
+                  />
+                  <TypingLine
+                    delay={1.2}
+                    text="Implementing resource collection UI..."
+                  />
                   <div className="mt-2">
-                    <TypingLine delay={1.5} text="✓ Game running at localhost:5173" />
+                    <TypingLine
+                      delay={1.5}
+                      text="✓ Game running at localhost:5173"
+                    />
                   </div>
                 </div>
               </div>
@@ -136,9 +188,9 @@ function Build5Page() {
         {/* Section: Multiplayer */}
         <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
           <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
-            <div className="sm:order-2">
+            <div>
               <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                02 — Multiplayer
+                03 — Multiplayer
               </div>
               <h2 className="mb-3 text-xl font-light sm:text-2xl">
                 One sentence, real-time
@@ -149,18 +201,30 @@ function Build5Page() {
                 networking code to write.
               </p>
             </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5 sm:order-1">
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
               <div className="space-y-3 text-xs">
                 <div className="text-muted-foreground">
                   <span className="text-muted-foreground/50">you &gt;</span>{" "}
                   add multiplayer so friends can mine together
                 </div>
                 <div className="border-t border-white/5 pt-3">
-                  <TypingLine delay={0.3} text="Installing @vibedgames/multiplayer..." />
-                  <TypingLine delay={0.6} text="Syncing asteroid positions across players..." />
-                  <TypingLine delay={0.9} text="Adding shared resource pool..." />
+                  <TypingLine
+                    delay={0.3}
+                    text="Installing @vibedgames/multiplayer..."
+                  />
+                  <TypingLine
+                    delay={0.6}
+                    text="Syncing asteroid positions across players..."
+                  />
+                  <TypingLine
+                    delay={0.9}
+                    text="Adding shared resource pool..."
+                  />
                   <div className="mt-2">
-                    <TypingLine delay={1.2} text="✓ Co-op multiplayer ready" />
+                    <TypingLine
+                      delay={1.2}
+                      text="✓ Co-op multiplayer ready"
+                    />
                   </div>
                 </div>
               </div>
@@ -171,9 +235,9 @@ function Build5Page() {
         {/* Section: Deploy */}
         <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
           <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
-            <div>
+            <div className="sm:order-2">
               <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                03 — Deploy
+                04 — Deploy
               </div>
               <h2 className="mb-3 text-xl font-light sm:text-2xl">
                 Live in seconds
@@ -184,18 +248,30 @@ function Build5Page() {
                 link and anyone can play.
               </p>
             </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5 sm:order-1">
               <div className="space-y-3 text-xs">
                 <div className="text-muted-foreground">
                   <span className="text-muted-foreground/50">you &gt;</span>{" "}
                   /deploy
                 </div>
                 <div className="border-t border-white/5 pt-3">
-                  <TypingLine delay={0.3} text="Building for production..." />
-                  <TypingLine delay={0.6} text="Optimizing assets (143kb)..." />
-                  <TypingLine delay={0.9} text="Uploading to vibedgames CDN..." />
+                  <TypingLine
+                    delay={0.3}
+                    text="Building for production..."
+                  />
+                  <TypingLine
+                    delay={0.6}
+                    text="Optimizing assets (143kb)..."
+                  />
+                  <TypingLine
+                    delay={0.9}
+                    text="Uploading to vibedgames CDN..."
+                  />
                   <div className="mt-2">
-                    <TypingLine delay={1.2} text="✓ Live at asteroid-miner.vibedgames.com" />
+                    <TypingLine
+                      delay={1.2}
+                      text="✓ Live at asteroid-miner.vibedgames.com"
+                    />
                   </div>
                 </div>
               </div>
@@ -206,9 +282,9 @@ function Build5Page() {
         {/* Section: Play */}
         <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
           <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
-            <div className="sm:order-2">
+            <div>
               <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                04 — Play
+                05 — Play
               </div>
               <h2 className="mb-3 text-xl font-light sm:text-2xl">
                 Players find your game
@@ -219,12 +295,27 @@ function Build5Page() {
                 maintenance.
               </p>
             </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5 sm:order-1">
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
               <div className="space-y-3">
                 {[
-                  { name: "Asteroid Miner", slug: "asteroid-miner", players: "4 playing", icon: "⛏" },
-                  { name: "Space Shooter", slug: "space-shooter", players: "2 playing", icon: "🚀" },
-                  { name: "Pixel Racer", slug: "pixel-racer", players: "6 playing", icon: "🏎" },
+                  {
+                    name: "Asteroid Miner",
+                    slug: "asteroid-miner",
+                    players: "4 playing",
+                    icon: "⛏",
+                  },
+                  {
+                    name: "Space Shooter",
+                    slug: "space-shooter",
+                    players: "2 playing",
+                    icon: "🚀",
+                  },
+                  {
+                    name: "Pixel Racer",
+                    slug: "pixel-racer",
+                    players: "6 playing",
+                    icon: "🏎",
+                  },
                 ].map((game) => (
                   <div
                     key={game.slug}
@@ -257,18 +348,13 @@ function Build5Page() {
             <h2 className="text-2xl font-light tracking-tight sm:text-3xl">
               Ready to ship your game?
             </h2>
-            <p className="text-muted-foreground max-w-sm text-sm">
-              Join the waitlist to get early access to vibedgames.
-            </p>
-            <WaitlistForm />
+            <div className="bg-secondary/50 rounded-lg border border-white/5 px-5 py-3 text-sm">
+              <span className="text-muted-foreground select-none">$ </span>
+              <span className="text-foreground">npx vibedgames skills .</span>
+            </div>
           </AnimatedSection>
         </section>
       </main>
-
-      <WaitlistDailog
-        waitlistOpen={waitlistOpen}
-        setWaitlistOpen={setWaitlistOpen}
-      />
     </div>
   );
 }

--- a/apps/web/src/routes/build-5.tsx
+++ b/apps/web/src/routes/build-5.tsx
@@ -1,0 +1,274 @@
+import { useState, useRef } from "react";
+import { Logo } from "@repo/ui/logo";
+import { cn } from "@repo/ui/utils";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { motion, useInView } from "motion/react";
+
+import { WaitlistDailog, WaitlistForm } from "@/components/game/waitlist-form";
+
+export const Route = createFileRoute("/build-5")({
+  head: () => ({ meta: [{ title: "Build — Vibedgames" }] }),
+  component: Build5Page,
+});
+
+function AnimatedSection({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-100px" });
+
+  return (
+    <motion.section
+      ref={ref}
+      initial={{ opacity: 0, y: 40 }}
+      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 40 }}
+      transition={{ duration: 0.6, ease: [0.21, 0.47, 0.32, 0.98] }}
+      className={className}
+    >
+      {children}
+    </motion.section>
+  );
+}
+
+function TypingLine({ text, delay = 0 }: { text: string; delay?: number }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-50px" });
+
+  return (
+    <div ref={ref} className="overflow-hidden">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={isInView ? { opacity: 1 } : { opacity: 0 }}
+        transition={{ delay, duration: 0.4 }}
+      >
+        {text}
+      </motion.div>
+    </div>
+  );
+}
+
+function Build5Page() {
+  const [waitlistOpen, setWaitlistOpen] = useState(false);
+
+  return (
+    <div className="relative min-h-dvh overflow-y-auto">
+      <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
+        <Link to="/" className="flex items-center gap-2">
+          <Logo className="w-6" />
+          <span className="font-mono text-sm">vibedgames</span>
+        </Link>
+      </nav>
+
+      <main className="font-mono">
+        {/* Hero */}
+        <section className="flex min-h-dvh flex-col items-center justify-center px-6 text-center">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, ease: [0.21, 0.47, 0.32, 0.98] }}
+          >
+            <p className="text-muted-foreground mb-4 text-xs uppercase tracking-widest">
+              Currently in private beta
+            </p>
+            <h1 className="mb-4 text-3xl font-light tracking-tight sm:text-5xl">
+              Your LLM builds the game.
+              <br />
+              <span className="text-muted-foreground">We handle the rest.</span>
+            </h1>
+            <p className="text-muted-foreground mx-auto mb-10 max-w-md text-sm leading-relaxed">
+              Infrastructure for vibe-coded games. Multiplayer, deployment,
+              hosting — all through skills your LLM already knows.
+            </p>
+            <div className="flex justify-center">
+              <WaitlistForm />
+            </div>
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 1.2, duration: 0.8 }}
+            className="text-muted-foreground/30 mt-16 text-xs"
+          >
+            scroll to explore ↓
+          </motion.div>
+        </section>
+
+        {/* Section: Describe */}
+        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
+          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
+            <div>
+              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
+                01 — Describe
+              </div>
+              <h2 className="mb-3 text-xl font-light sm:text-2xl">
+                Say what you want
+              </h2>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                Describe your game to any LLM. A platformer, a puzzle game, a
+                space shooter — whatever you're vibing. It writes the code,
+                picks the right framework, and runs it locally.
+              </p>
+            </div>
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
+              <div className="space-y-3 text-xs">
+                <div className="text-muted-foreground">
+                  <span className="text-muted-foreground/50">you &gt;</span>{" "}
+                  build me an asteroid mining game with physics
+                </div>
+                <div className="border-t border-white/5 pt-3">
+                  <TypingLine delay={0.3} text="Setting up project with Matter.js physics..." />
+                  <TypingLine delay={0.6} text="Creating asteroid field generator..." />
+                  <TypingLine delay={0.9} text="Adding mining beam mechanics..." />
+                  <TypingLine delay={1.2} text="Implementing resource collection UI..." />
+                  <div className="mt-2">
+                    <TypingLine delay={1.5} text="✓ Game running at localhost:5173" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </AnimatedSection>
+
+        {/* Section: Multiplayer */}
+        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
+          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
+            <div className="sm:order-2">
+              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
+                02 — Multiplayer
+              </div>
+              <h2 className="mb-3 text-xl font-light sm:text-2xl">
+                One sentence, real-time
+              </h2>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                "Make it multiplayer." Your LLM installs our SDK, wires up state
+                sync, and handles host authority. No servers to configure, no
+                networking code to write.
+              </p>
+            </div>
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5 sm:order-1">
+              <div className="space-y-3 text-xs">
+                <div className="text-muted-foreground">
+                  <span className="text-muted-foreground/50">you &gt;</span>{" "}
+                  add multiplayer so friends can mine together
+                </div>
+                <div className="border-t border-white/5 pt-3">
+                  <TypingLine delay={0.3} text="Installing @vibedgames/multiplayer..." />
+                  <TypingLine delay={0.6} text="Syncing asteroid positions across players..." />
+                  <TypingLine delay={0.9} text="Adding shared resource pool..." />
+                  <div className="mt-2">
+                    <TypingLine delay={1.2} text="✓ Co-op multiplayer ready" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </AnimatedSection>
+
+        {/* Section: Deploy */}
+        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
+          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
+            <div>
+              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
+                03 — Deploy
+              </div>
+              <h2 className="mb-3 text-xl font-light sm:text-2xl">
+                Live in seconds
+              </h2>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                One slash command. Your game is built for production, uploaded to
+                our global CDN, and live at your-game.vibedgames.com. Share the
+                link and anyone can play.
+              </p>
+            </div>
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
+              <div className="space-y-3 text-xs">
+                <div className="text-muted-foreground">
+                  <span className="text-muted-foreground/50">you &gt;</span>{" "}
+                  /deploy
+                </div>
+                <div className="border-t border-white/5 pt-3">
+                  <TypingLine delay={0.3} text="Building for production..." />
+                  <TypingLine delay={0.6} text="Optimizing assets (143kb)..." />
+                  <TypingLine delay={0.9} text="Uploading to vibedgames CDN..." />
+                  <div className="mt-2">
+                    <TypingLine delay={1.2} text="✓ Live at asteroid-miner.vibedgames.com" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </AnimatedSection>
+
+        {/* Section: Play */}
+        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
+          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
+            <div className="sm:order-2">
+              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
+                04 — Play
+              </div>
+              <h2 className="mb-3 text-xl font-light sm:text-2xl">
+                Players find your game
+              </h2>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                Your game appears on vibedgames.com where players can discover,
+                play, and share it. Global CDN for instant loads. Zero
+                maintenance.
+              </p>
+            </div>
+            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5 sm:order-1">
+              <div className="space-y-3">
+                {[
+                  { name: "Asteroid Miner", slug: "asteroid-miner", players: "4 playing", icon: "⛏" },
+                  { name: "Space Shooter", slug: "space-shooter", players: "2 playing", icon: "🚀" },
+                  { name: "Pixel Racer", slug: "pixel-racer", players: "6 playing", icon: "🏎" },
+                ].map((game) => (
+                  <div
+                    key={game.slug}
+                    className="flex items-center gap-3 rounded border border-white/5 bg-white/[0.02] p-3 text-xs"
+                  >
+                    <div className="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded text-sm">
+                      {game.icon}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-foreground truncate font-medium">
+                        {game.name}
+                      </div>
+                      <div className="text-muted-foreground/50">
+                        {game.slug}.vibedgames.com
+                      </div>
+                    </div>
+                    <div className="text-muted-foreground/50 shrink-0">
+                      {game.players}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </AnimatedSection>
+
+        {/* CTA */}
+        <section className="flex min-h-[50vh] flex-col items-center justify-center px-6 py-20 text-center">
+          <AnimatedSection className="flex flex-col items-center gap-6">
+            <h2 className="text-2xl font-light tracking-tight sm:text-3xl">
+              Ready to ship your game?
+            </h2>
+            <p className="text-muted-foreground max-w-sm text-sm">
+              Join the waitlist to get early access to vibedgames.
+            </p>
+            <WaitlistForm />
+          </AnimatedSection>
+        </section>
+      </main>
+
+      <WaitlistDailog
+        waitlistOpen={waitlistOpen}
+        setWaitlistOpen={setWaitlistOpen}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Add 5 build page design variations (`/build-1` through `/build-5`) for evaluating different onboarding page layouts. Each showcases how to use the platform via `npx vibedgames skills .` as the CTA.

**Variations:**
1. `/build-1` — Terminal Walkthrough (step-by-step terminal-style flow)
2. `/build-2` — Feature Cards Grid (hero + 6 feature cards)
3. `/build-3` — Vertical Timeline (alternating left-right timeline)
4. `/build-4` — Hero + Accordion FAQ (minimal hero with expandable Q&A)
5. `/build-5` — Interactive Demo Flow (full-viewport scroll sections with motion animations)

**Notes:**
- Composer "Build" button intentionally still opens the waitlist dialog (unchanged)
- Build pages intentionally do NOT include the waitlist form — they showcase the plugin install command instead
- Pages are accessible directly via URL for design review
- Only non-behavioral change to existing code: type annotation fix on `navigate` callback in `composer.tsx`

https://claude.ai/code/session_01PQJnVVBGVAYn3RMV2yE6BK