### PR TITLE
Update about copy to "a game studio right in your..."

### DIFF
--- a/apps/web/src/routes/_site/build.tsx
+++ b/apps/web/src/routes/_site/build.tsx
@@ -373,7 +373,7 @@ function OfferingsDeck() {
           A game studio
           <br />
           <span className="text-muted-foreground">
-            in your{" "}
+            right in your{" "}
             <RollingText
               words={["claude", "codex", "cursor", "agent"]}
               color={chromatic({ palette: ROLL_PALETTE })}


### PR DESCRIPTION
Tweaks the hero copy on the build/offerings deck from:

> A game studio
> in your *claude / codex / cursor / agent*

to:

> A game studio
> **right** in your *claude / codex / cursor / agent*

The rolling word ("xxx") is unchanged — it still cycles through `claude`, `codex`, `cursor`, `agent`.

https://claude.ai/code/session_01TAcZkFX9TPMWr9gLvsCruW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAcZkFX9TPMWr9gLvsCruW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy only in the site build route; no logic, API, or data changes.
> 
> **Overview**
> Updates the **Build** page hero headline in `OfferingsDeck` so the second line reads **"right in your …"** instead of **"in your …"**, with the `RollingText` word list unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 664a20934608c66fa24257b62c244f4ccded5e60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the hero copy in the Build/Offerings deck to “A game studio right in your …” for clearer positioning. The rolling word behavior is unchanged and still cycles through “claude”, “codex”, “cursor”, “agent”.

<sup>Written for commit 664a20934608c66fa24257b62c244f4ccded5e60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

