### PR TITLE
Add haptic feedback to button clicks and discover nav

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "react-hook-form": "^7.75.0",
     "superjson": "catalog:",
     "tw-animate-css": "^1.4.0",
+    "web-haptics": "^0.0.6",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useWebHaptics } from "web-haptics/react";
 
 import { FadeInBlur } from "@/components/ui/fade-in-blur";
 import { featuredGames, gameSearchSchema } from "@/components/game/data";
@@ -12,6 +13,7 @@ export const Route = createFileRoute("/discover")({
 function DiscoverPage() {
   const navigate = useNavigate();
   const { game: activeGame } = Route.useSearch();
+  const { trigger } = useWebHaptics();
 
   return (
     <header className="fixed bottom-16 left-0 z-10 flex max-h-full max-w-dvw flex-col px-4 md:w-96">
@@ -23,7 +25,10 @@ function DiscoverPage() {
               if (activeGame === game.slug) return;
               void navigate({ to: "/discover", search: { game: game.slug }, replace: true });
             }}
-            onClick={() => void navigate({ to: "/", search: { game: game.slug } })}
+            onClick={() => {
+              trigger("selection");
+              void navigate({ to: "/", search: { game: game.slug } });
+            }}
             className="hover:border-foreground relative aspect-video w-30 shrink-0 overflow-clip rounded-lg border border-transparent transition-colors"
           >
             <img

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,7 +22,8 @@
     "shadcn": "^4.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "web-haptics": "^0.0.6"
   },
   "devDependencies": {
     "@kyh/tsconfig": "catalog:",

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,11 +1,12 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
+import { useWebHaptics } from "web-haptics/react";
 
 import { Spinner } from "@repo/ui/components/spinner";
 import { cn } from "@repo/ui/lib/utils";
 
 const buttonVariants = cva(
-  "group/button relative inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button relative inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -64,13 +65,19 @@ function Button({
   loading,
   disabled,
   children,
+  onClick,
   ...props
 }: ButtonProps) {
+  const { trigger } = useWebHaptics();
   return (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, loading, className }))}
       disabled={loading || disabled}
+      onClick={(event) => {
+        trigger(variant === "destructive" ? "warning" : "selection");
+        onClick?.(event);
+      }}
       {...props}
     >
       {loading && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      web-haptics:
+        specifier: ^0.0.6
+        version: 0.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: 'catalog:'
         version: 4.4.2
@@ -629,6 +632,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      web-haptics:
+        specifier: ^0.0.6
+        version: 0.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -7349,6 +7355,23 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-haptics@0.0.6:
+    resolution: {integrity: sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+      svelte: '>=4'
+      vue: '>=3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -15001,6 +15024,11 @@ snapshots:
     dependencies:
       defaults: 1.0.4
     optional: true
+
+  web-haptics@0.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
Mirrors [uicapsule#22](https://github.com/kyh/uicapsule/pull/22) for vibedgames.

## Summary
- Integrates `web-haptics` into the shared `Button` (`packages/ui`): triggers `warning` on destructive variants and `selection` on every other variant
- Adds haptic feedback to game card taps on the discover route (the analog of uicapsule's `content-preview` cards)
- Swaps the button active-state animation from `translate-y-px` to `scale-[0.97]` so the visual press matches the haptic
- `GameNavArrows` (prev/next) inherits haptics automatically since it uses the shared `Button` — analogous to uicapsule's `aside.tsx` nav arrows

Notes:
- No `"use client"` directive added — vibedgames runs on TanStack Start (Vite SSR), which doesn't use the Next.js client-boundary convention
- Gracefully degrades on devices without `navigator.vibrate` (handled by `web-haptics`)

## Test plan
- [ ] Open the site on a mobile device and confirm Button presses produce a haptic tap
- [ ] Confirm destructive Buttons produce a stronger `warning` pattern
- [ ] Tap a game card on `/discover` and confirm a `selection` haptic fires before navigating to `/`
- [ ] Click prev/next on `GameNavArrows` and confirm selection haptic fires (via the shared Button)
- [ ] Verify desktop browsers without vibration support behave normally (no errors)
- [ ] Confirm the scale-down press animation feels right

https://claude.ai/code/session_01Dxndi7tYGRzzLCX19dxQww

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dxndi7tYGRzzLCX19dxQww)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the shared `Button` click handler and active-state styling, which affects button interactions across the app, and introduces a new dependency (`web-haptics`). Behavior should degrade gracefully on unsupported devices but needs validation on key click paths.
> 
> **Overview**
> Adds `web-haptics` and triggers haptic feedback on user interactions: the shared `packages/ui` `Button` now fires `selection` haptics on click (and `warning` for `destructive`), and `/discover` game-card clicks also trigger a `selection` haptic before navigating.
> 
> Also tweaks the shared button press animation from `translate-y-px` to `scale-[0.97]` to better match the haptic “press” feel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3de83b056401e7a42265ac5a76faa97599a211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add haptic feedback to button clicks and Discover navigation using `web-haptics`. Destructive actions use a stronger pattern, and the button press animation now scales to match the feel.

- **New Features**
  - Shared `Button` triggers `selection` haptic on click; `destructive` uses `warning` (inherits to `GameNavArrows`).
  - `/discover` game card taps trigger `selection` before navigating.
  - Press animation switched to `scale-[0.97]` for a tighter tap feel.

- **Dependencies**
  - Added `web-haptics@^0.0.6` to `apps/web` and `packages/ui`.

<sup>Written for commit 2f3de83b056401e7a42265ac5a76faa97599a211. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

