### PR TITLE
Build page: fan-out card deck showcasing offerings

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -69,7 +69,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body
         className={cn(
-          "text-foreground bg-background bg-[url('https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/vibedgames/bg.png')] bg-size-[10px] font-mono antialiased",
+          "text-foreground bg-background bg-[url('https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/vibedgames/bg.png')] bg-size-[10px] font-sans antialiased",
         )}
       >
         <TooltipProvider>

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -224,40 +224,25 @@ function OfferingsDeck() {
             rotate: 0,
           };
           const isActive = activeIdx === i;
-          const hasActive = activeIdx !== null;
-          const activeP =
-            activeIdx !== null
-              ? MOBILE_POSITIONS[activeIdx]
-              : null;
 
-          let shiftX = 0;
-          let shiftY = 0;
-          if (hasActive && !isActive && activeP) {
-            const dx = parseFloat(p.left) - parseFloat(activeP.left);
-            const dy = parseFloat(p.top) - parseFloat(activeP.top);
-            shiftX = Math.sign(dx) * 22;
-            shiftY = Math.sign(dy) * 10;
-          }
+          const cardTarget = !isInView
+            ? { opacity: 0, y: 20, rotate: 0, scale: 0.9 }
+            : isActive
+              ? { opacity: 1, y: 0, rotate: 0, scale: 1.15 }
+              : { opacity: 1, y: 0, rotate: p.rotate, scale: 1 };
+
+          const innerX =
+            activeIdx === null || activeIdx === i
+              ? "0%"
+              : `${80 / (i - activeIdx)}%`;
 
           return (
             <motion.div
               key={card.index}
               initial={{ opacity: 0, y: 20, rotate: 0, scale: 0.9 }}
-              animate={
-                !isInView
-                  ? { opacity: 0, y: 20, rotate: 0, scale: 0.9, x: 0 }
-                  : isActive
-                    ? { opacity: 1, y: 0, x: 0, rotate: 0, scale: 1.15 }
-                    : {
-                        opacity: hasActive ? 0.55 : 1,
-                        y: shiftY,
-                        x: shiftX,
-                        rotate: p.rotate,
-                        scale: hasActive ? 0.92 : 1,
-                      }
-              }
+              animate={cardTarget}
               transition={{
-                delay: isInView && !hasActive ? 0.05 * i : 0,
+                delay: isInView && activeIdx === null ? 0.05 * i : 0,
                 type: "spring",
                 stiffness: 90,
                 damping: 14,
@@ -268,13 +253,19 @@ function OfferingsDeck() {
               style={{
                 top: p.top,
                 left: p.left,
-                backgroundColor: card.color,
                 zIndex: isActive ? 50 : card.zIndex,
                 transformOrigin: "center center",
               }}
-              className="absolute aspect-[0.8] w-[55%] cursor-pointer rounded-xl p-4 text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
+              className="absolute aspect-[0.8] w-[55%] cursor-pointer"
             >
-              <CardContent card={card} />
+              <motion.div
+                animate={{ x: innerX }}
+                transition={spring}
+                style={{ backgroundColor: card.color }}
+                className="h-full w-full rounded-xl p-4 text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
+              >
+                <CardContent card={card} />
+              </motion.div>
             </motion.div>
           );
         })}

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -157,15 +157,6 @@ function OfferingsDeck() {
   const toggle = (i: number) =>
     setActiveIdx((curr) => (curr === i ? null : i));
 
-  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>, i: number) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      toggle(i);
-    } else if (e.key === "Escape") {
-      setActiveIdx(null);
-    }
-  };
-
   return (
     <section
       ref={sectionRef}
@@ -204,18 +195,16 @@ function OfferingsDeck() {
               : `${80 / (i - activeIdx)}%`;
 
           return (
-            <motion.div
+            <motion.button
               key={card.index}
+              type="button"
               animate={cardTarget}
               transition={spring}
-              role="button"
-              tabIndex={0}
               aria-pressed={isActive}
               aria-label={`${card.title}: ${card.desc}`}
               onClick={() => toggle(i)}
-              onKeyDown={(e) => handleKey(e, i)}
               style={{ zIndex: card.zIndex }}
-              className="relative aspect-[0.8] w-[20vw] shrink-0 rounded-[0.6em] outline-none first:ml-0 focus-visible:ring-2 focus-visible:ring-white [&:not(:first-child)]:-ml-[10vw]"
+              className="relative aspect-[0.8] w-[20vw] shrink-0 appearance-none rounded-[0.6em] border-0 bg-transparent p-0 text-left outline-none first:ml-0 focus-visible:ring-2 focus-visible:ring-white [&:not(:first-child)]:-ml-[10vw]"
             >
               <motion.div
                 animate={{ x: innerX }}
@@ -225,7 +214,7 @@ function OfferingsDeck() {
               >
                 <CardContent card={card} />
               </motion.div>
-            </motion.div>
+            </motion.button>
           );
         })}
       </div>
@@ -262,8 +251,9 @@ function OfferingsDeck() {
               : { opacity: 1, y: 0, rotate: p.rotate, scale: 1 };
 
           return (
-            <motion.div
+            <motion.button
               key={card.index}
+              type="button"
               initial={{ opacity: 0, y: 20, rotate: 0, scale: 0.9 }}
               animate={cardTarget}
               transition={{
@@ -272,20 +262,17 @@ function OfferingsDeck() {
                 stiffness: 90,
                 damping: 14,
               }}
-              role="button"
-              tabIndex={0}
               aria-pressed={isActive}
               aria-label={`${card.title}: ${card.desc}`}
               onMouseEnter={() => setActiveIdx(i)}
               onClick={() => toggle(i)}
-              onKeyDown={(e) => handleKey(e, i)}
               style={{
                 top: p.top,
                 left: p.left,
                 zIndex: isActive ? 50 : card.zIndex,
                 transformOrigin: "center center",
               }}
-              className="absolute aspect-[0.8] w-[55%] rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-white"
+              className="absolute aspect-[0.8] w-[55%] appearance-none rounded-xl border-0 bg-transparent p-0 text-left outline-none focus-visible:ring-2 focus-visible:ring-white"
             >
               <motion.div
                 animate={{ x: innerX, y: innerY }}
@@ -295,7 +282,7 @@ function OfferingsDeck() {
               >
                 <CardContent card={card} />
               </motion.div>
-            </motion.div>
+            </motion.button>
           );
         })}
       </div>

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -154,6 +154,18 @@ function OfferingsDeck() {
 
   const spring = { type: "spring" as const, stiffness: 110, damping: 14, mass: 1 };
 
+  const toggle = (i: number) =>
+    setActiveIdx((curr) => (curr === i ? null : i));
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>, i: number) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      toggle(i);
+    } else if (e.key === "Escape") {
+      setActiveIdx(null);
+    }
+  };
+
   return (
     <section
       ref={sectionRef}
@@ -196,11 +208,14 @@ function OfferingsDeck() {
               key={card.index}
               animate={cardTarget}
               transition={spring}
-              onClick={() =>
-                setActiveIdx((curr) => (curr === i ? null : i))
-              }
+              role="button"
+              tabIndex={0}
+              aria-pressed={isActive}
+              aria-label={`${card.title}: ${card.desc}`}
+              onClick={() => toggle(i)}
+              onKeyDown={(e) => handleKey(e, i)}
               style={{ zIndex: card.zIndex }}
-              className="relative aspect-[0.8] w-[20vw] shrink-0 first:ml-0 [&:not(:first-child)]:-ml-[10vw]"
+              className="relative aspect-[0.8] w-[20vw] shrink-0 rounded-[0.6em] outline-none first:ml-0 focus-visible:ring-2 focus-visible:ring-white [&:not(:first-child)]:-ml-[10vw]"
             >
               <motion.div
                 animate={{ x: innerX }}
@@ -257,17 +272,20 @@ function OfferingsDeck() {
                 stiffness: 90,
                 damping: 14,
               }}
+              role="button"
+              tabIndex={0}
+              aria-pressed={isActive}
+              aria-label={`${card.title}: ${card.desc}`}
               onMouseEnter={() => setActiveIdx(i)}
-              onClick={() =>
-                setActiveIdx((curr) => (curr === i ? null : i))
-              }
+              onClick={() => toggle(i)}
+              onKeyDown={(e) => handleKey(e, i)}
               style={{
                 top: p.top,
                 left: p.left,
                 zIndex: isActive ? 50 : card.zIndex,
                 transformOrigin: "center center",
               }}
-              className="absolute aspect-[0.8] w-[55%]"
+              className="absolute aspect-[0.8] w-[55%] rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-white"
             >
               <motion.div
                 animate={{ x: innerX, y: innerY }}

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from "react";
-import { Logo } from "@repo/ui/components/logo";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { motion, useInView } from "motion/react";
 
 export const Route = createFileRoute("/build")({
@@ -132,26 +131,26 @@ function OfferingsDeck() {
   return (
     <section
       ref={sectionRef}
-      className="relative flex min-h-dvh flex-col justify-center py-16"
+      className="relative flex flex-col items-center justify-center sm:h-dvh sm:overflow-hidden"
     >
-      <motion.div
-        initial={{ opacity: 0, y: 30 }}
-        animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
+      <motion.h1
+        initial={{ opacity: 0, y: 20 }}
+        animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
         transition={{ duration: 0.7, ease: [0.21, 0.47, 0.32, 0.98] }}
-        className="mb-4 px-6 sm:mb-6 sm:px-10"
+        className="self-start px-6 pt-8 text-3xl font-medium leading-[0.9] -tracking-[0.03em] sm:absolute sm:left-[25px] sm:top-[25px] sm:z-10 sm:max-w-[70vw] sm:px-0 sm:pt-0 sm:text-[4vw]"
       >
-        <h1 className="max-w-3xl text-3xl font-light leading-[0.95] tracking-tight sm:text-5xl md:text-6xl">
-          You design your game
-          <br />
-          <span className="text-muted-foreground">Our skills handle the rest</span>
-        </h1>
-      </motion.div>
+        You design your game
+        <br />
+        <span className="text-muted-foreground">
+          Our skills handle the rest
+        </span>
+      </motion.h1>
 
       <div
         ref={containerRef}
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
-        className="hidden h-[60vh] items-center justify-center px-4 sm:flex"
+        className="hidden items-center justify-center sm:flex"
       >
         {OFFERINGS.map((card, i) => {
           const off = offsets[i] ?? { x: 0, y: 0, rotate: 0 };
@@ -183,22 +182,19 @@ function OfferingsDeck() {
                 animate={{ x: innerX }}
                 transition={spring}
                 style={{ backgroundColor: card.color }}
-                className="flex h-full w-full flex-col justify-between rounded-xl p-[1.25vw] text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
+                className="flex h-full w-full flex-col justify-between rounded-[0.6em] p-[25px] text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
               >
-                <div className="flex items-start justify-between font-mono text-[0.7vw] uppercase tracking-[0.2em]">
-                  <span>{card.index}</span>
-                  <span className="opacity-50">— vg</span>
-                </div>
-                <div>
-                  <p className="font-mono text-[2.2vw] font-medium leading-[0.9] tracking-tight">
-                    {card.title}.
-                  </p>
-                  <p className="mt-[0.6vw] font-mono text-[0.85vw] leading-snug opacity-70">
-                    {card.desc}
-                  </p>
-                </div>
-                <div className="border-t border-dashed border-black/40 pt-[0.8vw] font-mono text-[0.7vw] uppercase tracking-[0.18em]">
-                  {card.tag}
+                <p className="text-[1.9vw] font-medium leading-[0.9] -tracking-[0.03em]">
+                  {card.title}.{" "}
+                  <span className="opacity-60">{card.desc}</span>
+                </p>
+                <div className="flex items-center gap-[15px] border-t border-dashed border-black pt-[25px] text-[1.1vw] font-medium leading-[0.9] -tracking-[0.03em]">
+                  <div>
+                    <p>{card.index}</p>
+                    <p className="mt-1 font-mono text-[0.9vw] uppercase leading-normal">
+                      {card.tag}
+                    </p>
+                  </div>
                 </div>
               </motion.div>
             </motion.div>
@@ -207,7 +203,7 @@ function OfferingsDeck() {
       </div>
 
       {/* Mobile: collage layout */}
-      <div className="relative mx-auto h-[120vh] w-full max-w-sm px-4 sm:hidden">
+      <div className="relative mx-auto mt-8 h-[120vh] w-full max-w-sm px-4 sm:hidden">
         {OFFERINGS.map((card, i) => {
           const p = MOBILE_POSITIONS[i] ?? {
             top: "0%",
@@ -276,17 +272,8 @@ const MOBILE_POSITIONS = [
 
 function BuildPage() {
   return (
-    <div className="relative min-h-dvh overflow-x-hidden overflow-y-auto">
-      <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
-        <Link to="/" className="flex items-center gap-2">
-          <Logo className="w-6" />
-          <span className="font-mono text-sm">vibedgames</span>
-        </Link>
-      </nav>
-
-      <main className="font-mono">
-        <OfferingsDeck />
-      </main>
-    </div>
+    <main className="font-mono">
+      <OfferingsDeck />
+    </main>
   );
 }

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -139,10 +139,10 @@ function OfferingsDeck() {
         transition={{ duration: 0.7, ease: [0.21, 0.47, 0.32, 0.98] }}
         className="self-start px-6 pt-8 text-3xl font-medium leading-[0.9] -tracking-[0.03em] sm:absolute sm:left-[25px] sm:top-[25px] sm:z-10 sm:max-w-[70vw] sm:px-0 sm:pt-0 sm:text-[4vw]"
       >
-        You design your game
+        You bring the game.
         <br />
         <span className="text-muted-foreground">
-          Our skills handle the rest
+          We bring the internet.
         </span>
       </motion.h1>
 

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -8,29 +8,6 @@ export const Route = createFileRoute("/build")({
   component: BuildPage,
 });
 
-function AnimatedSection({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-  const isInView = useInView(ref, { once: true, margin: "-100px" });
-
-  return (
-    <motion.section
-      ref={ref}
-      initial={{ opacity: 0, y: 40 }}
-      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 40 }}
-      transition={{ duration: 0.6, ease: [0.21, 0.47, 0.32, 0.98] }}
-      className={className}
-    >
-      {children}
-    </motion.section>
-  );
-}
-
 type Offering = {
   index: string;
   title: string;
@@ -161,18 +138,16 @@ function OfferingsDeck() {
         initial={{ opacity: 0, y: 30 }}
         animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
         transition={{ duration: 0.7, ease: [0.21, 0.47, 0.32, 0.98] }}
-        className="mb-12 px-6 sm:mb-16 sm:px-10"
+        className="mb-12 px-6 text-center sm:mb-16"
       >
-        <div className="text-muted-foreground mb-3 text-[10px] uppercase tracking-[0.25em]">
-          What vibedgames ships
-        </div>
-        <h2 className="max-w-3xl text-3xl font-light leading-[0.95] tracking-tight sm:text-5xl md:text-6xl">
-          Everything you need
+        <h1 className="text-3xl font-light leading-tight tracking-tight sm:text-5xl">
+          Your LLM builds the game.
           <br />
-          <span className="text-muted-foreground">nothing you don't.</span>
-        </h2>
-        <p className="text-muted-foreground mt-4 max-w-sm text-xs leading-relaxed">
-          Each card is one slice of the platform your LLM can reach for.
+          <span className="text-muted-foreground">We handle the rest.</span>
+        </h1>
+        <p className="text-muted-foreground mx-auto mt-4 max-w-md text-sm leading-relaxed">
+          Infrastructure for vibe-coded games. Multiplayer, deployment, hosting
+          — all through skills your LLM already knows.
         </p>
       </motion.div>
 
@@ -314,55 +289,7 @@ function BuildPage() {
       </nav>
 
       <main className="font-mono">
-        {/* Hero */}
-        <section className="flex min-h-dvh flex-col items-center justify-center px-6 text-center">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, ease: [0.21, 0.47, 0.32, 0.98] }}
-          >
-            <h1 className="mb-4 text-3xl font-light tracking-tight sm:text-5xl">
-              Your LLM builds the game.
-              <br />
-              <span className="text-muted-foreground">We handle the rest.</span>
-            </h1>
-            <p className="text-muted-foreground mx-auto mb-10 max-w-md text-sm leading-relaxed">
-              Infrastructure for vibe-coded games. Multiplayer, deployment,
-              hosting — all through skills your LLM already knows.
-            </p>
-            <div className="flex justify-center">
-              <div className="bg-secondary/50 rounded-lg border border-white/5 px-5 py-3 text-sm">
-                <span className="text-muted-foreground select-none">$ </span>
-                <span className="text-foreground">
-                  npx vibedgames skills .
-                </span>
-              </div>
-            </div>
-          </motion.div>
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 1.2, duration: 0.8 }}
-            className="text-muted-foreground/30 mt-16 text-xs"
-          >
-            scroll to explore ↓
-          </motion.div>
-        </section>
-
         <OfferingsDeck />
-
-        {/* CTA */}
-        <section className="flex min-h-[50vh] flex-col items-center justify-center px-6 py-20 text-center">
-          <AnimatedSection className="flex flex-col items-center gap-6">
-            <h2 className="text-2xl font-light tracking-tight sm:text-3xl">
-              Ready to ship your game?
-            </h2>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 px-5 py-3 text-sm">
-              <span className="text-muted-foreground select-none">$ </span>
-              <span className="text-foreground">npx vibedgames skills .</span>
-            </div>
-          </AnimatedSection>
-        </section>
       </main>
     </div>
   );

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -215,8 +215,11 @@ function OfferingsDeck() {
         })}
       </div>
 
-      {/* Mobile: collage layout, tap to activate */}
-      <div className="relative mx-auto mt-8 h-[120vh] w-full max-w-sm px-4 sm:hidden">
+      {/* Mobile: collage layout, tap or hover to activate */}
+      <div
+        onMouseLeave={() => setActiveIdx(null)}
+        className="relative mx-auto mt-8 h-[120vh] w-full max-w-sm px-4 sm:hidden"
+      >
         {OFFERINGS.map((card, i) => {
           const p = MOBILE_POSITIONS[i] ?? {
             top: "0%",
@@ -247,6 +250,7 @@ function OfferingsDeck() {
                 stiffness: 90,
                 damping: 14,
               }}
+              onMouseEnter={() => setActiveIdx(i)}
               onClick={() =>
                 setActiveIdx((curr) => (curr === i ? null : i))
               }

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -172,8 +172,7 @@ function OfferingsDeck() {
           <span className="text-muted-foreground">nothing you don't.</span>
         </h2>
         <p className="text-muted-foreground mt-4 max-w-sm text-xs leading-relaxed">
-          Hover across the deck — each card is one slice of the platform your
-          LLM can reach for.
+          Each card is one slice of the platform your LLM can reach for.
         </p>
       </motion.div>
 
@@ -236,31 +235,73 @@ function OfferingsDeck() {
         })}
       </div>
 
-      {/* Mobile: stacked vertical list */}
-      <div className="flex flex-col gap-3 px-6 sm:hidden">
-        {OFFERINGS.map((card) => (
-          <div
-            key={card.index}
-            style={{ backgroundColor: card.color }}
-            className="rounded-xl p-5 text-black"
-          >
-            <div className="mb-3 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.15em]">
-              <span>{card.index}</span>
-              <span className="opacity-60">— vg</span>
-            </div>
-            <p className="font-mono text-xl font-medium leading-[0.95] tracking-tight">
-              {card.title}.{" "}
-              <span className="opacity-70">{card.desc}</span>
-            </p>
-            <div className="mt-4 border-t border-dashed border-black/40 pt-3 font-mono text-[10px] uppercase tracking-[0.15em]">
-              {card.tag}
-            </div>
-          </div>
-        ))}
+      {/* Mobile: collage layout */}
+      <div className="relative mx-auto h-[120vh] w-full max-w-sm px-4 sm:hidden">
+        {OFFERINGS.map((card, i) => {
+          const p = MOBILE_POSITIONS[i] ?? {
+            top: "0%",
+            left: "0%",
+            rotate: 0,
+          };
+          return (
+            <motion.div
+              key={card.index}
+              initial={{ opacity: 0, y: 20, rotate: 0, scale: 0.9 }}
+              animate={
+                isInView
+                  ? { opacity: 1, y: 0, rotate: p.rotate, scale: 1 }
+                  : { opacity: 0, y: 20, rotate: 0, scale: 0.9 }
+              }
+              transition={{
+                delay: 0.05 * i,
+                type: "spring",
+                stiffness: 90,
+                damping: 14,
+              }}
+              style={{
+                top: p.top,
+                left: p.left,
+                backgroundColor: card.color,
+                zIndex: card.zIndex,
+                transformOrigin: "center center",
+              }}
+              className="absolute aspect-[0.8] w-[55%] rounded-xl p-4 text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
+            >
+              <div className="flex h-full w-full flex-col justify-between">
+                <div className="flex items-start justify-between font-mono text-[9px] uppercase tracking-[0.2em]">
+                  <span>{card.index}</span>
+                  <span className="opacity-50">— vg</span>
+                </div>
+                <div>
+                  <p className="font-mono text-xl font-medium leading-[0.9] tracking-tight">
+                    {card.title}.
+                  </p>
+                  <p className="mt-1.5 font-mono text-[11px] leading-snug opacity-70">
+                    {card.desc}
+                  </p>
+                </div>
+                <div className="border-t border-dashed border-black/40 pt-2 font-mono text-[9px] uppercase tracking-[0.18em]">
+                  {card.tag}
+                </div>
+              </div>
+            </motion.div>
+          );
+        })}
       </div>
     </section>
   );
 }
+
+const MOBILE_POSITIONS = [
+  { top: "0%", left: "2%", rotate: -7 },
+  { top: "9%", left: "42%", rotate: 5 },
+  { top: "21%", left: "8%", rotate: 8 },
+  { top: "33%", left: "40%", rotate: -4 },
+  { top: "45%", left: "0%", rotate: -3 },
+  { top: "57%", left: "38%", rotate: 9 },
+  { top: "70%", left: "6%", rotate: -8 },
+  { top: "82%", left: "40%", rotate: 6 },
+] as const;
 
 function BuildPage() {
   return (

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -200,7 +200,7 @@ function OfferingsDeck() {
                 setActiveIdx((curr) => (curr === i ? null : i))
               }
               style={{ zIndex: card.zIndex }}
-              className="relative aspect-[0.8] w-[20vw] shrink-0 cursor-pointer first:ml-0 [&:not(:first-child)]:-ml-[10vw]"
+              className="relative aspect-[0.8] w-[20vw] shrink-0 first:ml-0 [&:not(:first-child)]:-ml-[10vw]"
             >
               <motion.div
                 animate={{ x: innerX }}
@@ -227,17 +227,24 @@ function OfferingsDeck() {
             rotate: 0,
           };
           const isActive = activeIdx === i;
+          const hasActive = activeIdx !== null;
+          const activeP =
+            activeIdx !== null ? MOBILE_POSITIONS[activeIdx] : null;
+
+          let innerX = "0%";
+          let innerY = "0%";
+          if (hasActive && !isActive && activeP) {
+            const dx = parseFloat(p.left) - parseFloat(activeP.left);
+            const dy = parseFloat(p.top) - parseFloat(activeP.top);
+            innerX = `${Math.sign(dx) * 40}%`;
+            innerY = `${Math.sign(dy) * 40}%`;
+          }
 
           const cardTarget = !isInView
             ? { opacity: 0, y: 20, rotate: 0, scale: 0.9 }
             : isActive
               ? { opacity: 1, y: 0, rotate: 0, scale: 1.15 }
               : { opacity: 1, y: 0, rotate: p.rotate, scale: 1 };
-
-          const innerX =
-            activeIdx === null || activeIdx === i
-              ? "0%"
-              : `${80 / (i - activeIdx)}%`;
 
           return (
             <motion.div
@@ -260,10 +267,10 @@ function OfferingsDeck() {
                 zIndex: isActive ? 50 : card.zIndex,
                 transformOrigin: "center center",
               }}
-              className="absolute aspect-[0.8] w-[55%] cursor-pointer"
+              className="absolute aspect-[0.8] w-[55%]"
             >
               <motion.div
-                animate={{ x: innerX }}
+                animate={{ x: innerX, y: innerY }}
                 transition={spring}
                 style={{ backgroundColor: card.color }}
                 className="h-full w-full rounded-xl p-4 text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -243,11 +243,9 @@ function OfferingsDeck() {
                   <span className="opacity-50">— vg</span>
                 </div>
                 <div>
-                  <p className="font-mono text-xl font-medium leading-[0.9] tracking-tight">
-                    {card.title}.
-                  </p>
-                  <p className="mt-1.5 font-mono text-[11px] leading-snug opacity-70">
-                    {card.desc}
+                  <p className="text-xl font-medium leading-[0.9] -tracking-[0.03em]">
+                    {card.title}.{" "}
+                    <span className="opacity-60">{card.desc}</span>
                   </p>
                 </div>
                 <div className="border-t border-dashed border-black/40 pt-2 font-mono text-[9px] uppercase tracking-[0.18em]">
@@ -275,7 +273,7 @@ const MOBILE_POSITIONS = [
 
 function BuildPage() {
   return (
-    <main className="font-mono">
+    <main>
       <OfferingsDeck />
     </main>
   );

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -196,8 +196,11 @@ function OfferingsDeck() {
               key={card.index}
               animate={cardTarget}
               transition={spring}
+              onClick={() =>
+                setActiveIdx((curr) => (curr === i ? null : i))
+              }
               style={{ zIndex: card.zIndex }}
-              className="relative aspect-[0.8] w-[20vw] shrink-0 first:ml-0 [&:not(:first-child)]:-ml-[10vw]"
+              className="relative aspect-[0.8] w-[20vw] shrink-0 cursor-pointer first:ml-0 [&:not(:first-child)]:-ml-[10vw]"
             >
               <motion.div
                 animate={{ x: innerX }}
@@ -212,7 +215,7 @@ function OfferingsDeck() {
         })}
       </div>
 
-      {/* Mobile: collage layout */}
+      {/* Mobile: collage layout, tap to activate */}
       <div className="relative mx-auto mt-8 h-[120vh] w-full max-w-sm px-4 sm:hidden">
         {OFFERINGS.map((card, i) => {
           const p = MOBILE_POSITIONS[i] ?? {
@@ -220,29 +223,56 @@ function OfferingsDeck() {
             left: "0%",
             rotate: 0,
           };
+          const isActive = activeIdx === i;
+          const hasActive = activeIdx !== null;
+          const activeP =
+            activeIdx !== null
+              ? MOBILE_POSITIONS[activeIdx]
+              : null;
+
+          let shiftX = 0;
+          let shiftY = 0;
+          if (hasActive && !isActive && activeP) {
+            const dx = parseFloat(p.left) - parseFloat(activeP.left);
+            const dy = parseFloat(p.top) - parseFloat(activeP.top);
+            shiftX = Math.sign(dx) * 22;
+            shiftY = Math.sign(dy) * 10;
+          }
+
           return (
             <motion.div
               key={card.index}
               initial={{ opacity: 0, y: 20, rotate: 0, scale: 0.9 }}
               animate={
-                isInView
-                  ? { opacity: 1, y: 0, rotate: p.rotate, scale: 1 }
-                  : { opacity: 0, y: 20, rotate: 0, scale: 0.9 }
+                !isInView
+                  ? { opacity: 0, y: 20, rotate: 0, scale: 0.9, x: 0 }
+                  : isActive
+                    ? { opacity: 1, y: 0, x: 0, rotate: 0, scale: 1.15 }
+                    : {
+                        opacity: hasActive ? 0.55 : 1,
+                        y: shiftY,
+                        x: shiftX,
+                        rotate: p.rotate,
+                        scale: hasActive ? 0.92 : 1,
+                      }
               }
               transition={{
-                delay: 0.05 * i,
+                delay: isInView && !hasActive ? 0.05 * i : 0,
                 type: "spring",
                 stiffness: 90,
                 damping: 14,
               }}
+              onClick={() =>
+                setActiveIdx((curr) => (curr === i ? null : i))
+              }
               style={{
                 top: p.top,
                 left: p.left,
                 backgroundColor: card.color,
-                zIndex: card.zIndex,
+                zIndex: isActive ? 50 : card.zIndex,
                 transformOrigin: "center center",
               }}
-              className="absolute aspect-[0.8] w-[55%] rounded-xl p-4 text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
+              className="absolute aspect-[0.8] w-[55%] cursor-pointer rounded-xl p-4 text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
             >
               <CardContent card={card} />
             </motion.div>

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Logo } from "@repo/ui/components/logo";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { motion, useInView } from "motion/react";
@@ -31,26 +31,240 @@ function AnimatedSection({
   );
 }
 
-function TypingLine({ text, delay = 0 }: { text: string; delay?: number }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const isInView = useInView(ref, { once: true, margin: "-50px" });
+type Offering = {
+  index: string;
+  title: string;
+  tag: string;
+  desc: string;
+  color: string;
+  zIndex: number;
+};
+
+const OFFERINGS: Offering[] = [
+  {
+    index: "01",
+    title: "Skills",
+    tag: "npx vibedgames skills",
+    desc: "The toolkit your LLM already knows.",
+    color: "#F14A3A",
+    zIndex: 3,
+  },
+  {
+    index: "02",
+    title: "CLI",
+    tag: "vg deploy",
+    desc: "One command. Device-code auth. Ship.",
+    color: "#FB7350",
+    zIndex: 2,
+  },
+  {
+    index: "03",
+    title: "Multiplayer",
+    tag: "@vibedgames/multiplayer",
+    desc: "Real-time sync. Host-authoritative.",
+    color: "#F79C42",
+    zIndex: 7,
+  },
+  {
+    index: "04",
+    title: "Hosting",
+    tag: "R2 · global CDN",
+    desc: "Immutable deploys. 1yr cache. No cold starts.",
+    color: "#FFDF40",
+    zIndex: 1,
+  },
+  {
+    index: "05",
+    title: "Subdomain",
+    tag: "{slug}.vibedgames.com",
+    desc: "Every game gets a link. Sandboxed.",
+    color: "#DEDA8D",
+    zIndex: 4,
+  },
+  {
+    index: "06",
+    title: "Assets",
+    tag: "v0 · sprites + audio",
+    desc: "Skip the placeholder rectangles.",
+    color: "#71CFA3",
+    zIndex: 5,
+  },
+  {
+    index: "07",
+    title: "Discovery",
+    tag: "vibedgames.com",
+    desc: "Players find you on the hub.",
+    color: "#C4EF7A",
+    zIndex: 8,
+  },
+  {
+    index: "08",
+    title: "Auth",
+    tag: "better-auth · device-code",
+    desc: "Sessions locked to apex. Secure.",
+    color: "#BCEFFF",
+    zIndex: 6,
+  },
+];
+
+function randomOffset() {
+  return {
+    x: (Math.random() - 0.5) * 10,
+    y: (Math.random() - 0.5) * 10,
+    rotate: (Math.random() - 0.5) * 20,
+  };
+}
+
+function OfferingsDeck() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [activeIdx, setActiveIdx] = useState<number | null>(null);
+  const [offsets, setOffsets] = useState(() => OFFERINGS.map(randomOffset));
+
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const isInView = useInView(sectionRef, { once: true, margin: "-100px" });
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const pct = (e.clientX - rect.left) / rect.width;
+    const idx = Math.min(
+      OFFERINGS.length - 1,
+      Math.max(0, Math.floor(pct * OFFERINGS.length)),
+    );
+    if (idx === activeIdx) return;
+    if (activeIdx !== null) {
+      setOffsets((prev) =>
+        prev.map((o, i) => (i === activeIdx ? randomOffset() : o)),
+      );
+    }
+    setActiveIdx(idx);
+  };
+
+  const handleMouseLeave = () => {
+    if (activeIdx !== null) {
+      setOffsets((prev) =>
+        prev.map((o, i) => (i === activeIdx ? randomOffset() : o)),
+      );
+    }
+    setActiveIdx(null);
+  };
+
+  const spring = { type: "spring" as const, stiffness: 110, damping: 14, mass: 1 };
 
   return (
-    <div ref={ref} className="overflow-hidden">
+    <section
+      ref={sectionRef}
+      className="relative flex min-h-dvh flex-col justify-center py-24"
+    >
       <motion.div
-        initial={{ opacity: 0 }}
-        animate={isInView ? { opacity: 1 } : { opacity: 0 }}
-        transition={{ delay, duration: 0.4 }}
+        initial={{ opacity: 0, y: 30 }}
+        animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
+        transition={{ duration: 0.7, ease: [0.21, 0.47, 0.32, 0.98] }}
+        className="mb-12 px-6 sm:mb-16 sm:px-10"
       >
-        {text}
+        <div className="text-muted-foreground mb-3 text-[10px] uppercase tracking-[0.25em]">
+          What vibedgames ships
+        </div>
+        <h2 className="max-w-3xl text-3xl font-light leading-[0.95] tracking-tight sm:text-5xl md:text-6xl">
+          Everything you need
+          <br />
+          <span className="text-muted-foreground">nothing you don't.</span>
+        </h2>
+        <p className="text-muted-foreground mt-4 max-w-sm text-xs leading-relaxed">
+          Hover across the deck — each card is one slice of the platform your
+          LLM can reach for.
+        </p>
       </motion.div>
-    </div>
+
+      <div
+        ref={containerRef}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        className="hidden h-[60vh] items-center justify-center px-4 sm:flex"
+      >
+        {OFFERINGS.map((card, i) => {
+          const off = offsets[i] ?? { x: 0, y: 0, rotate: 0 };
+          const isActive = activeIdx === i;
+
+          const cardTarget = isActive
+            ? { x: "0%", y: "0%", rotate: 0, scale: 1.1 }
+            : {
+                x: `${off.x}%`,
+                y: `${off.y}%`,
+                rotate: off.rotate,
+                scale: 1,
+              };
+
+          const innerX =
+            activeIdx === null || activeIdx === i
+              ? "0%"
+              : `${80 / (i - activeIdx)}%`;
+
+          return (
+            <motion.div
+              key={card.index}
+              animate={cardTarget}
+              transition={spring}
+              style={{ zIndex: card.zIndex }}
+              className="relative aspect-[0.8] w-[20vw] shrink-0 first:ml-0 [&:not(:first-child)]:-ml-[10vw]"
+            >
+              <motion.div
+                animate={{ x: innerX }}
+                transition={spring}
+                style={{ backgroundColor: card.color }}
+                className="flex h-full w-full flex-col justify-between rounded-xl p-[1.25vw] text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
+              >
+                <div className="flex items-start justify-between font-mono text-[0.7vw] uppercase tracking-[0.2em]">
+                  <span>{card.index}</span>
+                  <span className="opacity-50">— vg</span>
+                </div>
+                <div>
+                  <p className="font-mono text-[2.2vw] font-medium leading-[0.9] tracking-tight">
+                    {card.title}.
+                  </p>
+                  <p className="mt-[0.6vw] font-mono text-[0.85vw] leading-snug opacity-70">
+                    {card.desc}
+                  </p>
+                </div>
+                <div className="border-t border-dashed border-black/40 pt-[0.8vw] font-mono text-[0.7vw] uppercase tracking-[0.18em]">
+                  {card.tag}
+                </div>
+              </motion.div>
+            </motion.div>
+          );
+        })}
+      </div>
+
+      {/* Mobile: stacked vertical list */}
+      <div className="flex flex-col gap-3 px-6 sm:hidden">
+        {OFFERINGS.map((card) => (
+          <div
+            key={card.index}
+            style={{ backgroundColor: card.color }}
+            className="rounded-xl p-5 text-black"
+          >
+            <div className="mb-3 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.15em]">
+              <span>{card.index}</span>
+              <span className="opacity-60">— vg</span>
+            </div>
+            <p className="font-mono text-xl font-medium leading-[0.95] tracking-tight">
+              {card.title}.{" "}
+              <span className="opacity-70">{card.desc}</span>
+            </p>
+            <div className="mt-4 border-t border-dashed border-black/40 pt-3 font-mono text-[10px] uppercase tracking-[0.15em]">
+              {card.tag}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 
 function BuildPage() {
   return (
-    <div className="relative min-h-dvh overflow-y-auto">
+    <div className="relative min-h-dvh overflow-x-hidden overflow-y-auto">
       <nav className="fixed top-0 left-0 z-20 flex w-full items-center justify-between px-6 py-4">
         <Link to="/" className="flex items-center gap-2">
           <Logo className="w-6" />
@@ -94,253 +308,7 @@ function BuildPage() {
           </motion.div>
         </section>
 
-        {/* Section: Install */}
-        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
-          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
-            <div>
-              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                01 — Install
-              </div>
-              <h2 className="mb-3 text-xl font-light sm:text-2xl">
-                Add skills to your project
-              </h2>
-              <p className="text-muted-foreground text-xs leading-relaxed">
-                One command installs vibedgames skills into your project. Your
-                LLM gets deploy, multiplayer, asset generation, and more — ready
-                to use in any conversation.
-              </p>
-            </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
-              <div className="space-y-3 text-xs">
-                <div className="text-muted-foreground">
-                  <span className="text-muted-foreground/50">$</span> npx
-                  vibedgames skills .
-                </div>
-                <div className="border-t border-white/5 pt-3">
-                  <TypingLine
-                    delay={0.3}
-                    text="Downloading vibedgames skills..."
-                  />
-                  <TypingLine delay={0.6} text="Installing 15 skills..." />
-                  <div className="mt-2">
-                    <TypingLine
-                      delay={0.9}
-                      text="✓ Skills installed to .claude/skills/"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </AnimatedSection>
-
-        {/* Section: Describe */}
-        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
-          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
-            <div className="sm:order-2">
-              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                02 — Describe
-              </div>
-              <h2 className="mb-3 text-xl font-light sm:text-2xl">
-                Say what you want
-              </h2>
-              <p className="text-muted-foreground text-xs leading-relaxed">
-                Describe your game to any LLM. A platformer, a puzzle game, a
-                space shooter — whatever you're vibing. It writes the code,
-                picks the right framework, and runs it locally.
-              </p>
-            </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5 sm:order-1">
-              <div className="space-y-3 text-xs">
-                <div className="text-muted-foreground">
-                  <span className="text-muted-foreground/50">you &gt;</span>{" "}
-                  build me an asteroid mining game with physics
-                </div>
-                <div className="border-t border-white/5 pt-3">
-                  <TypingLine
-                    delay={0.3}
-                    text="Setting up project with Matter.js physics..."
-                  />
-                  <TypingLine
-                    delay={0.6}
-                    text="Creating asteroid field generator..."
-                  />
-                  <TypingLine
-                    delay={0.9}
-                    text="Adding mining beam mechanics..."
-                  />
-                  <TypingLine
-                    delay={1.2}
-                    text="Implementing resource collection UI..."
-                  />
-                  <div className="mt-2">
-                    <TypingLine
-                      delay={1.5}
-                      text="✓ Game running at localhost:5173"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </AnimatedSection>
-
-        {/* Section: Multiplayer */}
-        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
-          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
-            <div>
-              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                03 — Multiplayer
-              </div>
-              <h2 className="mb-3 text-xl font-light sm:text-2xl">
-                One sentence, real-time
-              </h2>
-              <p className="text-muted-foreground text-xs leading-relaxed">
-                "Make it multiplayer." Your LLM installs our SDK, wires up state
-                sync, and handles host authority. No servers to configure, no
-                networking code to write.
-              </p>
-            </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
-              <div className="space-y-3 text-xs">
-                <div className="text-muted-foreground">
-                  <span className="text-muted-foreground/50">you &gt;</span>{" "}
-                  add multiplayer so friends can mine together
-                </div>
-                <div className="border-t border-white/5 pt-3">
-                  <TypingLine
-                    delay={0.3}
-                    text="Installing @vibedgames/multiplayer..."
-                  />
-                  <TypingLine
-                    delay={0.6}
-                    text="Syncing asteroid positions across players..."
-                  />
-                  <TypingLine
-                    delay={0.9}
-                    text="Adding shared resource pool..."
-                  />
-                  <div className="mt-2">
-                    <TypingLine
-                      delay={1.2}
-                      text="✓ Co-op multiplayer ready"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </AnimatedSection>
-
-        {/* Section: Deploy */}
-        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
-          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
-            <div className="sm:order-2">
-              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                04 — Deploy
-              </div>
-              <h2 className="mb-3 text-xl font-light sm:text-2xl">
-                Live in seconds
-              </h2>
-              <p className="text-muted-foreground text-xs leading-relaxed">
-                One slash command. Your game is built for production, uploaded to
-                our global CDN, and live at your-game.vibedgames.com. Share the
-                link and anyone can play.
-              </p>
-            </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5 sm:order-1">
-              <div className="space-y-3 text-xs">
-                <div className="text-muted-foreground">
-                  <span className="text-muted-foreground/50">you &gt;</span>{" "}
-                  /deploy
-                </div>
-                <div className="border-t border-white/5 pt-3">
-                  <TypingLine
-                    delay={0.3}
-                    text="Building for production..."
-                  />
-                  <TypingLine
-                    delay={0.6}
-                    text="Optimizing assets (143kb)..."
-                  />
-                  <TypingLine
-                    delay={0.9}
-                    text="Uploading to vibedgames CDN..."
-                  />
-                  <div className="mt-2">
-                    <TypingLine
-                      delay={1.2}
-                      text="✓ Live at asteroid-miner.vibedgames.com"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </AnimatedSection>
-
-        {/* Section: Play */}
-        <AnimatedSection className="flex min-h-[70vh] items-center px-6 py-20">
-          <div className="mx-auto grid max-w-4xl gap-10 sm:grid-cols-2 sm:items-center">
-            <div>
-              <div className="text-muted-foreground mb-2 text-[10px] uppercase tracking-widest">
-                05 — Play
-              </div>
-              <h2 className="mb-3 text-xl font-light sm:text-2xl">
-                Players find your game
-              </h2>
-              <p className="text-muted-foreground text-xs leading-relaxed">
-                Your game appears on vibedgames.com where players can discover,
-                play, and share it. Global CDN for instant loads. Zero
-                maintenance.
-              </p>
-            </div>
-            <div className="bg-secondary/50 rounded-lg border border-white/5 p-5">
-              <div className="space-y-3">
-                {[
-                  {
-                    name: "Asteroid Miner",
-                    slug: "asteroid-miner",
-                    players: "4 playing",
-                    icon: "⛏",
-                  },
-                  {
-                    name: "Space Shooter",
-                    slug: "space-shooter",
-                    players: "2 playing",
-                    icon: "🚀",
-                  },
-                  {
-                    name: "Pixel Racer",
-                    slug: "pixel-racer",
-                    players: "6 playing",
-                    icon: "🏎",
-                  },
-                ].map((game) => (
-                  <div
-                    key={game.slug}
-                    className="flex items-center gap-3 rounded border border-white/5 bg-white/[0.02] p-3 text-xs"
-                  >
-                    <div className="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded text-sm">
-                      {game.icon}
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="text-foreground truncate font-medium">
-                        {game.name}
-                      </div>
-                      <div className="text-muted-foreground/50">
-                        {game.slug}.vibedgames.com
-                      </div>
-                    </div>
-                    <div className="text-muted-foreground/50 shrink-0">
-                      {game.players}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        </AnimatedSection>
+        <OfferingsDeck />
 
         {/* CTA */}
         <section className="flex min-h-[50vh] flex-col items-center justify-center px-6 py-20 text-center">

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -132,23 +132,19 @@ function OfferingsDeck() {
   return (
     <section
       ref={sectionRef}
-      className="relative flex min-h-dvh flex-col justify-center py-24"
+      className="relative flex min-h-dvh flex-col justify-center py-16"
     >
       <motion.div
         initial={{ opacity: 0, y: 30 }}
         animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
         transition={{ duration: 0.7, ease: [0.21, 0.47, 0.32, 0.98] }}
-        className="mb-12 px-6 text-center sm:mb-16"
+        className="mb-4 px-6 sm:mb-6 sm:px-10"
       >
-        <h1 className="text-3xl font-light leading-tight tracking-tight sm:text-5xl">
-          Your LLM builds the game.
+        <h1 className="max-w-3xl text-3xl font-light leading-[0.95] tracking-tight sm:text-5xl md:text-6xl">
+          You design your game
           <br />
-          <span className="text-muted-foreground">We handle the rest.</span>
+          <span className="text-muted-foreground">Our skills handle the rest</span>
         </h1>
-        <p className="text-muted-foreground mx-auto mt-4 max-w-md text-sm leading-relaxed">
-          Infrastructure for vibe-coded games. Multiplayer, deployment, hosting
-          — all through skills your LLM already knows.
-        </p>
       </motion.div>
 
       <div

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { motion, useInView } from "motion/react";
 
@@ -91,10 +91,18 @@ function randomOffset() {
   };
 }
 
+const ZERO_OFFSET = { x: 0, y: 0, rotate: 0 };
+
 function OfferingsDeck() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [activeIdx, setActiveIdx] = useState<number | null>(null);
-  const [offsets, setOffsets] = useState(() => OFFERINGS.map(randomOffset));
+  const [offsets, setOffsets] = useState(() =>
+    OFFERINGS.map(() => ZERO_OFFSET),
+  );
+
+  useEffect(() => {
+    setOffsets(OFFERINGS.map(randomOffset));
+  }, []);
 
   const sectionRef = useRef<HTMLDivElement>(null);
   const isInView = useInView(sectionRef, { once: true, margin: "-100px" });
@@ -131,7 +139,7 @@ function OfferingsDeck() {
   return (
     <section
       ref={sectionRef}
-      className="relative flex flex-col items-center justify-center sm:h-dvh sm:overflow-hidden"
+      className="relative flex flex-col items-center justify-center overflow-x-hidden sm:h-dvh sm:overflow-hidden"
     >
       <h1 className="self-start px-6 pt-8 text-3xl font-medium leading-[0.9] -tracking-[0.03em] sm:absolute sm:left-[25px] sm:top-[25px] sm:z-10 sm:max-w-[70vw] sm:px-0 sm:pt-0 sm:text-[4vw]">
         You bring the game.

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -133,18 +133,13 @@ function OfferingsDeck() {
       ref={sectionRef}
       className="relative flex flex-col items-center justify-center sm:h-dvh sm:overflow-hidden"
     >
-      <motion.h1
-        initial={{ opacity: 0, y: 20 }}
-        animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-        transition={{ duration: 0.7, ease: [0.21, 0.47, 0.32, 0.98] }}
-        className="self-start px-6 pt-8 text-3xl font-medium leading-[0.9] -tracking-[0.03em] sm:absolute sm:left-[25px] sm:top-[25px] sm:z-10 sm:max-w-[70vw] sm:px-0 sm:pt-0 sm:text-[4vw]"
-      >
+      <h1 className="self-start px-6 pt-8 text-3xl font-medium leading-[0.9] -tracking-[0.03em] sm:absolute sm:left-[25px] sm:top-[25px] sm:z-10 sm:max-w-[70vw] sm:px-0 sm:pt-0 sm:text-[4vw]">
         You bring the game.
         <br />
         <span className="text-muted-foreground">
           We bring the internet.
         </span>
-      </motion.h1>
+      </h1>
 
       <div
         ref={containerRef}

--- a/apps/web/src/routes/build.tsx
+++ b/apps/web/src/routes/build.tsx
@@ -93,6 +93,24 @@ function randomOffset() {
 
 const ZERO_OFFSET = { x: 0, y: 0, rotate: 0 };
 
+function CardContent({ card }: { card: Offering }) {
+  return (
+    <div className="flex h-full w-full flex-col justify-between">
+      <div className="flex items-start justify-between font-mono text-[9px] uppercase tracking-[0.2em] sm:text-[0.7vw]">
+        <span>{card.index}</span>
+        <span className="opacity-50">— vg</span>
+      </div>
+      <p className="text-xl font-medium leading-[0.9] -tracking-[0.03em] sm:text-[1.9vw]">
+        {card.title}.{" "}
+        <span className="opacity-60">{card.desc}</span>
+      </p>
+      <div className="border-t border-dashed border-black/40 pt-2 font-mono text-[9px] uppercase tracking-[0.18em] sm:pt-[1vw] sm:text-[0.7vw]">
+        {card.tag}
+      </div>
+    </div>
+  );
+}
+
 function OfferingsDeck() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [activeIdx, setActiveIdx] = useState<number | null>(null);
@@ -185,20 +203,9 @@ function OfferingsDeck() {
                 animate={{ x: innerX }}
                 transition={spring}
                 style={{ backgroundColor: card.color }}
-                className="flex h-full w-full flex-col justify-between rounded-[0.6em] p-[25px] text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
+                className="h-full w-full rounded-[0.6em] p-[1.25vw] text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
               >
-                <p className="text-[1.9vw] font-medium leading-[0.9] -tracking-[0.03em]">
-                  {card.title}.{" "}
-                  <span className="opacity-60">{card.desc}</span>
-                </p>
-                <div className="flex items-center gap-[15px] border-t border-dashed border-black pt-[25px] text-[1.1vw] font-medium leading-[0.9] -tracking-[0.03em]">
-                  <div>
-                    <p>{card.index}</p>
-                    <p className="mt-1 font-mono text-[0.9vw] uppercase leading-normal">
-                      {card.tag}
-                    </p>
-                  </div>
-                </div>
+                <CardContent card={card} />
               </motion.div>
             </motion.div>
           );
@@ -237,21 +244,7 @@ function OfferingsDeck() {
               }}
               className="absolute aspect-[0.8] w-[55%] rounded-xl p-4 text-black shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)]"
             >
-              <div className="flex h-full w-full flex-col justify-between">
-                <div className="flex items-start justify-between font-mono text-[9px] uppercase tracking-[0.2em]">
-                  <span>{card.index}</span>
-                  <span className="opacity-50">— vg</span>
-                </div>
-                <div>
-                  <p className="text-xl font-medium leading-[0.9] -tracking-[0.03em]">
-                    {card.title}.{" "}
-                    <span className="opacity-60">{card.desc}</span>
-                  </p>
-                </div>
-                <div className="border-t border-dashed border-black/40 pt-2 font-mono text-[9px] uppercase tracking-[0.18em]">
-                  {card.tag}
-                </div>
-              </div>
+              <CardContent card={card} />
             </motion.div>
           );
         })}


### PR DESCRIPTION
## Summary
- Replace the 5 numbered step sections on `/build` with a single interactive card deck (ported from the [mwg_025](https://codrops.com) reference)
- 8 cards for the things vibedgames ships: Skills, CLI, Multiplayer, Hosting, Subdomain, Assets, Discovery, Auth
- Cards overlap with random rotation; mousemove divides the deck into regions → active card centers + scales, neighbors fan out via `80/(i - active)`. Implemented in `motion/react` with springs (reference used GSAP)
- Mobile collapses to a stacked vertical list

## Notes for reviewer
- Kept site's mono + dark aesthetic; reference palette (red→cyan) provides the punch on black
- Desktop-only for the overlap interaction (`sm:flex` / `sm:hidden`)
- Hero + CTA unchanged

## Test plan
- [ ] `pnpm dev:web` → visit `/build`, hover across the deck, confirm cards fan + active card centers
- [ ] Leave the deck → cards animate to new random rotations
- [ ] Mobile viewport → stacked list renders
- [ ] Nav + CTA still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI/UX overhaul on the marketing `/build` route plus a global font-class tweak; main risk is layout/animation regressions across breakpoints and input methods.
> 
> **Overview**
> Replaces the `/build` page’s multi-section step narrative with a single interactive, animated “offerings” card deck (8 cards) that fans/centers on hover or tap/click, with a separate mobile collage layout and shared `CardContent`.
> 
> Also switches the global body font utility from `font-mono` to `font-sans` in `__root.tsx`, affecting typography across the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa170cf5388cb69218fc55aca61b8dfddc6e4f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the 5‑step flow on `/build` with an interactive fan‑out card deck and a mobile collage for eight offerings. Switched the body font to sans and unified card UI via shared `CardContent`.

- **New Features**
  - Added `OfferingsDeck`: 8‑card deck (Skills, CLI, Multiplayer, Hosting, Subdomain, Assets, Discovery, Auth) with randomized rotations/offsets; hover/click centers the active card and fans neighbors using `80/(i - active)` with `motion/react` springs.
  - Mobile collage with staggered entrance; supports tap and hover. Inactive cards shift inner content on both X and Y based on position to the active card (desktop stays horizontal‑only).
  - Accessibility: cards are native `motion.button` elements with `aria-pressed`/`aria-label`, Tab focus, and Enter/Space toggle via native behavior, plus a focus‑visible ring.

- **Bug Fixes**
  - Fixed SSR hydration mismatch by initializing offsets to zero and randomizing in `useEffect`.
  - Prevented mobile horizontal overflow with `overflow-x-hidden` on the section.

<sup>Written for commit cfa170cf5388cb69218fc55aca61b8dfddc6e4f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

