### PR TITLE
Move GitHub icon to bottom-right on build/discover

### DIFF
--- a/apps/web/src/components/auth/register-link.tsx
+++ b/apps/web/src/components/auth/register-link.tsx
@@ -14,6 +14,12 @@ export const RegisterLink = () => (
     >
       Register
     </Link>
+  </FadeInBlur>
+);
+
+// Bottom-right, aligned right with RegisterLink and bottom with the Nav.
+export const GitHubLink = () => (
+  <FadeInBlur className="fixed right-0 bottom-0 z-10 flex items-center px-4 py-6">
     <a
       href={GITHUB_URL}
       target="_blank"

--- a/apps/web/src/routes/_site/build.tsx
+++ b/apps/web/src/routes/_site/build.tsx
@@ -9,7 +9,7 @@ import {
 } from "@repo/ui/components/input-group";
 import { CheckIcon, ChevronRightIcon, CopyIcon } from "lucide-react";
 
-import { RegisterLink } from "@/components/auth/register-link";
+import { GitHubLink, RegisterLink } from "@/components/auth/register-link";
 import { ClaudeIcon, CodexIcon, CursorIcon } from "@/components/ui/brand-icons";
 import { FadeInBlur } from "@/components/ui/fade-in-blur";
 import { chromatic, RollingText } from "@/components/ui/rolling-text";
@@ -394,6 +394,7 @@ function BuildPage() {
       <RegisterLink />
       <OfferingsDeck />
       <InstallPrompt />
+      <GitHubLink />
     </main>
   );
 }

--- a/apps/web/src/routes/_site/discover.tsx
+++ b/apps/web/src/routes/_site/discover.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useWebHaptics } from "web-haptics/react";
 
-import { RegisterLink } from "@/components/auth/register-link";
+import { GitHubLink, RegisterLink } from "@/components/auth/register-link";
 import { FadeInBlur } from "@/components/ui/fade-in-blur";
 import { featuredGames, gameSearchSchema } from "@/components/game/data";
 
@@ -43,6 +43,7 @@ function DiscoverPage() {
           ))}
         </FadeInBlur>
       </header>
+      <GitHubLink />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Moves the GitHub icon from the top-right (where it shared the `RegisterLink` cluster with "Register") to the **bottom-right** corner.

- **Right-aligned with Register**: same `right-0 px-4` horizontal positioning, so its right edge lines up with the Register link above it.
- **Bottom-aligned with the Nav**: same `bottom-0 py-6` vertical positioning as the bottom-left `Nav`, so the icon sits on the same baseline.

## Changes

- `register-link.tsx`: extracted the GitHub anchor into a standalone `GitHubLink` component fixed at `bottom-0 right-0`; `RegisterLink` now only renders the Register link.
- `build.tsx` & `discover.tsx`: render `<GitHubLink />` (both pages used `RegisterLink`, so this keeps the icon present on both — just relocated).

https://claude.ai/code/session_01BM1H9qNfmyZQsoX5AxynRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01BM1H9qNfmyZQsoX5AxynRo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change to fixed chrome on two marketing routes; no auth, data, or API impact.
> 
> **Overview**
> Moves the GitHub icon out of the top-right **Register** cluster into a dedicated **`GitHubLink`** fixed at the **bottom-right** on **build** and **discover**.
> 
> **`RegisterLink`** now only renders the Register link at `top-0 right-0`. **`GitHubLink`** reuses the same external link and styling but uses `bottom-0 right-0` with matching `px-4 py-6` so it lines up horizontally with Register and vertically with the bottom nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b748c847d86868e1761c91fa26f8b71f42febda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the GitHub icon from the top-right to the bottom-right on the Build and Discover pages. It now aligns with the Register link on the right and with the bottom nav vertically.

- **Refactors**
  - Split `GitHubLink` from `RegisterLink`; `GitHubLink` is fixed at `bottom-0 right-0` with `px-4 py-6`.
  - Added `GitHubLink` to `build` and `discover`; `RegisterLink` now only renders "Register".

<sup>Written for commit 6b748c847d86868e1761c91fa26f8b71f42febda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

