### PR TITLE
add vg init, portable skills installer

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -11,12 +11,21 @@ npm i -g vibedgames
 ## Commands
 
 ```sh
+vg init [dir]         # install Claude Code skills into ./.claude/skills
 vg login              # authenticate via browser
 vg logout             # clear credentials
 vg whoami             # show current user
 vg deploy [dir]       # deploy a game directory
 vg deploy ./dist --slug my-game
 ```
+
+`vg skills install` is an alias for `vg init`.
+
+## Using with Claude Code
+
+Run `vg init` in your project to drop the full set of game-building skills
+(Phaser, Three.js, Aseprite, fal.ai, deploy, etc.) into `./.claude/skills/`.
+Claude picks them up automatically on next session.
 
 ## How deploy works
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -19,7 +19,8 @@
     "@trpc/client": "catalog:",
     "citty": "^0.1.6",
     "consola": "^3.4.2",
-    "superjson": "catalog:"
+    "superjson": "catalog:",
+    "tar": "^7.5.13"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,7 +20,7 @@
     "citty": "^0.1.6",
     "consola": "^3.4.2",
     "superjson": "catalog:",
-    "tar": "^7.5.13"
+    "tar-stream": "^3.1.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
@@ -28,6 +28,7 @@
     "@repo/api": "workspace:^",
     "@trpc/server": "catalog:",
     "@types/node": "catalog:",
+    "@types/tar-stream": "^3.1.4",
     "typescript": "catalog:"
   }
 }

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -2,9 +2,9 @@ import { defineCommand } from "citty";
 
 import { installSkills } from "../lib/install-skills.js";
 
-const installSubcommand = defineCommand({
+export const initCommand = defineCommand({
   meta: {
-    name: "install",
+    name: "init",
     description: "Install vibedgames Claude Code skills into your project",
   },
   args: {
@@ -21,14 +21,4 @@ const installSubcommand = defineCommand({
     },
   },
   run: ({ args }) => installSkills(args.dir, args.force),
-});
-
-export const skillsCommand = defineCommand({
-  meta: {
-    name: "skills",
-    description: "Manage vibedgames Claude Code skills",
-  },
-  subCommands: {
-    install: installSubcommand,
-  },
 });

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -2,11 +2,10 @@ import { defineCommand } from "citty";
 
 import { installSkills } from "../lib/install-skills.js";
 
+const description = "Install vibedgames Claude Code skills into your project";
+
 export const initCommand = defineCommand({
-  meta: {
-    name: "init",
-    description: "Install vibedgames Claude Code skills into your project",
-  },
+  meta: { name: "init", description },
   args: {
     dir: {
       type: "positional",
@@ -21,4 +20,9 @@ export const initCommand = defineCommand({
     },
   },
   run: ({ args }) => installSkills(args.dir, args.force),
+});
+
+export const skillsInstallCommand = defineCommand({
+  ...initCommand,
+  meta: { name: "install", description },
 });

--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -1,27 +1,6 @@
 import { defineCommand } from "citty";
 
-import { installSkills } from "../lib/install-skills.js";
-
-const installSubcommand = defineCommand({
-  meta: {
-    name: "install",
-    description: "Install vibedgames Claude Code skills into your project",
-  },
-  args: {
-    dir: {
-      type: "positional",
-      description: "Project directory",
-      required: false,
-      default: ".",
-    },
-    force: {
-      type: "boolean",
-      description: "Overwrite existing skills without prompting",
-      default: false,
-    },
-  },
-  run: ({ args }) => installSkills(args.dir, args.force),
-});
+import { skillsInstallCommand } from "./init.js";
 
 export const skillsCommand = defineCommand({
   meta: {
@@ -29,6 +8,6 @@ export const skillsCommand = defineCommand({
     description: "Manage vibedgames Claude Code skills",
   },
   subCommands: {
-    install: installSubcommand,
+    install: skillsInstallCommand,
   },
 });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { defineCommand, runMain } from "citty";
 
 import { deployCommand } from "./commands/deploy.js";
+import { initCommand } from "./commands/init.js";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
 import { skillsCommand } from "./commands/skills.js";
@@ -14,6 +15,7 @@ const main = defineCommand({
     description: "vibedgames CLI",
   },
   subCommands: {
+    init: initCommand,
     login: loginCommand,
     logout: logoutCommand,
     deploy: deployCommand,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
 import { defineCommand, runMain } from "citty";
 
 import { deployCommand } from "./commands/deploy.js";
@@ -8,10 +10,14 @@ import { logoutCommand } from "./commands/logout.js";
 import { skillsCommand } from "./commands/skills.js";
 import { whoamiCommand } from "./commands/whoami.js";
 
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string };
+
 const main = defineCommand({
   meta: {
     name: "vg",
-    version: "0.0.1",
+    version: pkg.version,
     description: "vibedgames CLI",
   },
   subCommands: {

--- a/apps/cli/src/lib/install-skills.ts
+++ b/apps/cli/src/lib/install-skills.ts
@@ -1,13 +1,60 @@
-import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import {
+  cpSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
 
 import consola from "consola";
-import { x as extract } from "tar";
+import { extract } from "tar-stream";
 
 const REPO = "kyh/vibedgames";
 const BRANCH = "main";
+
+const extractFiltered = (tmpDir: string, prefix: string) => {
+  const extractor = extract();
+
+  extractor.on("entry", (header, stream, next) => {
+    if (!header.name.startsWith(prefix)) {
+      stream.on("end", next);
+      stream.resume();
+      return;
+    }
+
+    const relPath = header.name.slice(prefix.length);
+    if (!relPath) {
+      stream.on("end", next);
+      stream.resume();
+      return;
+    }
+
+    const outPath = join(tmpDir, relPath);
+
+    if (header.type === "directory") {
+      mkdirSync(outPath, { recursive: true });
+      stream.on("end", next);
+      stream.resume();
+      return;
+    }
+
+    if (header.type === "file") {
+      mkdirSync(dirname(outPath), { recursive: true });
+      stream.pipe(createWriteStream(outPath)).on("finish", next);
+      return;
+    }
+
+    stream.on("end", next);
+    stream.resume();
+  });
+
+  return extractor;
+};
 
 export const installSkills = async (projectDir: string, force: boolean) => {
   const targetDir = join(projectDir, ".claude", "skills");
@@ -38,20 +85,16 @@ export const installSkills = async (projectDir: string, force: boolean) => {
     const prefix = `vibedgames-${BRANCH}/plugins/`;
     await pipeline(
       Readable.fromWeb(res.body),
-      extract({
-        cwd: tmpDir,
-        strip: 1,
-        filter: (path) => path.startsWith(prefix),
-      }),
+      createGunzip(),
+      extractFiltered(tmpDir, prefix),
     );
 
     mkdirSync(targetDir, { recursive: true });
 
-    const pluginsDir = join(tmpDir, "plugins");
     const installed: string[] = [];
 
-    for (const plugin of readdirSync(pluginsDir)) {
-      const skillsDir = join(pluginsDir, plugin, "skills");
+    for (const plugin of readdirSync(tmpDir)) {
+      const skillsDir = join(tmpDir, plugin, "skills");
       if (!existsSync(skillsDir)) continue;
 
       for (const skill of readdirSync(skillsDir)) {

--- a/apps/cli/src/lib/install-skills.ts
+++ b/apps/cli/src/lib/install-skills.ts
@@ -1,12 +1,11 @@
 import {
-  cpSync,
   createWriteStream,
   existsSync,
   mkdirSync,
   readdirSync,
   rmSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, relative, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGunzip } from "node:zlib";
@@ -16,31 +15,45 @@ import { extract } from "tar-stream";
 
 const REPO = "kyh/vibedgames";
 const BRANCH = "main";
+const PREFIX = `vibedgames-${BRANCH}/plugins/`;
 
-const extractFiltered = (tmpDir: string, prefix: string) => {
+const isInside = (parent: string, child: string) => {
+  const rel = relative(parent, child);
+  return !!rel && !rel.startsWith("..") && !rel.startsWith(`..${sep}`);
+};
+
+const extractToTarget = (targetDir: string) => {
+  const targetResolved = resolve(targetDir);
+  const installed = new Set<string>();
+  const wiped = new Set<string>();
   const extractor = extract();
 
   extractor.on("entry", (header, stream, next) => {
-    if (!header.name.startsWith(prefix)) {
+    const skip = () => {
       stream.on("end", next);
       stream.resume();
+    };
+
+    if (!header.name.startsWith(PREFIX)) return skip();
+    const parts = header.name.slice(PREFIX.length).split("/").filter(Boolean);
+    const [, skillsSegment, skill, ...rest] = parts;
+    if (skillsSegment !== "skills" || !skill) return skip();
+
+    const outPath = resolve(targetResolved, skill, ...rest);
+    if (!isInside(targetResolved, outPath)) {
+      next(new Error(`Refusing to extract outside target dir: ${header.name}`));
       return;
     }
 
-    const relPath = header.name.slice(prefix.length);
-    if (!relPath) {
-      stream.on("end", next);
-      stream.resume();
-      return;
+    if (!wiped.has(skill)) {
+      rmSync(resolve(targetResolved, skill), { recursive: true, force: true });
+      wiped.add(skill);
     }
-
-    const outPath = join(tmpDir, relPath);
+    installed.add(skill);
 
     if (header.type === "directory") {
       mkdirSync(outPath, { recursive: true });
-      stream.on("end", next);
-      stream.resume();
-      return;
+      return skip();
     }
 
     if (header.type === "file") {
@@ -49,17 +62,15 @@ const extractFiltered = (tmpDir: string, prefix: string) => {
       return;
     }
 
-    stream.on("end", next);
-    stream.resume();
+    return skip();
   });
 
-  return extractor;
+  return { extractor, installed };
 };
 
 export const installSkills = async (projectDir: string, force: boolean) => {
-  const targetDir = join(projectDir, ".claude", "skills");
+  const targetDir = resolve(projectDir, ".claude", "skills");
   const tarballUrl = `https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz`;
-  const tmpDir = join(projectDir, ".vg-skills-tmp");
 
   if (existsSync(targetDir) && readdirSync(targetDir).length > 0 && !force) {
     const proceed = await consola.prompt(
@@ -74,45 +85,17 @@ export const installSkills = async (projectDir: string, force: boolean) => {
 
   consola.start("Fetching skills from vibedgames...");
 
-  try {
-    mkdirSync(tmpDir, { recursive: true });
-
-    const res = await fetch(tarballUrl);
-    if (!res.ok || !res.body) {
-      throw new Error(`Failed to download tarball: ${res.status}`);
-    }
-
-    const prefix = `vibedgames-${BRANCH}/plugins/`;
-    await pipeline(
-      Readable.fromWeb(res.body),
-      createGunzip(),
-      extractFiltered(tmpDir, prefix),
-    );
-
-    mkdirSync(targetDir, { recursive: true });
-
-    const installed: string[] = [];
-
-    for (const plugin of readdirSync(tmpDir)) {
-      const skillsDir = join(tmpDir, plugin, "skills");
-      if (!existsSync(skillsDir)) continue;
-
-      for (const skill of readdirSync(skillsDir)) {
-        const dest = join(targetDir, skill);
-        if (existsSync(dest)) rmSync(dest, { recursive: true });
-        cpSync(join(skillsDir, skill), dest, { recursive: true });
-        installed.push(skill);
-      }
-    }
-
-    consola.success(`Installed ${installed.length} skills to ${targetDir}`);
-    consola.log(`  ${installed.join(", ")}`);
-  } catch (err) {
-    consola.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
-  } finally {
-    if (existsSync(tmpDir)) {
-      rmSync(tmpDir, { recursive: true });
-    }
+  const res = await fetch(tarballUrl);
+  if (!res.ok || !res.body) {
+    throw new Error(`Failed to download tarball: ${res.status}`);
   }
+
+  mkdirSync(targetDir, { recursive: true });
+
+  const { extractor, installed } = extractToTarget(targetDir);
+  await pipeline(Readable.fromWeb(res.body), createGunzip(), extractor);
+
+  const skills = [...installed];
+  consola.success(`Installed ${skills.length} skills to ${targetDir}`);
+  consola.log(`  ${skills.join(", ")}`);
 };

--- a/apps/cli/src/lib/install-skills.ts
+++ b/apps/cli/src/lib/install-skills.ts
@@ -1,8 +1,10 @@
-import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 import consola from "consola";
+import { x as extract } from "tar";
 
 const REPO = "kyh/vibedgames";
 const BRANCH = "main";
@@ -28,9 +30,19 @@ export const installSkills = async (projectDir: string, force: boolean) => {
   try {
     mkdirSync(tmpDir, { recursive: true });
 
-    execSync(
-      `curl -sL "${tarballUrl}" | tar xz --strip-components=1 -C "${tmpDir}" "vibedgames-${BRANCH}/plugins"`,
-      { stdio: "pipe" },
+    const res = await fetch(tarballUrl);
+    if (!res.ok || !res.body) {
+      throw new Error(`Failed to download tarball: ${res.status}`);
+    }
+
+    const prefix = `vibedgames-${BRANCH}/plugins/`;
+    await pipeline(
+      Readable.fromWeb(res.body),
+      extract({
+        cwd: tmpDir,
+        strip: 1,
+        filter: (path) => path.startsWith(prefix),
+      }),
     );
 
     mkdirSync(targetDir, { recursive: true });
@@ -45,9 +57,7 @@ export const installSkills = async (projectDir: string, force: boolean) => {
       for (const skill of readdirSync(skillsDir)) {
         const dest = join(targetDir, skill);
         if (existsSync(dest)) rmSync(dest, { recursive: true });
-        execSync(`cp -r "${join(skillsDir, skill)}" "${targetDir}/"`, {
-          stdio: "pipe",
-        });
+        cpSync(join(skillsDir, skill), dest, { recursive: true });
         installed.push(skill);
       }
     }

--- a/apps/cli/src/lib/install-skills.ts
+++ b/apps/cli/src/lib/install-skills.ts
@@ -58,7 +58,7 @@ const extractToTarget = (targetDir: string) => {
 
     if (header.type === "file") {
       mkdirSync(dirname(outPath), { recursive: true });
-      stream.pipe(createWriteStream(outPath)).on("finish", next);
+      pipeline(stream, createWriteStream(outPath)).then(() => next(), next);
       return;
     }
 

--- a/apps/cli/src/lib/install-skills.ts
+++ b/apps/cli/src/lib/install-skills.ts
@@ -1,0 +1,65 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import consola from "consola";
+
+const REPO = "kyh/vibedgames";
+const BRANCH = "main";
+
+export const installSkills = async (projectDir: string, force: boolean) => {
+  const targetDir = join(projectDir, ".claude", "skills");
+  const tarballUrl = `https://github.com/${REPO}/archive/refs/heads/${BRANCH}.tar.gz`;
+  const tmpDir = join(projectDir, ".vg-skills-tmp");
+
+  if (existsSync(targetDir) && readdirSync(targetDir).length > 0 && !force) {
+    const proceed = await consola.prompt(
+      `${targetDir} already has content. Overwrite existing skills?`,
+      { type: "confirm", initial: false },
+    );
+    if (!proceed) {
+      consola.info("Aborted.");
+      return;
+    }
+  }
+
+  consola.start("Fetching skills from vibedgames...");
+
+  try {
+    mkdirSync(tmpDir, { recursive: true });
+
+    execSync(
+      `curl -sL "${tarballUrl}" | tar xz --strip-components=1 -C "${tmpDir}" "vibedgames-${BRANCH}/plugins"`,
+      { stdio: "pipe" },
+    );
+
+    mkdirSync(targetDir, { recursive: true });
+
+    const pluginsDir = join(tmpDir, "plugins");
+    const installed: string[] = [];
+
+    for (const plugin of readdirSync(pluginsDir)) {
+      const skillsDir = join(pluginsDir, plugin, "skills");
+      if (!existsSync(skillsDir)) continue;
+
+      for (const skill of readdirSync(skillsDir)) {
+        const dest = join(targetDir, skill);
+        if (existsSync(dest)) rmSync(dest, { recursive: true });
+        execSync(`cp -r "${join(skillsDir, skill)}" "${targetDir}/"`, {
+          stdio: "pipe",
+        });
+        installed.push(skill);
+      }
+    }
+
+    consola.success(`Installed ${installed.length} skills to ${targetDir}`);
+    consola.log(`  ${installed.join(", ")}`);
+  } catch (err) {
+    consola.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  } finally {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true });
+    }
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,81 +6,27 @@ settings:
 
 catalogs:
   default:
-    '@cloudflare/vite-plugin':
-      specifier: ^1.3.0
-      version: 1.31.2
     '@cloudflare/workers-types':
       specifier: ^4.20260408.1
       version: 4.20260409.1
     '@kyh/tsconfig':
       specifier: ^1.1.14
       version: 1.1.14
-    '@tailwindcss/vite':
-      specifier: ^4.2.2
-      version: 4.2.2
-    '@tanstack/react-query':
-      specifier: ^5.96.2
-      version: 5.97.0
-    '@tanstack/react-router':
-      specifier: ^1.168.10
-      version: 1.168.10
-    '@tanstack/react-router-ssr-query':
-      specifier: ^1.166.10
-      version: 1.166.10
-    '@tanstack/react-start':
-      specifier: ^1.167.16
-      version: 1.167.16
     '@trpc/client':
       specifier: ^11.16.0
       version: 11.16.0
     '@trpc/server':
       specifier: ^11.16.0
       version: 11.16.0
-    '@trpc/tanstack-react-query':
-      specifier: ^11.16.0
-      version: 11.16.0
     '@types/node':
       specifier: ^25.5.2
       version: 25.5.2
-    '@types/react':
-      specifier: ^19.2.14
-      version: 19.2.14
-    '@types/react-dom':
-      specifier: ^19.2.3
-      version: 19.2.3
-    '@vitejs/plugin-react':
-      specifier: ^6.0.1
-      version: 6.0.1
-    '@vitejs/plugin-react-swc':
-      specifier: ^4.3.0
-      version: 4.3.0
-    globals:
-      specifier: ^17.4.0
-      version: 17.4.0
-    react:
-      specifier: ^19.2.4
-      version: 19.2.4
-    react-dom:
-      specifier: ^19.2.4
-      version: 19.2.4
     superjson:
       specifier: ^2.2.6
       version: 2.2.6
-    tailwindcss:
-      specifier: ^4.2.2
-      version: 4.2.2
     typescript:
       specifier: ^6.0.2
       version: 6.0.2
-    vite:
-      specifier: ^8.0.7
-      version: 8.0.8
-    wrangler:
-      specifier: ^4.81.0
-      version: 4.81.1
-    zod:
-      specifier: ^4.3.6
-      version: 3.25.76
 
 overrides:
   react-hook-form: ^7.72.1
@@ -122,6 +68,9 @@ importers:
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
+      tar:
+        specifier: ^7.5.13
+        version: 7.5.13
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -9202,7 +9151,6 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
-    optional: true
 
   '@isaacs/ttlcache@1.4.1':
     optional: true
@@ -11242,8 +11190,7 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
-  chownr@3.0.0:
-    optional: true
+  chownr@3.0.0: {}
 
   chrome-launcher@0.15.2:
     dependencies:
@@ -13241,13 +13188,11 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.3:
-    optional: true
+  minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
-    optional: true
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -14565,7 +14510,6 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
-    optional: true
 
   terminal-link@2.1.1:
     dependencies:
@@ -15043,8 +14987,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@5.0.0:
-    optional: true
+  yallist@5.0.0: {}
 
   yaml@2.8.3:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,27 +6,81 @@ settings:
 
 catalogs:
   default:
+    '@cloudflare/vite-plugin':
+      specifier: ^1.3.0
+      version: 1.31.2
     '@cloudflare/workers-types':
       specifier: ^4.20260408.1
       version: 4.20260409.1
     '@kyh/tsconfig':
       specifier: ^1.1.14
       version: 1.1.14
+    '@tailwindcss/vite':
+      specifier: ^4.2.2
+      version: 4.2.2
+    '@tanstack/react-query':
+      specifier: ^5.96.2
+      version: 5.97.0
+    '@tanstack/react-router':
+      specifier: ^1.168.10
+      version: 1.168.10
+    '@tanstack/react-router-ssr-query':
+      specifier: ^1.166.10
+      version: 1.166.10
+    '@tanstack/react-start':
+      specifier: ^1.167.16
+      version: 1.167.16
     '@trpc/client':
       specifier: ^11.16.0
       version: 11.16.0
     '@trpc/server':
       specifier: ^11.16.0
       version: 11.16.0
+    '@trpc/tanstack-react-query':
+      specifier: ^11.16.0
+      version: 11.16.0
     '@types/node':
       specifier: ^25.5.2
       version: 25.5.2
+    '@types/react':
+      specifier: ^19.2.14
+      version: 19.2.14
+    '@types/react-dom':
+      specifier: ^19.2.3
+      version: 19.2.3
+    '@vitejs/plugin-react':
+      specifier: ^6.0.1
+      version: 6.0.1
+    '@vitejs/plugin-react-swc':
+      specifier: ^4.3.0
+      version: 4.3.0
+    globals:
+      specifier: ^17.4.0
+      version: 17.4.0
+    react:
+      specifier: ^19.2.4
+      version: 19.2.4
+    react-dom:
+      specifier: ^19.2.4
+      version: 19.2.4
     superjson:
       specifier: ^2.2.6
       version: 2.2.6
+    tailwindcss:
+      specifier: ^4.2.2
+      version: 4.2.2
     typescript:
       specifier: ^6.0.2
       version: 6.0.2
+    vite:
+      specifier: ^8.0.7
+      version: 8.0.8
+    wrangler:
+      specifier: ^4.81.0
+      version: 4.81.1
+    zod:
+      specifier: ^4.3.6
+      version: 4.3.6
 
 overrides:
   react-hook-form: ^7.72.1
@@ -68,9 +122,9 @@ importers:
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
-      tar:
-        specifier: ^7.5.13
-        version: 7.5.13
+      tar-stream:
+        specifier: ^3.1.8
+        version: 3.1.8
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -87,6 +141,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.2
+      '@types/tar-stream':
+        specifier: ^3.1.4
+        version: 3.1.4
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -577,7 +634,7 @@ importers:
         version: 1.4.0
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.3.6
     devDependencies:
       '@kyh/tsconfig':
         specifier: 'catalog:'
@@ -3578,6 +3635,9 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
+
   '@types/three@0.182.0':
     resolution: {integrity: sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==}
 
@@ -3818,6 +3878,14 @@ packages:
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
@@ -3894,6 +3962,47 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.0:
+    resolution: {integrity: sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.0:
+    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.2:
+    resolution: {integrity: sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -4734,6 +4843,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -4849,6 +4961,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -6773,6 +6888,9 @@ packages:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
     engines: {node: '>= 0.10.0'}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -6894,9 +7012,15 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
@@ -6926,6 +7050,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -9151,6 +9278,7 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
+    optional: true
 
   '@isaacs/ttlcache@1.4.1':
     optional: true
@@ -10483,6 +10611,10 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 25.5.2
+
   '@types/three@0.182.0':
     dependencies:
       '@dimforge/rapier3d-compat': 0.12.0
@@ -10768,6 +10900,8 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
+  b4a@1.8.0: {}
+
   babel-dead-code-elimination@1.0.12:
     dependencies:
       '@babel/core': 7.29.0
@@ -10926,6 +11060,38 @@ snapshots:
     optional: true
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.0(bare-events@2.8.2)
+      bare-url: 2.4.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.0: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.0
+
+  bare-stream@2.13.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.2:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -11190,7 +11356,8 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
-  chownr@3.0.0: {}
+  chownr@3.0.0:
+    optional: true
 
   chrome-launcher@0.15.2:
     dependencies:
@@ -11773,6 +11940,12 @@ snapshots:
   event-target-shim@5.0.1:
     optional: true
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0:
     optional: true
 
@@ -11961,6 +12134,8 @@ snapshots:
     optional: true
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -13188,11 +13363,13 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.3: {}
+  minipass@7.1.3:
+    optional: true
 
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
+    optional: true
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -14375,6 +14552,15 @@ snapshots:
   stream-buffers@2.2.0:
     optional: true
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
@@ -14503,6 +14689,17 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar@7.5.13:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -14510,6 +14707,14 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+    optional: true
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   terminal-link@2.1.1:
     dependencies:
@@ -14542,6 +14747,12 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
     optional: true
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thenify-all@1.6.0:
     dependencies:
@@ -14987,7 +15198,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@5.0.0: {}
+  yallist@5.0.0:
+    optional: true
 
   yaml@2.8.3:
     optional: true


### PR DESCRIPTION
## Summary

- New `vg init` command drops all marketplace skills into `./.claude/skills/`. `vg skills install` is an alias.
- Fixes the broken `vg skills` command — was pulling from the empty `.claude/skills/` path; now pulls from `plugins/*/skills/*` where skills actually live.
- Replaces `curl | tar` shell-out with Node `fetch` + `tar-stream` + built-in `zlib`. Cross-platform, no shell deps. ~56kB added (not ~1MB like the full `tar` pkg).
- `vg --version` now reads from `package.json` at runtime so it can't drift.
- Prompt before overwriting existing skills; `--force` to skip.

## Why

Game devs have two entry points:
1. Install the CLI first → `vg init` drops game-building skills into their project.
2. Install skills via the plugin marketplace first → the deploy skill uses `npx vibedgames deploy`, so no global CLI install required.

Both paths now converge cleanly.

## Test plan

- [x] `vg --version` matches package.json
- [x] Fresh `vg init` installs 15 skills with nested `references/` dirs intact
- [x] Re-run prompts; declining aborts; `--force` skips
- [x] `vg skills install` alias behaves identically
- [ ] Windows (code path is Node-native but untested on windows-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new network-downloading tarball extractor that writes to the local filesystem and changes the `skills` install flow, so failures could affect users’ project directories. Also updates dependency resolution (notably `zod` in the lockfile), which can have wider downstream impact if consumed elsewhere.
> 
> **Overview**
> Adds a new `vg init [dir]` command (and `vg skills install` alias) to install Claude Code skills into `./.claude/skills`, and updates the CLI README to document the workflow.
> 
> Replaces the previous `curl | tar` shell-based skills installer with a Node-native streaming implementation (`fetch` + `zlib` + `tar-stream`) that extracts from `plugins/*/skills/*`, prompts before overwriting existing skills (with `--force` to skip), and includes a path traversal guard.
> 
> Updates `vg --version` to read the version from `package.json` at runtime, and adds the new installer dependencies (`tar-stream`, types) plus corresponding lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dede6f2a6077ad01304d046168e20702e46b56d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vg init` to install Claude Code skills into `./.claude/skills` with a cross‑platform, streaming installer. Fixes the skills source path and hardens extraction (now surfaces write errors); `vg --version` reads from `package.json`.

- **New Features**
  - `vg init` installs skills to `./.claude/skills` (alias: `vg skills install`).
  - Streaming download/extract via fetch + zlib + `tar-stream`; no `curl`/`tar` deps.
  - Prompts before overwriting; `--force` to skip.
  - `vg --version` reads from `package.json`.

- **Bug Fixes**
  - Installs from `plugins/*/skills/*` (was using `.claude/skills/`).
  - Hardens extraction: path‑traversal guard, direct write to target, and `stream.pipeline` to surface write errors to the CLI.

<sup>Written for commit dede6f2a6077ad01304d046168e20702e46b56d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

