### PR TITLE
Filter UA bot check to documented Claude/OpenAI agents

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -6,7 +6,7 @@ import { PlayView } from "@/components/game/play-view";
 import { installResponse } from "@/lib/install-response";
 
 const AI_BOT_UA =
-  /(ClaudeBot|Claude-User|Anthropic-AI|GPTBot|ChatGPT-User|OAI-SearchBot|PerplexityBot|Bytespider|cohere-ai|FacebookBot|Applebot-Extended|Google-Extended|YouBot|Diffbot)/i;
+  /(ClaudeBot|Claude-User|Anthropic-AI|GPTBot|ChatGPT-User|OAI-SearchBot|Cursor)/i;
 
 export const Route = createFileRoute("/")({
   validateSearch: gameSearchSchema,

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -6,7 +6,7 @@ import { PlayView } from "@/components/game/play-view";
 import { installResponse } from "@/lib/install-response";
 
 const AI_BOT_UA =
-  /(ClaudeBot|Claude-User|Anthropic-AI|GPTBot|ChatGPT-User|OAI-SearchBot|Cursor)/i;
+  /(ClaudeBot|Claude-User|Claude-SearchBot|GPTBot|ChatGPT-User|OAI-SearchBot)/i;
 
 export const Route = createFileRoute("/")({
   validateSearch: gameSearchSchema,


### PR DESCRIPTION
## Summary
- Narrow `AI_BOT_UA` in `apps/web/src/routes/index.tsx` so the install response only triggers for currently documented Claude and OpenAI user agents.
- Final list: `ClaudeBot`, `Claude-User`, `Claude-SearchBot`, `GPTBot`, `ChatGPT-User`, `OAI-SearchBot`.
- Removed `Anthropic-AI` (deprecated by Anthropic, replaced by ClaudeBot).
- Removed `PerplexityBot`, `Bytespider`, `cohere-ai`, `FacebookBot`, `Applebot-Extended`, `Google-Extended`, `YouBot`, `Diffbot`.
- Cursor was considered but has no officially documented web-fetch UA, so it is not included.

## Test plan
- [ ] Verify request with `ClaudeBot`, `Claude-User`, `Claude-SearchBot`, `GPTBot`, `ChatGPT-User`, or `OAI-SearchBot` UA returns the install response.
- [ ] Verify previously matched UAs (e.g. `PerplexityBot`, `Google-Extended`, `Anthropic-AI`) now fall through to `next()`.

https://claude.ai/code/session_01DM71qLhmN81NYAyxcZboiq