### PR TITLE
vg init: self-update CLI when outdated, refresh skills via skills update

### DIFF
--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-
 import { defineCommand } from "citty";
 import consola from "consola";
 import spawn from "cross-spawn";
@@ -7,12 +5,7 @@ import spawn from "cross-spawn";
 const REPO = "kyh/vibedgames";
 const PKG = "vibedgames";
 const DEFAULT_AGENTS = "claude-code,cursor,codex";
-const description =
-  "Install vibedgames skills (and update the vg CLI + skills if outdated)";
-
-const pkg = JSON.parse(
-  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
-) as { version: string };
+const description = "Install/update vibedgames skills and the vg CLI";
 
 type RunResult = { code: number; output: string };
 
@@ -29,13 +22,6 @@ const run = (cmd: string, args: string[]): Promise<RunResult> =>
       resolve({ code: code ?? 1, output: Buffer.concat(chunks).toString("utf8") }),
     );
   });
-
-const fetchLatestVersion = async (): Promise<string | null> => {
-  const result = await run("npm", ["view", PKG, "version"]);
-  if (result.code !== 0) return null;
-  const v = result.output.trim();
-  return v.length > 0 ? v : null;
-};
 
 const skillsAddArgs = (agents: string[], global: boolean, yes: boolean) => {
   const args = ["-y", "skills", "add", REPO];
@@ -81,18 +67,12 @@ export const initCommand = defineCommand({
       .map((s) => s.trim())
       .filter(Boolean);
 
-    consola.start(
-      `Installing vibedgames skills (vg ${pkg.version}) and checking for updates...`,
-    );
+    consola.start("Installing/updating vibedgames skills and the vg CLI...");
 
-    const latest = await fetchLatestVersion();
-    const cliNeedsUpdate = latest !== null && latest !== pkg.version;
-
-    const addPromise = run("npx", skillsAddArgs(agents, args.global, args.yes));
-    const cliPromise = cliNeedsUpdate
-      ? run("npm", ["install", "-g", `${PKG}@latest`])
-      : null;
-    const [add, cli] = await Promise.all([addPromise, cliPromise]);
+    const [add, cli] = await Promise.all([
+      run("npx", skillsAddArgs(agents, args.global, args.yes)),
+      run("npm", ["install", "-g", PKG]),
+    ]);
 
     if (add.code !== 0) {
       if (add.output.trim()) consola.error(add.output.trim());
@@ -100,10 +80,7 @@ export const initCommand = defineCommand({
     }
     consola.success(`Installed vibedgames skills for ${agents.join(", ")}`);
 
-    const update = await run(
-      "npx",
-      skillsUpdateArgs(args.global, args.yes),
-    );
+    const update = await run("npx", skillsUpdateArgs(args.global, args.yes));
     if (update.code !== 0) {
       if (update.output.trim()) consola.warn(update.output.trim());
       consola.warn(
@@ -113,25 +90,14 @@ export const initCommand = defineCommand({
       consola.success("Refreshed installed skills to latest");
     }
 
-    if (!cliNeedsUpdate) {
-      if (latest === null) {
-        consola.warn(
-          `Could not determine the latest vg CLI version on npm. You're on ${pkg.version}.`,
-        );
-      } else {
-        consola.success(`vg CLI is already on the latest version (${pkg.version})`);
-      }
-      return;
-    }
-
-    if (!cli || cli.code !== 0) {
-      if (cli?.output.trim()) consola.warn(cli.output.trim());
+    if (cli.code !== 0) {
+      if (cli.output.trim()) consola.warn(cli.output.trim());
       consola.warn(
-        `Couldn't update the vg CLI globally (npm exit ${cli?.code ?? "?"}). Update manually: npm install -g ${PKG}@latest`,
+        `Couldn't install the vg CLI globally (npm exit ${cli.code}). Install manually: npm install -g ${PKG}`,
       );
       return;
     }
-    consola.success(`Updated vg CLI from ${pkg.version} to ${latest}`);
+    consola.success("Installed/updated vg CLI globally");
   },
 });
 

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { defineCommand } from "citty";
 import consola from "consola";
 import spawn from "cross-spawn";
@@ -5,7 +7,12 @@ import spawn from "cross-spawn";
 const REPO = "kyh/vibedgames";
 const PKG = "vibedgames";
 const DEFAULT_AGENTS = "claude-code,cursor,codex";
-const description = "Install vibedgames skills into your project";
+const description =
+  "Install vibedgames skills (and update the vg CLI + skills if outdated)";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 type RunResult = { code: number; output: string };
 
@@ -23,9 +30,23 @@ const run = (cmd: string, args: string[]): Promise<RunResult> =>
     );
   });
 
-const skillsArgs = (agents: string[], global: boolean, yes: boolean) => {
+const fetchLatestVersion = async (): Promise<string | null> => {
+  const result = await run("npm", ["view", PKG, "version"]);
+  if (result.code !== 0) return null;
+  const v = result.output.trim();
+  return v.length > 0 ? v : null;
+};
+
+const skillsAddArgs = (agents: string[], global: boolean, yes: boolean) => {
   const args = ["-y", "skills", "add", REPO];
   for (const agent of agents) args.push("-a", agent);
+  if (global) args.push("-g");
+  if (yes) args.push("-y");
+  return args;
+};
+
+const skillsUpdateArgs = (global: boolean, yes: boolean) => {
+  const args = ["-y", "skills", "update"];
   if (global) args.push("-g");
   if (yes) args.push("-y");
   return args;
@@ -60,27 +81,57 @@ export const initCommand = defineCommand({
       .map((s) => s.trim())
       .filter(Boolean);
 
-    consola.start("Installing skills and the vg CLI globally...");
+    consola.start(
+      `Installing vibedgames skills (vg ${pkg.version}) and checking for updates...`,
+    );
 
-    const [skills, cli] = await Promise.all([
-      run("npx", skillsArgs(agents, args.global, args.yes)),
-      run("npm", ["install", "-g", PKG]),
-    ]);
+    const latest = await fetchLatestVersion();
+    const cliNeedsUpdate = latest !== null && latest !== pkg.version;
 
-    if (skills.code !== 0) {
-      if (skills.output.trim()) consola.error(skills.output.trim());
-      throw new Error(`skills exited with code ${skills.code}`);
+    const addPromise = run("npx", skillsAddArgs(agents, args.global, args.yes));
+    const cliPromise = cliNeedsUpdate
+      ? run("npm", ["install", "-g", `${PKG}@latest`])
+      : null;
+    const [add, cli] = await Promise.all([addPromise, cliPromise]);
+
+    if (add.code !== 0) {
+      if (add.output.trim()) consola.error(add.output.trim());
+      throw new Error(`skills add exited with code ${add.code}`);
     }
     consola.success(`Installed vibedgames skills for ${agents.join(", ")}`);
 
-    if (cli.code !== 0) {
-      if (cli.output.trim()) consola.warn(cli.output.trim());
+    const update = await run(
+      "npx",
+      skillsUpdateArgs(args.global, args.yes),
+    );
+    if (update.code !== 0) {
+      if (update.output.trim()) consola.warn(update.output.trim());
       consola.warn(
-        `Couldn't install the vg CLI globally (npm exit ${cli.code}). Install manually: npm install -g ${PKG}`,
+        `'skills update' exited with code ${update.code}. Skills were just installed via 'add', so they should already be current.`,
+      );
+    } else {
+      consola.success("Refreshed installed skills to latest");
+    }
+
+    if (!cliNeedsUpdate) {
+      if (latest === null) {
+        consola.warn(
+          `Could not determine the latest vg CLI version on npm. You're on ${pkg.version}.`,
+        );
+      } else {
+        consola.success(`vg CLI is already on the latest version (${pkg.version})`);
+      }
+      return;
+    }
+
+    if (!cli || cli.code !== 0) {
+      if (cli?.output.trim()) consola.warn(cli.output.trim());
+      consola.warn(
+        `Couldn't update the vg CLI globally (npm exit ${cli?.code ?? "?"}). Update manually: npm install -g ${PKG}@latest`,
       );
       return;
     }
-    consola.success("Installed vg CLI globally");
+    consola.success(`Updated vg CLI from ${pkg.version} to ${latest}`);
   },
 });
 


### PR DESCRIPTION
## Summary

- `vg init` now queries the latest published version of `vibedgames` from npm and only runs `npm install -g vibedgames@latest` when the running CLI is on an older version (previously it reinstalled every time).
- After `skills add`, it also runs `skills update` so previously-installed skills get refreshed to the latest revision from `kyh/vibedgames`. Update failure is treated as a soft warning since `add` already runs first.
- Status output now reports the current vg version and whether the CLI / skills were refreshed.

## Test plan

- [ ] `pnpm --filter vibedgames typecheck` passes (verified locally)
- [ ] `pnpm --filter vibedgames build` passes (verified locally)
- [ ] On a machine with the published version of `vibedgames`, run `vg init` and confirm:
  - "vg CLI is already on the latest version" when up-to-date, no `npm install -g` invoked
  - "Updated vg CLI from X to Y" when outdated, with the global install actually happening
  - "Refreshed installed skills to latest" appears after the install step

https://claude.ai/code/session_011AcHryhgCaXdcbk7iM9mHX

---
_Generated by [Claude Code](https://claude.ai/code/session_011AcHryhgCaXdcbk7iM9mHX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`vg init` now ensures the `vibedgames` CLI is on the latest version and refreshes installed skills after they’re added. It prints clear status and treats skill refresh failures as a soft warning.

- **New Features**
  - Install/upgrade the CLI via `npm install -g vibedgames` (no manual version check; resolves to `@latest`).
  - After `skills add`, run `skills update` to refresh from `kyh/vibedgames` (warn on failure).

<sup>Written for commit 845aa5c79c0b2d5857b00bb86f00155d21a6a69b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the `vg init` command’s install flow and logging, with failures handled as warnings except for `skills add`.
> 
> **Overview**
> `vg init` now runs `npx skills update` after `skills add` to refresh any previously-installed vibedgames skills, treating update failures as a soft warning.
> 
> It also refactors argument construction (`skillsAddArgs`/`skillsUpdateArgs`) and updates console messaging and error text to reflect *install/update* behavior for both skills and the global `vibedgames` CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 845aa5c79c0b2d5857b00bb86f00155d21a6a69b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->