### PR TITLE
Center start-screen instructions in astroid

### DIFF
--- a/games/astroid/index.html
+++ b/games/astroid/index.html
@@ -173,18 +173,18 @@
 
       #attract {
         position: fixed;
-        bottom: 28px;
+        top: 50%;
         left: 50%;
-        transform: translateX(-50%);
+        transform: translate(-50%, -50%);
         pointer-events: none;
-        padding: 4px 14px;
+        padding: 6px 18px;
         background: rgba(0, 0, 0, 0.35);
         border: 1px solid rgba(255, 255, 255, 0.12);
         border-radius: 999px;
-        font-size: 11px;
+        font-size: 13px;
         text-transform: uppercase;
         letter-spacing: 1px;
-        opacity: 0.6;
+        opacity: 0.7;
         transition: opacity 0.4s ease;
       }
 


### PR DESCRIPTION
## What

Move astroid's start-screen instructions to the center of the screen, matching the other games.

## Why

The request: across all games, instructions should be centered on the starting screen. Audit of the start screens:

| Game | Start instructions | Status |
|------|--------------------|--------|
| pacman | Centered title banner with full controls | ✓ already centered |
| farm / moba | Dedicated centered title/select screens | ✓ already centered |
| flappy-dragons | Hint shown only on ready screen | clean, deliberate |
| tetris / pong | Instructions in a **persistent** gameplay HUD element | left as-is (centering would overlay live play) |
| **astroid** | Controls pinned to the **bottom** bar | ✗ fixed here |

Astroid already had a start-screen instruction element (`#attract` → `move · mouse — fire · hold`) that fades out on the player's first shot — it was just pinned to the bottom instead of centered.

## Change

CSS-only reposition of `#attract` from `bottom: 28px` to vertically + horizontally centered (`top: 50%; transform: translate(-50%, -50%)`), with a slightly larger/more-visible treatment befitting a start prompt. Fade-out-on-first-fire behavior is unchanged.

https://claude.ai/code/session_01T3vbwE6y3mfCVvSyjs43Sp

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3vbwE6y3mfCVvSyjs43Sp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on a non-interactive HUD element; no gameplay or logic changes.
> 
> **Overview**
> Repositions the astroid start prompt (`#attract`: move · mouse — fire · hold) from a **bottom bar** to the **center of the viewport**, consistent with other games’ start screens.
> 
> CSS-only: `top: 50%` with `transform: translate(-50%, -50%)` replaces `bottom: 28px` and horizontal-only centering. Padding, font size (11px → 13px), and opacity are bumped slightly so the prompt reads better as a primary start instruction. **Fade-out on the player’s first shot** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aa9379a2a0534eae4c49939f647709ff76a481d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the astroid start-screen instructions (`#attract`) to align with other games. CSS-only update with top/left center positioning and small style tweaks (padding, font size, opacity); fade-out-on-first-fire is unchanged.

<sup>Written for commit 1aa9379a2a0534eae4c49939f647709ff76a481d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

