### PR TITLE
Add X (Twitter) icon button to bottom-right

### DIFF
--- a/apps/web/src/components/auth/register-link.tsx
+++ b/apps/web/src/components/auth/register-link.tsx
@@ -1,9 +1,10 @@
 import { Link } from "@tanstack/react-router";
 
-import { GitHubIcon } from "@/components/ui/brand-icons";
+import { GitHubIcon, XIcon } from "@/components/ui/brand-icons";
 import { FadeInBlur } from "@/components/ui/fade-in-blur";
 
 const GITHUB_URL = "https://github.com/kyh/vibedgames";
+const X_URL = "https://x.com/kaiyuhsu";
 
 // Top-right entry point to registration, mirroring the bottom-left Nav.
 export const RegisterLink = () => (
@@ -19,7 +20,16 @@ export const RegisterLink = () => (
 
 // Bottom-right, aligned right with RegisterLink and bottom with the Nav.
 export const GitHubLink = () => (
-  <FadeInBlur className="fixed right-0 bottom-0 z-10 flex items-center px-4 py-6">
+  <FadeInBlur className="fixed right-0 bottom-0 z-10 flex items-center gap-4 px-4 py-6">
+    <a
+      href={X_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="X"
+      className="text-muted-foreground hover:text-foreground transition"
+    >
+      <XIcon className="size-4" />
+    </a>
     <a
       href={GITHUB_URL}
       target="_blank"

--- a/apps/web/src/components/ui/brand-icons.tsx
+++ b/apps/web/src/components/ui/brand-icons.tsx
@@ -23,6 +23,13 @@ export const CursorIcon = (props: BrandIconProps) => (
   </svg>
 );
 
+export const XIcon = (props: BrandIconProps) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-label="X" {...props}>
+    <title>X</title>
+    <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
+  </svg>
+);
+
 export const GitHubIcon = (props: BrandIconProps) => (
   <svg viewBox="0 0 24 24" fill="currentColor" aria-label="GitHub" {...props}>
     <title>GitHub</title>


### PR DESCRIPTION
Adds an X (Twitter) icon link in the bottom-right corner, placed before the existing GitHub icon.

- New `XIcon` brand icon (X logo) in `brand-icons.tsx`
- X link to `https://x.com/kaiyuhsu` added to `GitHubLink`, with `gap-4` spacing to match the top-right layout

https://claude.ai/code/session_01A673LHhRqJywARkfbV5MRL

---
_Generated by [Claude Code](https://claude.ai/code/session_01A673LHhRqJywARkfbV5MRL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational footer links with no auth, API, or data changes.
> 
> **Overview**
> Adds an **X profile link** next to the existing GitHub control in the fixed bottom-right `GitHubLink` block, using the same external-link pattern (`target="_blank"`, `rel="noopener noreferrer"`, muted hover styles) and **`gap-4`** spacing to align with the top-right layout.
> 
> Introduces a reusable **`XIcon`** SVG in `brand-icons.tsx` and points the new link at `https://x.com/kaiyuhsu`. Any page that already renders `GitHubLink` (e.g. build and discover) will show both icons without further route changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4273baa63d0658e05365144e8133e26d12573f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an X (Twitter) icon link in the bottom-right before the GitHub icon, linking to https://x.com/kaiyuhsu. Introduces `XIcon` and applies `gap-4` spacing to match the top-right layout.

<sup>Written for commit d4273baa63d0658e05365144e8133e26d12573f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

