### PR TITLE
Auto-confirm CLI login instead of manual code match

### DIFF
--- a/apps/web/src/components/auth/cli-auth-confirm.tsx
+++ b/apps/web/src/components/auth/cli-auth-confirm.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@repo/ui/components/button";
+import { useEffect, useRef } from "react";
 import { useMutation } from "@tanstack/react-query";
 
 import { useTRPC } from "@/lib/trpc";
@@ -12,33 +12,48 @@ export const CliAuthConfirm = ({ code, userName }: CliAuthConfirmProps) => {
   const trpc = useTRPC();
   const confirm = useMutation(trpc.auth.cliConfirm.mutationOptions());
 
+  // Auto-confirm on mount: reaching this page is the authorization. The loader
+  // already gated on an authenticated session (redirecting to login otherwise),
+  // so the logged-in user landing here is the consent — no manual code match.
+  // The ref guard keeps the one-shot mutation from firing twice under React
+  // strict mode / re-renders.
+  const { mutate } = confirm;
+  const firedRef = useRef(false);
+  useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+    mutate({ code });
+  }, [mutate, code]);
+
+  if (confirm.isError) {
+    return (
+      <div className="flex flex-col gap-4 text-center">
+        <h1 className="text-lg font-light">Couldn&apos;t connect the CLI</h1>
+        <p className="text-sm text-red-500">{confirm.error.message}</p>
+        <p className="text-muted-foreground text-xs">
+          Run <code>vg login</code> to try again.
+        </p>
+      </div>
+    );
+  }
+
+  if (confirm.isSuccess) {
+    return (
+      <div className="flex flex-col gap-4 text-center">
+        <h1 className="text-lg font-light">Successfully connected</h1>
+        <p className="text-muted-foreground text-sm">
+          The VG CLI is now authorized as <strong>{userName}</strong>. You can close this window.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-4 text-center">
-      <h1 className="text-lg font-light">Authorize VG CLI</h1>
+      <h1 className="text-lg font-light">Connecting the VG CLI…</h1>
       <p className="text-muted-foreground text-sm">
-        The VG CLI is requesting access as <strong>{userName}</strong>.
+        Authorizing as <strong>{userName}</strong>.
       </p>
-      <p className="font-mono text-2xl tracking-widest">{code}</p>
-      <p className="text-muted-foreground text-xs">
-        Confirm this code matches what you see in your terminal.
-      </p>
-      {confirm.isSuccess ? (
-        <p className="text-sm text-green-500">
-          Authorized! You can close this window.
-        </p>
-      ) : (
-        <Button
-          onClick={() => confirm.mutate({ code })}
-          loading={confirm.isPending}
-        >
-          Authorize
-        </Button>
-      )}
-      {confirm.isError && (
-        <p className="text-sm text-red-500">
-          {confirm.error.message}
-        </p>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## What

Removes the human code-verification step from the CLI login browser page. The page now auto-confirms on load and shows a plain **"Successfully connected"** state — like clicking a CLI auth link.

## Why

The old `/auth/cli` page asked the user to eyeball-match the 6-char code against their terminal and click **Authorize**. But the CLI pre-fills the code into the URL it opens:

```ts
const authUrl = `${baseUrl}/auth/cli?code=${code}`; // apps/cli/src/commands/login.ts
```

so on the legitimate path the browser code and the terminal code are the *same value rendered twice* — the match can never fail, and the step doesn't defend against device-code phishing (which would need a separate `device_code`/`user_code` split, not pursued here). It was friction without protection, and the primary `vg` CLI user is an agent, not a human.

## How

- Reaching `/auth/cli` already requires an authenticated session — the route loader redirects to login otherwise — so landing on the page **is** the consent.
- `CliAuthConfirm` now fires `cliConfirm` on mount (one-shot, ref-guarded against React strict-mode double-invoke) and renders connecting → success / error states.
- **No server changes.** `cliConfirm` stays a `protectedProcedure` — that authenticated mutation is the real authorization boundary and is untouched.

## Test

- `pnpm typecheck` (web) passes.
- oxlint + oxfmt clean on the changed file.

https://claude.ai/code/session_018fgwrGLcmv8DZNVRh6fgYb

---
_Generated by [Claude Code](https://claude.ai/code/session_018fgwrGLcmv8DZNVRh6fgYb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI OAuth-style consent UX; authorization still depends on the existing authenticated `cliConfirm` mutation, but removing explicit user confirmation slightly changes the security UX model.
> 
> **Overview**
> **CLI browser auth** no longer shows the 6-character code or an **Authorize** button. **`CliAuthConfirm`** now calls **`auth.cliConfirm`** once on mount (ref-guarded for strict mode) and shows **Connecting → Successfully connected** or a dedicated error state with **`vg login`** retry guidance.
> 
> Consent is treated as **landing on `/auth/cli` with an authenticated session** (unchanged loader behavior). **No backend or `cliConfirm` changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d095dd2bcac05ee40048b1ba16248cda39c5db27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-confirms CLI login in the browser by calling `cliConfirm` on page load, removing the manual code match and button click. This streamlines login while keeping the server-side auth boundary as-is.

- **New Features**
  - Call `cliConfirm` with the `code` on first render; ref guard prevents double fire under React Strict Mode.
  - Replace the code entry UI with states: Connecting → “Successfully connected” (shows user) → Error (shows message, suggests `vg login`).
  - Page access is already gated by an authenticated session, so landing here counts as consent.

<sup>Written for commit d095dd2bcac05ee40048b1ba16248cda39c5db27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

