### PR TITLE
Align bottom-right social icons with bottom-left nav

### DIFF
--- a/apps/web/src/components/auth/register-link.tsx
+++ b/apps/web/src/components/auth/register-link.tsx
@@ -26,7 +26,7 @@ export const GitHubLink = () => (
       target="_blank"
       rel="noopener noreferrer"
       aria-label="X"
-      className="text-muted-foreground hover:text-foreground transition"
+      className="text-muted-foreground hover:text-foreground py-1.5 transition"
     >
       <XIcon className="size-4" />
     </a>
@@ -35,7 +35,7 @@ export const GitHubLink = () => (
       target="_blank"
       rel="noopener noreferrer"
       aria-label="GitHub"
-      className="text-muted-foreground hover:text-foreground transition"
+      className="text-muted-foreground hover:text-foreground py-1.5 transition"
     >
       <GitHubIcon className="size-4" />
     </a>


### PR DESCRIPTION
## Problem

The X (Twitter) and GitHub icons in the bottom-right corner sat slightly lower than the `[ Discover ] Play Build` nav in the bottom-left, even though the code comment states they should be "aligned ... bottom with the Nav." See the reported screenshot.

## Cause

Both rows share a `py-6` fixed container, but:

- `Nav` tabs (`nav.tsx`) wrap their `text-xs` (16px line-height) labels in `py-1.5` → row box height **28px**, center **~38px** from the viewport bottom.
- The `GitHubLink` icon anchors wrapped `size-4` (16px) icons with **no** vertical padding → row box height **16px**, center **~32px** from the bottom.

That 6px gap left the icons sitting lower than the nav text. (The two icons were already aligned with each other — both glyphs are vertically centered in their viewBoxes.)

## Fix

Add `py-1.5` to the icon anchors so their box height (28px) matches the nav tabs. With both containers using `py-6`, the row centers now line up at ~38px from the bottom.

Single-file CSS-only change in `apps/web/src/components/auth/register-link.tsx`.

https://claude.ai/code/session_01NQCAgpQADisk8AfxcbprHM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQCAgpQADisk8AfxcbprHM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only padding tweak on auth footer links with no logic, auth, or data impact.
> 
> **Overview**
> Adds **`py-1.5`** to the X and GitHub anchor elements in `GitHubLink` so their clickable row height matches the bottom-left nav tabs (`nav.tsx` already uses `py-1.5` on tab links). Both corners keep the same `py-6` fixed container; this change lines up the vertical centers of the social icons with the nav labels instead of sitting ~6px lower.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f97fe1571f24bee17046d9c2066c291841994d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the bottom-right X and GitHub icons with the bottom-left nav by matching their vertical padding. This removes a ~6px misalignment and centers both rows evenly.

- **Bug Fixes**
  - Added `py-1.5` to the social link anchors in `apps/web/src/components/auth/register-link.tsx` to match nav tab padding, ensuring consistent row height within the shared `py-6` container.

<sup>Written for commit 55f97fe1571f24bee17046d9c2066c291841994d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

