### PR TITLE
Add scroll-driven edge fades to discover games list

### DIFF
--- a/apps/web/src/routes/_site/discover.tsx
+++ b/apps/web/src/routes/_site/discover.tsx
@@ -20,7 +20,7 @@ function DiscoverPage() {
     <>
       <RegisterLink />
       <header className="fixed bottom-16 left-0 z-10 flex max-h-full max-w-dvw flex-col px-4 md:w-96">
-        <FadeInBlur className="flex gap-4 overflow-auto pb-4 md:flex-col-reverse">
+        <FadeInBlur className="scroll-fade flex gap-4 overflow-auto pb-4 md:flex-col-reverse">
           {featuredGames.map((game) => (
             <button
               key={game.slug}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,1 +1,84 @@
 @import "@repo/ui/globals.css";
+
+/*
+ * Scroll-driven edge fades (progressive enhancement).
+ *
+ * A masked gradient fades the scroll container's leading/trailing edge. Two
+ * scroll-driven animations grow each fade in only once there's content hidden
+ * past that edge, so the fade disappears when scrolled fully to that end (and
+ * when the content isn't scrollable at all). Browsers without scroll-driven
+ * animations fall back to no fade — the registered custom properties stay at 0.
+ *
+ * Horizontal by default; switches to vertical at the `md` breakpoint, matching
+ * the discover games list (row on mobile, column on md+).
+ */
+@property --scroll-fade-start {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+@property --scroll-fade-end {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+@layer components {
+  .scroll-fade {
+    mask: linear-gradient(
+      to right,
+      transparent,
+      black var(--scroll-fade-start),
+      black calc(100% - var(--scroll-fade-end)),
+      transparent
+    );
+  }
+
+  @media (width >= 48rem) {
+    .scroll-fade {
+      mask: linear-gradient(
+        to bottom,
+        transparent,
+        black var(--scroll-fade-start),
+        black calc(100% - var(--scroll-fade-end)),
+        transparent
+      );
+    }
+  }
+
+  @supports (animation-timeline: scroll()) {
+    .scroll-fade {
+      animation:
+        scroll-fade-in linear,
+        scroll-fade-out linear;
+      animation-timeline: scroll(self x), scroll(self x);
+      animation-range:
+        0 2.5rem,
+        calc(100% - 2.5rem) 100%;
+      animation-fill-mode: both;
+    }
+
+    @media (width >= 48rem) {
+      .scroll-fade {
+        animation-timeline: scroll(self y), scroll(self y);
+      }
+    }
+  }
+}
+
+@keyframes scroll-fade-in {
+  from {
+    --scroll-fade-start: 0%;
+  }
+  to {
+    --scroll-fade-start: 2.5rem;
+  }
+}
+@keyframes scroll-fade-out {
+  from {
+    --scroll-fade-end: 2.5rem;
+  }
+  to {
+    --scroll-fade-end: 0%;
+  }
+}


### PR DESCRIPTION
## What

The games list on the discover page now fades out on each side of the scroll, so items dissolve into the edges instead of being hard-clipped.

## How

CSS-only, no JS — a masked linear gradient on the scroll container. Two scroll-driven animations (`animation-timeline: scroll(self)`) grow each fade in only when there's content hidden past that edge, so:

- the leading fade is hidden when scrolled fully to the start
- the trailing fade is hidden when scrolled fully to the end
- no fades appear when the content isn't scrollable at all

The list is a horizontal row on mobile and a vertical column at `md+`, so the mask and scroll axis switch at the `md` breakpoint to match.

This is a progressive enhancement: the animation properties sit behind `@supports (animation-timeline: scroll())`, and the registered `@property` custom properties default to `0` so browsers without scroll-driven animation support simply get the normal scroller with no fade (no broken state).

## Files

- `apps/web/src/styles/globals.css` — `.scroll-fade` utility + `@property`/`@keyframes`
- `apps/web/src/routes/_site/discover.tsx` — apply `scroll-fade` to the list container

https://claude.ai/code/session_013rxJvH4CWTEg56nydXbVJD

---
_Generated by [Claude Code](https://claude.ai/code/session_013rxJvH4CWTEg56nydXbVJD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure presentational CSS on one route with a safe no-fade fallback for older browsers.
> 
> **Overview**
> The discover page games scroller gets **soft edge fades** instead of hard clipping when content overflows.
> 
> A new **`.scroll-fade`** utility in `globals.css` uses a **mask gradient** plus **scroll-timeline animations** so leading/trailing fades only appear when there is hidden content past that edge, and disappear at the scroll extremes or when the list isn’t scrollable. Layout matches the list: **horizontal on mobile**, **vertical at `md+`**. Unsupported browsers keep normal scrolling via **`@supports (animation-timeline: scroll())`** and `@property` defaults of `0`.
> 
> `discover.tsx` only adds the `scroll-fade` class on the `FadeInBlur` list container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c33abc70f8916ab2fc3f39f874db71b4ff05be51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scroll-driven edge fades to the Discover games list so items gently fade at the edges instead of being hard-clipped. CSS-only mask with scroll-driven animations; gracefully falls back to a normal scroller if unsupported.

- **New Features**
  - Fades appear only when content overflows; hidden at the start/end when fully scrolled.
  - Axis switches at the `md` breakpoint (horizontal on mobile, vertical on `md+`).
  - Implemented as a `.scroll-fade` utility in CSS; no JS added.

<sup>Written for commit c33abc70f8916ab2fc3f39f874db71b4ff05be51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

