### PR TITLE
add launch.json, ignore worktrees and playwright-mcp

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev:web"],
+      "port": 5173
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ local.*
 
 # claude
 .claude/scheduled_tasks.lock
+.claude/worktrees
+.playwright-mcp


### PR DESCRIPTION
## Summary
- Add `.claude/launch.json` with web dev config
- Ignore `.claude/worktrees` and `.playwright-mcp`

## Test plan
- [ ] Verify `.claude/launch.json` loads in Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a dev launch config file and updates `.gitignore` to exclude local Claude/Playwright artifacts; no runtime or production code changes.
> 
> **Overview**
> Adds `.claude/launch.json` to define a `pnpm dev:web` launch configuration for the web app (port `5173`).
> 
> Updates `.gitignore` to ignore `.claude/worktrees` and `.playwright-mcp` so local tooling/worktree artifacts are not committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35accfa56da8dff0c18e09b6b2ad483fa9e7dcd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.claude/launch.json` with a `pnpm` launch for `dev:web`, and update `.gitignore` to ignore `.claude/worktrees` and `.playwright-mcp`. Improves local dev workflow; no runtime or production changes.

<sup>Written for commit 35accfa56da8dff0c18e09b6b2ad483fa9e7dcd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

