### PR TITLE
Replace Discord card on build page with teach-me skill card

### DIFF
--- a/apps/web/src/routes/_site/build.tsx
+++ b/apps/web/src/routes/_site/build.tsx
@@ -115,8 +115,8 @@ const OFFERINGS: Offering[] = [
   {
     index: "05",
     title: "Learn as you build",
-    tag: "/teach-me game development",
-    desc: "A built-in tutor for design, code, art, and juice. Every lesson ends playable.",
+    tag: "/teach-me how to build a platformer",
+    desc: "A built-in tutor. Learn gamedev by shipping real games.",
     color: "#73B7E5",
     zIndex: 3,
   },

--- a/apps/web/src/routes/_site/build.tsx
+++ b/apps/web/src/routes/_site/build.tsx
@@ -114,9 +114,9 @@ const OFFERINGS: Offering[] = [
   },
   {
     index: "05",
-    title: "Learn together",
-    tag: "join the discord",
-    desc: "A Discord of vibe game devs learning side by side.",
+    title: "Learn as you build",
+    tag: "teach me game development",
+    desc: "A built-in tutor. Learn gamedev by shipping real games.",
     color: "#73B7E5",
     zIndex: 3,
   },

--- a/apps/web/src/routes/_site/build.tsx
+++ b/apps/web/src/routes/_site/build.tsx
@@ -115,8 +115,8 @@ const OFFERINGS: Offering[] = [
   {
     index: "05",
     title: "Learn as you build",
-    tag: "teach me game development",
-    desc: "A built-in tutor. Learn gamedev by shipping real games.",
+    tag: "/teach-me game development",
+    desc: "A built-in tutor for design, code, art, and juice. Every lesson ends playable.",
     color: "#73B7E5",
     zIndex: 3,
   },


### PR DESCRIPTION
The last offering card on the build page previously pointed to the Discord. It now highlights the built-in `teach-me` skill instead:

- **Title:** "Learn together" → "Learn as you build"
- **Copyable prompt:** "join the discord" → "teach me game development" (matches the skill's trigger phrasing)
- **Description:** "A Discord of vibe game devs learning side by side." → "A built-in tutor. Learn gamedev by shipping real games."

The copy is grounded in `plugins/game-craft/skills/teach-me/SKILL.md`, which teaches end-to-end game development where every lesson ends with something playable.

https://claude.ai/code/session_011g8t4G22qhxa1X72N8xJSn

---
_Generated by [Claude Code](https://claude.ai/code/session_011g8t4G22qhxa1X72N8xJSn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy only in static `OFFERINGS` data; no routing, auth, or product logic changes.
> 
> **Overview**
> Updates the fifth **build** page offering card (index `05`) from Discord community messaging to the built-in **`teach-me`** skill.
> 
> **Title** is now “Learn as you build”; the **copyable prompt** is `/teach-me how to build a platformer`; the **description** positions an in-product tutor (“Learn gamedev by shipping real games”). Card layout, colors, and deck behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9de036adbcdd345588805ec0cd86b6e91b826bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped the last offering card on the build page to promote the built-in `teach-me` skill instead of Discord. Updated the title to “Learn as you build”, set the copyable prompt to “/teach-me game development”, and refined the description to cover design, code, art, and juice with “Every lesson ends playable.”

<sup>Written for commit efc76fd75069de6a1725d43509d3f2a698de0c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

