### PR TITLE
fix(web): tune chromatic rolling text on build page

### DIFF
--- a/apps/web/src/components/ui/rolling-text.tsx
+++ b/apps/web/src/components/ui/rolling-text.tsx
@@ -289,7 +289,11 @@ export const RollingText = ({
   }
 
   return (
-    <span className={cn("inline-flex", className)} aria-label={words[0]}>
+    <span className={cn("inline-flex", className)}>
+      {/* aria-label is unreliable on generic elements, so the accessible name
+          lives in a visually-hidden span instead; the animated columns are
+          aria-hidden. */}
+      <span className="sr-only">{words[0]}</span>
       {Array.from({ length: len }, (_, i) => (
         <RollingColumn
           key={i}

--- a/apps/web/src/components/ui/rolling-text.tsx
+++ b/apps/web/src/components/ui/rolling-text.tsx
@@ -1,8 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
-import { AnimatePresence, motion, useReducedMotion, type TargetAndTransition } from "motion/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  animate,
+  AnimatePresence,
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  type TargetAndTransition,
+} from "motion/react";
 import { cn } from "@repo/ui/lib/utils";
 
-const NBSP = " ";
+const NBSP = " ";
 const glyph = (char: string) => (char === " " ? NBSP : char);
 
 // Springy overshoot — slot-text's "back" easing, so each letter lands with a
@@ -16,24 +23,47 @@ const wobble = (i: number, salt: number) => {
   return (n - Math.floor(n)) * 2 - 1;
 };
 
+// Width of the glyph `char` puts in a column, read off that column's hidden
+// candidate spans. 0 when the current word doesn't reach this column.
+const measureChar = (els: Map<string, HTMLSpanElement>, char: string) => {
+  if (!char) return 0;
+  const el = els.get(glyph(char));
+  return el ? el.getBoundingClientRect().width : null;
+};
+
 type ChromaticOptions = {
   from?: number;
   spread?: number;
   saturation?: number;
   lightness?: number;
+  /** Explicit color stops swept across the line instead of a hue ramp. */
+  palette?: string[];
 };
 
 /**
- * Hue sweep across the line: every glyph rolls in its own color, so the change
- * lands as a chromatic spectrum before settling to the resting color.
+ * Color sweep across the line: every glyph rolls in its own color, so the
+ * change lands as a chromatic spectrum before settling to the resting color.
  *
- *   <RollingText color={chromatic()} />            // full rainbow
+ *   <RollingText color={chromatic()} />              // full rainbow
  *   <RollingText color={chromatic({ from: 190 })} /> // start cyan
+ *   <RollingText color={chromatic({ palette: ["#f00", "#00f"] })} />
  */
 export const chromatic =
-  ({ from = 0, spread = 320, saturation = 92, lightness = 60 }: ChromaticOptions = {}) =>
+  ({ from = 0, spread = 320, saturation = 92, lightness = 60, palette }: ChromaticOptions = {}) =>
   (index: number, total: number) => {
     const t = total <= 1 ? 0 : index / (total - 1);
+    if (palette && palette.length > 0) {
+      if (palette.length === 1) return palette[0] ?? "";
+      // Interpolate between the two stops this glyph falls between.
+      const pos = t * (palette.length - 1);
+      const lower = Math.min(Math.floor(pos), palette.length - 2);
+      const mix = Math.round((pos - lower) * 100);
+      const a = palette[lower] ?? "";
+      const b = palette[lower + 1] ?? "";
+      if (mix <= 0) return a;
+      if (mix >= 100) return b;
+      return `color-mix(in oklab, ${b} ${mix}%, ${a})`;
+    }
     return `hsl(${(from + t * spread) % 360} ${saturation}% ${lightness}%)`;
   };
 
@@ -57,6 +87,156 @@ type RollingTextProps = {
   /** How long the chromatic tint fades back to rest, in seconds. */
   colorFade?: number;
   className?: string;
+};
+
+type RollingColumnProps = {
+  /** Every glyph this column can show, across all words. */
+  candidates: string[];
+  /** The glyph the current word puts in this column ("" when it's shorter). */
+  char: string;
+  /** Current word index — keys the faces so AnimatePresence swaps them. */
+  wordKey: number;
+  enterY: string;
+  exitY: string;
+  tilt: number;
+  delay: number;
+  exitOffset: number;
+  duration: number;
+  tint?: string;
+  colorFade: number;
+};
+
+const RollingColumn = ({
+  candidates,
+  char,
+  wordKey,
+  enterY,
+  exitY,
+  tilt,
+  delay,
+  exitOffset,
+  duration,
+  tint,
+  colorFade,
+}: RollingColumnProps) => {
+  const sizerRef = useRef<HTMLSpanElement>(null);
+  const candidateEls = useRef(new Map<string, HTMLSpanElement>());
+  const charRef = useRef(char);
+  charRef.current = char;
+  // "auto" until the first measurement, so SSR/pre-hydration falls back to the
+  // widest-candidate width the sizer provides.
+  const width = useMotionValue<number | "auto">("auto");
+
+  // Size the column to the glyph it's currently showing — measured off the
+  // hidden candidates — instead of the widest candidate, so narrow letters
+  // like "l" don't float in a slot sized for "o" or "u". The width rolls to
+  // the incoming glyph's in step with the letters.
+  useEffect(() => {
+    const target = measureChar(candidateEls.current, char);
+    if (target === null) return;
+    if (width.get() === "auto") {
+      width.set(target);
+      return;
+    }
+    const controls = animate(width, target, {
+      delay: delay + exitOffset,
+      duration,
+      ease: "easeOut",
+    });
+    return () => controls.stop();
+  }, [char, width, delay, exitOffset, duration]);
+
+  // Re-measure when the sizer's own box changes (font load, breakpoint font
+  // size) — jump straight to the new width, no roll.
+  useEffect(() => {
+    const sizer = sizerRef.current;
+    if (!sizer || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      const target = measureChar(candidateEls.current, charRef.current);
+      if (target !== null) width.set(target);
+    });
+    observer.observe(sizer);
+    return () => observer.disconnect();
+  }, [width]);
+
+  // The new glyph rolls in tinted (--flash: 1) and the tint mixes out to the
+  // resting color via color-mix, so it works regardless of the theme's color
+  // space (currentColor is oklch here).
+  const roll = { delay: delay + exitOffset, duration, ease: EASE };
+  const exitRoll = { delay, duration, ease: EASE };
+  const initial: TargetAndTransition = {
+    y: enterY,
+    rotate: tilt,
+    ...(tint && { "--flash": 1 }),
+  };
+  const enter: TargetAndTransition = {
+    y: "0%",
+    rotate: 0,
+    ...(tint && { "--flash": 0 }),
+    transition: {
+      y: roll,
+      rotate: roll,
+      ...(tint && {
+        "--flash": {
+          delay: delay + exitOffset + duration,
+          duration: colorFade,
+          ease: "linear",
+        },
+      }),
+    },
+  };
+
+  return (
+    <motion.span
+      aria-hidden
+      style={{ width }}
+      className="relative inline-flex justify-center overflow-x-visible [overflow-y:clip]"
+    >
+      {/* Invisible sizer renders every glyph this column can show (overlapped
+          in one grid cell) so the current one can be measured. It also keeps
+          the column at full text height while the faces are absolutely
+          positioned. Until the first measurement lands, it sizes the column
+          to its widest candidate. */}
+      <span ref={sizerRef} className="invisible inline-grid">
+        {(candidates.length ? candidates : [NBSP]).map((candidate) => (
+          <span
+            key={candidate}
+            ref={(el) => {
+              if (el) candidateEls.current.set(candidate, el);
+              else candidateEls.current.delete(candidate);
+            }}
+            // justifySelf keeps each candidate at its own glyph width instead
+            // of stretching to the cell, so the measurement is per-glyph.
+            style={{ gridArea: "1 / 1", justifySelf: "start" }}
+          >
+            {candidate}
+          </span>
+        ))}
+      </span>
+      <AnimatePresence initial={false}>
+        <motion.span
+          key={wordKey}
+          className="absolute inset-0 flex items-center justify-center will-change-transform"
+          style={
+            tint
+              ? {
+                  color: `color-mix(in oklab, ${tint} calc(var(--flash) * 100%), currentColor)`,
+                }
+              : undefined
+          }
+          initial={initial}
+          animate={enter}
+          exit={{
+            y: exitY,
+            rotate: -tilt,
+            transition: { y: exitRoll, rotate: exitRoll },
+          }}
+        >
+          {glyph(char)}
+        </motion.span>
+      </AnimatePresence>
+    </motion.span>
+  );
 };
 
 /**
@@ -87,10 +267,9 @@ export const RollingText = ({
     return () => clearInterval(id);
   }, [reduceMotion, words.length, interval]);
 
-  // Every glyph that can appear in each column, across all words (padded to the
-  // longest word). The sizer reserves the widest of them so a column's width
-  // never changes as words cycle — the line never reflows and an outgoing glyph
-  // stays aligned while it rolls, regardless of the incoming word's length.
+  // Every glyph that can appear in each column, across all words (padded to
+  // the longest word). The column renders them all in a hidden sizer so it can
+  // measure whichever one the current word shows.
   const columns = useMemo(() => {
     const len = words.reduce((max, word) => Math.max(max, word.length), 0);
     return Array.from({ length: len }, (_, i) =>
@@ -108,82 +287,22 @@ export const RollingText = ({
 
   return (
     <span className={cn("inline-flex", className)} aria-label={words[0]}>
-      {Array.from({ length: len }, (_, i) => {
-        const column = columns[i] ?? [];
-        const char = word[i] ?? "";
-        const tilt = bounce * 5 * wobble(i, 3);
-        const base = i * stagger;
-        const tint = color?.(i, len);
-
-        // The new glyph rolls in tinted (--flash: 1) and the tint mixes out to
-        // the resting color via color-mix, so it works regardless of the theme's
-        // color space (currentColor is oklch here).
-        const roll = { delay: base + exitOffset, duration, ease: EASE };
-        const exitRoll = { delay: base, duration, ease: EASE };
-        const initial: TargetAndTransition = {
-          y: enterY,
-          rotate: tilt,
-          ...(tint && { "--flash": 1 }),
-        };
-        const enter: TargetAndTransition = {
-          y: "0%",
-          rotate: 0,
-          ...(tint && { "--flash": 0 }),
-          transition: {
-            y: roll,
-            rotate: roll,
-            ...(tint && {
-              "--flash": {
-                delay: base + exitOffset + duration,
-                duration: colorFade,
-                ease: "linear",
-              },
-            }),
-          },
-        };
-
-        return (
-          <span
-            key={i}
-            aria-hidden
-            className="relative inline-flex justify-center overflow-x-visible [overflow-y:clip]"
-          >
-            {/* Invisible sizer reserves the widest glyph this column can ever
-                show (all candidates overlapped in one grid cell), so the cell
-                width is constant and the absolutely positioned faces never
-                reflow the line as they roll. */}
-            <span className="invisible inline-grid">
-              {(column.length ? column : [NBSP]).map((candidate) => (
-                <span key={candidate} style={{ gridArea: "1 / 1" }}>
-                  {candidate}
-                </span>
-              ))}
-            </span>
-            <AnimatePresence initial={false}>
-              <motion.span
-                key={index}
-                className="absolute inset-0 flex items-center justify-center will-change-transform"
-                style={
-                  tint
-                    ? {
-                        color: `color-mix(in oklab, ${tint} calc(var(--flash) * 100%), currentColor)`,
-                      }
-                    : undefined
-                }
-                initial={initial}
-                animate={enter}
-                exit={{
-                  y: exitY,
-                  rotate: -tilt,
-                  transition: { y: exitRoll, rotate: exitRoll },
-                }}
-              >
-                {glyph(char)}
-              </motion.span>
-            </AnimatePresence>
-          </span>
-        );
-      })}
+      {Array.from({ length: len }, (_, i) => (
+        <RollingColumn
+          key={i}
+          candidates={columns[i] ?? []}
+          char={word[i] ?? ""}
+          wordKey={index}
+          enterY={enterY}
+          exitY={exitY}
+          tilt={bounce * 5 * wobble(i, 3)}
+          delay={i * stagger}
+          exitOffset={exitOffset}
+          duration={duration}
+          tint={color?.(i, len)}
+          colorFade={colorFade}
+        />
+      ))}
     </span>
   );
 };

--- a/apps/web/src/components/ui/rolling-text.tsx
+++ b/apps/web/src/components/ui/rolling-text.tsx
@@ -190,7 +190,7 @@ const RollingColumn = ({
     <motion.span
       aria-hidden
       style={{ width }}
-      className="relative inline-flex justify-center overflow-x-visible [overflow-y:clip]"
+      className="relative inline-flex min-w-0 justify-center overflow-x-visible [overflow-y:clip]"
     >
       {/* Invisible sizer renders every glyph this column can show (overlapped
           in one grid cell) so the current one can be measured. It also keeps

--- a/apps/web/src/components/ui/rolling-text.tsx
+++ b/apps/web/src/components/ui/rolling-text.tsx
@@ -9,7 +9,7 @@ import {
 } from "motion/react";
 import { cn } from "@repo/ui/lib/utils";
 
-const NBSP = " ";
+const NBSP = "\u00A0";
 const glyph = (char: string) => (char === " " ? NBSP : char);
 
 // Springy overshoot — slot-text's "back" easing, so each letter lands with a
@@ -190,7 +190,10 @@ const RollingColumn = ({
     <motion.span
       aria-hidden
       style={{ width }}
-      className="relative inline-flex min-w-0 justify-center overflow-x-visible [overflow-y:clip]"
+      // overflow-y clips at the padding box, so the symmetric py/-my pair
+      // extends the clip past tight line-heights (descenders like "g" were
+      // getting cut) without changing the line metrics.
+      className="relative -my-[0.2em] inline-flex min-w-0 justify-center overflow-x-visible py-[0.2em] [overflow-y:clip]"
     >
       {/* Invisible sizer renders every glyph this column can show (overlapped
           in one grid cell) so the current one can be measured. It also keeps

--- a/apps/web/src/routes/_site/build.tsx
+++ b/apps/web/src/routes/_site/build.tsx
@@ -123,6 +123,16 @@ const OFFERINGS: Offering[] = [
   },
 ];
 
+// The card pastels above, saturated a touch so the chromatic flash still reads
+// once the letters settle into the muted heading color.
+const ROLL_PALETTE = [
+  "hsl(12 90% 66%)", // #F59279
+  "hsl(31 95% 62%)", // #F9B060
+  "hsl(50 94% 57%)", // #F5D84A
+  "hsl(125 55% 60%)", // #80D487
+  "hsl(204 75% 60%)", // #73B7E5
+];
+
 function randomOffset() {
   return {
     x: (Math.random() - 0.5) * 10,
@@ -366,8 +376,7 @@ function OfferingsDeck() {
             in your{" "}
             <RollingText
               words={["claude", "codex", "cursor", "agent"]}
-              color={chromatic()}
-              className="text-foreground"
+              color={chromatic({ palette: ROLL_PALETTE })}
             />
           </span>
         </h1>


### PR DESCRIPTION
Fixes four issues with the chromatic rolling text in the build page headline ("A game studio in your claude/codex/cursor/agent"):

## Letter spacing ("l" looked off)

Each column used to reserve the width of the *widest* glyph that could ever appear in it across all words, with the current glyph centered in that slot. The narrow "l" in "claude" sat in a slot sized for "o"/"u"/"g", producing visible gaps (`c l aude`).

Columns are now sized to the glyph they're currently showing, measured off the hidden candidate sizer, and the width rolls to the incoming glyph's width in step with the letter animation (driven by a `MotionValue`; a `ResizeObserver` re-measures on font load / breakpoint changes, snapping instead of animating). Columns also carry `min-w-0` so the in-flow sizer's flex automatic minimum can't floor the animated width (raised by Bugbot review). A bonus: trailing columns now collapse to zero width for shorter words ("codex", "agent"), removing the dangling gap.

| Before | After |
|---|---|
| `in your c l aude` | `in your claude` |

## Chromatic colors

`chromatic()` now accepts a `palette` of explicit color stops (interpolated between with `color-mix(in oklab, …)`), and the build page passes the five offering-card pastels, saturated a touch so the flash still reads once the letters settle. Verified at flash peak that the six glyphs sweep salmon → orange → yellow → green → blue.

## Resting color

Dropped the `text-foreground` override so the rolling word settles into the same muted color as the rest of the second row instead of white.

## Clipped descenders ("g" in agent)

The `overflow-y: clip` that hides the rolling glyphs clipped descenders under the heading's tight `leading-[0.9]`. Clipping happens at the padding box, so a symmetric `py-[0.2em] -my-[0.2em]` pair extends the clip region past the ink extent without changing line metrics.

Also restores the NBSP literal (now written as an explicit ` ` escape) that the rewrite had silently degraded to a plain space — identified by cubic review.

Verified locally with Playwright screenshots (spacing at rest, palette mid-roll/at flash peak via computed colors, descenders on "agent"). `tsc --noEmit` and oxlint pass.

https://claude.ai/code/session_01VLv7JRdo5eHpkqRUJH3ek2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only animation and styling on a single marketing page; no auth, data, or API changes.
> 
> **Overview**
> Refactors **`RollingText`** so each letter column **animates width to the current glyph** (via `MotionValue` + hidden candidate measurement) instead of staying fixed to the widest possible character—fixing awkward spacing for narrow letters and letting unused columns collapse for shorter words.
> 
> **`chromatic()`** gains an optional **`palette`** of explicit color stops interpolated with `color-mix(in oklab, …)`; the build headline uses offering-card pastels via **`ROLL_PALETTE`** and drops **`text-foreground`** so the word rests in the muted line color.
> 
> Per-column roll logic moves into **`RollingColumn`**, with **`py` / `-my`** padding to avoid clipping descenders under tight line-height, **`sr-only`** for the accessible label (replacing **`aria-label`** on the wrapper), and an explicit **`\u00A0`** for spaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd78ef94db13562b5ee9c6016d13c07e1aabd3f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->