### PR TITLE
feat(starfall): v5 expansion — XP/levels, new weapons + enemies + boss, player-scaled map

### DIFF
--- a/games/starfall/index.html
+++ b/games/starfall/index.html
@@ -41,14 +41,6 @@
         justify-content: space-between;
         align-items: flex-start;
       }
-      #xpbar {
-        height: 3px;
-        width: 0%;
-        max-width: 120px;
-        background: #6ff7ff;
-        box-shadow: 0 0 6px #6ff7ff;
-        transition: width 140ms linear;
-      }
       #weapon {
         font-size: 11px;
         text-transform: uppercase;
@@ -259,7 +251,6 @@
     <div id="game"></div>
     <div id="hud">
       <div>
-        <div id="xpbar"></div>
         <div id="weapon">NORMAL BEAM</div>
         <div id="weaponbar"></div>
         <div id="shield">

--- a/games/starfall/index.html
+++ b/games/starfall/index.html
@@ -234,12 +234,6 @@
         opacity: 0.55;
         font-style: italic;
       }
-      #replay {
-        font-size: 12px;
-        opacity: 0.6;
-        font-variant-numeric: tabular-nums;
-        letter-spacing: 1px;
-      }
       #countdown {
         font-size: 14px;
         opacity: 0.7;
@@ -277,7 +271,6 @@
       <div id="destroyed">DESTROYED</div>
       <div id="cause"></div>
       <div id="hint"></div>
-      <div id="replay"></div>
       <div id="countdown"></div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/games/starfall/index.html
+++ b/games/starfall/index.html
@@ -41,11 +41,13 @@
         justify-content: space-between;
         align-items: flex-start;
       }
-      #score {
-        font-size: 24px;
-        font-weight: 200;
-        font-variant-numeric: tabular-nums;
-        letter-spacing: 2px;
+      #xpbar {
+        height: 3px;
+        width: 0%;
+        max-width: 120px;
+        background: #6ff7ff;
+        box-shadow: 0 0 6px #6ff7ff;
+        transition: width 140ms linear;
       }
       #weapon {
         font-size: 11px;
@@ -129,9 +131,32 @@
         opacity: 0.5;
       }
 
+      #bossbar {
+        position: fixed;
+        top: 14px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 44vw;
+        max-width: 720px;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.25s ease;
+      }
+      #bossbar .track {
+        height: 8px;
+        background: rgba(0, 0, 0, 0.5);
+        border: 1px solid rgba(255, 45, 45, 0.5);
+      }
+      #bosshp {
+        height: 100%;
+        width: 100%;
+        background: #ff2d2d;
+        box-shadow: 0 0 10px #ff2d2d;
+        transition: width 120ms linear;
+      }
       #combo {
         position: fixed;
-        top: 16px;
+        top: 48px;
         left: 50%;
         transform: translateX(-50%);
         pointer-events: none;
@@ -234,7 +259,7 @@
     <div id="game"></div>
     <div id="hud">
       <div>
-        <div id="score">0</div>
+        <div id="xpbar"></div>
         <div id="weapon">NORMAL BEAM</div>
         <div id="weaponbar"></div>
         <div id="shield">
@@ -248,6 +273,9 @@
         <div id="boosts"></div>
       </div>
       <div id="players">connecting&hellip;</div>
+    </div>
+    <div id="bossbar">
+      <div class="track"><div id="bosshp"></div></div>
     </div>
     <div id="combo">
       <div id="comboval">&times;2 &middot; 3</div>

--- a/games/starfall/src/render/energy-barrier.ts
+++ b/games/starfall/src/render/energy-barrier.ts
@@ -1,7 +1,5 @@
 import Phaser from "phaser";
 
-import { WORLD_H, WORLD_W } from "../shared/constants";
-
 const BARRIER_CORE_TINT = 0x6ff7ff; // hot cyan core — energized arcade neon
 const BARRIER_BLOOM_TINT = 0xb24bff; // magenta outer bloom (cyan/magenta = retro neon)
 const BARRIER_PULSE_HZ = 0.5; // slow breath, one pulse per 2s
@@ -29,42 +27,43 @@ export class EnergyBarrier {
     this.drawVignette();
   }
 
-  /** Animated; call from scene.update() with the scene clock (ms). */
-  update(timeMs: number): void {
+  /** Animated; call from scene.update() with the scene clock (ms) and the live
+   *  play bounds (the barrier marks the play area, which grows with players). */
+  update(timeMs: number, worldW: number, worldH: number): void {
     const t = timeMs / 1000;
     const pulse = 0.75 + 0.25 * Math.sin(t * BARRIER_PULSE_HZ * Math.PI * 2);
     const g = this.frame;
     g.clear();
-    // Outer bloom → core: three stroked passes on the world rect.
-    g.lineStyle(26, BARRIER_BLOOM_TINT, 0.1 * pulse).strokeRect(0, 0, WORLD_W, WORLD_H);
-    g.lineStyle(10, BARRIER_CORE_TINT, 0.22 * pulse).strokeRect(0, 0, WORLD_W, WORLD_H);
-    g.lineStyle(2, 0xffffff, 0.85 * pulse).strokeRect(0, 0, WORLD_W, WORLD_H);
+    // Outer bloom → core: three stroked passes on the play rect.
+    g.lineStyle(26, BARRIER_BLOOM_TINT, 0.1 * pulse).strokeRect(0, 0, worldW, worldH);
+    g.lineStyle(10, BARRIER_CORE_TINT, 0.22 * pulse).strokeRect(0, 0, worldW, worldH);
+    g.lineStyle(2, 0xffffff, 0.85 * pulse).strokeRect(0, 0, worldW, worldH);
     // Scanline shimmer: a bright segment traveling along each edge.
     const span = 600;
-    const fx = ((timeMs * 0.25) % (WORLD_W + span)) - span;
-    const fy = ((timeMs * 0.25) % (WORLD_H + span)) - span;
+    const fx = ((timeMs * 0.25) % (worldW + span)) - span;
+    const fy = ((timeMs * 0.25) % (worldH + span)) - span;
     g.lineStyle(3, BARRIER_CORE_TINT, 0.5 * pulse);
     g.lineBetween(fx, 0, fx + span, 0);
-    g.lineBetween(WORLD_W - fx, WORLD_H, WORLD_W - fx - span, WORLD_H);
+    g.lineBetween(worldW - fx, worldH, worldW - fx - span, worldH);
     g.lineBetween(0, fy, 0, fy + span);
-    g.lineBetween(WORLD_W, WORLD_H - fy, WORLD_W, WORLD_H - fy - span);
+    g.lineBetween(worldW, worldH - fy, worldW, worldH - fy - span);
     // Inner-edge fade: faint additive strokes stepping inward (playfield glow).
     for (let i = 1; i <= 4; i++) {
       const inset = i * 14;
       g.lineStyle(2, BARRIER_CORE_TINT, 0.06 * (1 - i / 5) * pulse).strokeRect(
         inset,
         inset,
-        WORLD_W - inset * 2,
-        WORLD_H - inset * 2,
+        worldW - inset * 2,
+        worldH - inset * 2,
       );
     }
     // Corner node accents.
     g.fillStyle(0xffffff, 0.7 * pulse);
     for (const [cx, cy] of [
       [0, 0],
-      [WORLD_W, 0],
-      [0, WORLD_H],
-      [WORLD_W, WORLD_H],
+      [worldW, 0],
+      [0, worldH],
+      [worldW, worldH],
     ] as const) {
       g.fillCircle(cx, cy, 4 + 2 * pulse);
     }

--- a/games/starfall/src/scenes/game-scene.ts
+++ b/games/starfall/src/scenes/game-scene.ts
@@ -29,12 +29,61 @@ import {
   asteroidShardCount,
   asteroidSpawnIntervalMs,
   asteroidSpeed,
+  baseRegenMult,
+  baseWeaponForLevel,
   BOOSTER_KINDS,
   BOOSTER_SPECS,
+  BULWARK_CONE_DEG,
+  BULWARK_FRONT_MULT,
+  BOSS_CONTACT_DMG,
+  BOSS_ORBIT_RADIUS,
+  BOSS_P1_CYCLE_MS,
+  BOSS_P1_SPREAD_COUNT,
+  BOSS_P1_SPREAD_DEG,
+  BOSS_P1_TELEGRAPH_MS,
+  BOSS_P2_AIM_MS,
+  BOSS_P2_CYCLE_MS,
+  BOSS_P2_LANCES,
+  BOSS_P3_CYCLE_MS,
+  BOSS_P3_MITES,
+  BOSS_P3_NOVA_COUNT,
+  BOSS_P3_TELEGRAPH_MS,
+  BOSS_REWARD_SHARDS,
+  BOSS_SHOT_SPEED,
+  BOSS_SPAWN_COOLDOWN_MS,
+  BOSS_SPAWN_INTENSITY,
+  BOSS_SPAWN_MIN_PLAYERS,
+  BOSS_SPEED,
+  bossHp,
+  bossPhase,
+  enemyShotHit,
+  MITE_GRACE_MS,
+  SNIPER_AIM_MS,
+  SNIPER_COOLDOWN_MS,
+  SNIPER_FIRE_RANGE,
+  SNIPER_KEEP_DIST,
+  SNIPER_SHOT_SPEED,
+  SNIPER_SPEED,
+  SPAWNER_BROOD_CAP,
+  SPAWNER_BROOD_PER_PULSE,
+  SPAWNER_PULSE_MS,
+  SPAWNER_SPEED,
+  SPAWNER_TELEGRAPH_MS,
+  WARDEN_COOLDOWN_MS,
+  WARDEN_FIRE_RANGE,
+  WARDEN_SHIELDED_DR,
+  WARDEN_SHOT_SPEED,
+  WARDEN_SPEED,
+  WARDEN_TELEGRAPH_MS,
+  WARDEN_TURN_DEG_PER_S,
+  WARDEN_VENT_DR,
+  WARDEN_VENT_MS,
+  type EnemyState,
   COMBO_WINDOW_MS,
   CONTACT_IFRAME_MS,
   DMG,
   comboMult,
+  LEVEL_CAP,
   DRONE_COOLDOWN_MS,
   DRONE_FIRE_CONE_DEG,
   DRONE_SHOT_SPEED,
@@ -125,14 +174,12 @@ import {
   RESPAWN_DELAY_MS,
   rollLootClass,
   rollWeightedKey,
-  SCORE,
   SENTRY_FIRE_MS,
   SENTRY_LIFETIME_MS,
   SENTRY_RANGE,
   SHARD_DRIFT_SPEED,
   SHARD_MAGNET_PULL_SPEED,
   SHARD_PICKUP_RADIUS,
-  SHARD_SCORE,
   SHARD_TINT,
   SHARDS_MAX_LIVE,
   SHIELD_HALO_RADIUS,
@@ -149,6 +196,10 @@ import {
   SIPHON_HEAL_ENEMY,
   SIPHON_HEAL_PLAYER,
   SINGULARITY_PULL_MS,
+  GRAVITON_PULL_MS,
+  LEECH_FIELD_HEAL,
+  LEECH_FIELD_RANGE,
+  SALVAGE_MULT,
   SINGULARITY_PULL_RANGE,
   SINGULARITY_PULL_SPEED,
   SIPHON_OVERHEAL_DECAY_PER_S,
@@ -194,6 +245,10 @@ import {
   WORLD_BLEED_PX,
   WORLD_H,
   WORLD_W,
+  XP,
+  XP_DEATH_MAX_DELEVELS,
+  XP_DEATH_PENALTY_FRAC,
+  xpToNext,
   type AsteroidState,
   type BoosterKind,
   type BoostNetState,
@@ -323,15 +378,20 @@ type EnemySim = {
    *  impulses live here, decay, and ride on top (LANCER takes direct vx/vy). */
   kbVx: number;
   kbVy: number;
+  /** SPAWNER/BOSS: live mites attributed to this parent (self-caps the brood). */
+  broodCount: number;
+  /** Mites: the spawner/boss they belong to (decrements broodCount on death). */
+  broodParent: string | null;
 };
 
 const MULTIPLAYER_HOST = import.meta.env.DEV
   ? "http://localhost:8787"
   : "https://vibedgames-party.kyh.workers.dev";
 
-// Fresh room name per shared-state shape change (v4 adds `pulls`): old
-// deployed clients can't pollute this build's world.
-const ROOM = "starfall-arena-v4";
+// Fresh room name per shared-state shape change (v5: XP/level on PlayerNetState,
+// new EnemyKind union members + EnemyState.maxHp/lances/shielded): old deployed
+// clients can't pollute this build's world.
+const ROOM = "starfall-arena-v5";
 /** Per-arena cap. The party server clamps to its own hard ceiling and overflows
  *  player #33+ into a sibling arena (starfall-arena-v4~2, …) automatically. */
 const STARFALL_MAX_PLAYERS = 32;
@@ -420,7 +480,11 @@ export class GameScene extends Phaser.Scene {
   private weapon: Weapon = WEAPON_DEFAULT;
   private weaponUntil = 0;
   private shootCooldown = 0;
-  private score = 0;
+  /** Levelling: you level by destroying things; XP is into the current level. */
+  private level = 1;
+  private xp = 0;
+  /** Shield-regen speed multiplier from the current level (baseRegenMult). */
+  private regenMult = 1;
   private beams: Beam[] = [];
   private firedOnce = false;
   /** Phaser's activePointer sits at (0,0) until the first real pointer event —
@@ -524,6 +588,10 @@ export class GameScene extends Phaser.Scene {
   private comboTier = 1;
   private sessionBest = 0;
 
+  // boss (host-private; recomputed from the world each tick so migration adopts it)
+  private bossAlive = false;
+  private lastBossKilledAt = 0;
+
   // death bookkeeping (overlay cause + adaptive hints)
   private deathCause = "";
   private deathHint = "";
@@ -579,7 +647,9 @@ export class GameScene extends Phaser.Scene {
   private remoteTrailCount = 0;
 
   // HUD (DOM, owned by index.html)
-  private scoreEl: HTMLElement | null = null;
+  private xpBarEl: HTMLElement | null = null;
+  private bossBarEl: HTMLElement | null = null;
+  private bossHpEl: HTMLElement | null = null;
   private weaponEl: HTMLElement | null = null;
   private weaponBarEl: HTMLElement | null = null;
   private shieldEl: HTMLElement | null = null;
@@ -605,7 +675,9 @@ export class GameScene extends Phaser.Scene {
   }
 
   create(): void {
-    this.scoreEl = document.getElementById("score");
+    this.xpBarEl = document.getElementById("xpbar");
+    this.bossBarEl = document.getElementById("bossbar");
+    this.bossHpEl = document.getElementById("bosshp");
     this.weaponEl = document.getElementById("weapon");
     this.weaponBarEl = document.getElementById("weaponbar");
     this.shieldEl = document.getElementById("shield");
@@ -737,7 +809,11 @@ export class GameScene extends Phaser.Scene {
     this.pickupItems(now);
     this.collectShards(now);
     this.tickShield(now, dt);
-    if (this.weapon !== WEAPON_DEFAULT && now >= this.weaponUntil) this.weapon = WEAPON_DEFAULT;
+    // Special expired → revert to the CURRENT level's base weapon, not L1.
+    if (this.weaponUntil !== 0 && now >= this.weaponUntil) {
+      this.weapon = baseWeaponForLevel(this.level);
+      this.weaponUntil = 0;
+    }
     if (this.streak > 0 && now >= this.comboExpiresAt) {
       this.streak = 0;
       this.comboTier = 1;
@@ -789,6 +865,8 @@ export class GameScene extends Phaser.Scene {
     this.overHp = 0;
     this.lastDamageAt = 0;
     this.regenActive = false;
+    this.weaponUntil = 0;
+    this.applyBaseLoadout(now); // revive at the level's base weapon + regen
     this.kickX = 0;
     this.kickY = 0;
     this.cameras.main.centerOn(pos.x, pos.y);
@@ -1545,7 +1623,7 @@ export class GameScene extends Phaser.Scene {
         e.blinkUntil = now + 150;
         if (e.hp - dmgHp <= 0 && !this.predictedKills.has(e.id)) {
           this.predictedKills.set(e.id, now);
-          this.registerKill(ENEMY_SPECS[e.kind].score, now, "enemy", e.x, e.y);
+          this.registerKill(ENEMY_SPECS[e.kind].xp, now, "enemy", e.x, e.y);
         }
         this.netSendEvent("enemy_hit", { enemyId: e.id, damage: dmgHp });
         return;
@@ -1557,9 +1635,9 @@ export class GameScene extends Phaser.Scene {
         const destroyed = a.radius - ASTEROID_MAX_RADIUS * Math.min(power, 1) < ASTEROID_MIN_RADIUS;
         if (destroyed && !this.predictedKills.has(a.id)) {
           this.predictedKills.set(a.id, now);
-          this.registerKill(SCORE.ASTEROID_DESTROY, now, "asteroid", a.x, a.y);
+          this.registerKill(XP.ASTEROID_DESTROY, now, "asteroid", a.x, a.y);
         } else {
-          this.score += SCORE.ASTEROID_CHIP;
+          this.gainXp(XP.ASTEROID_CHIP, now);
         }
         this.netSendEvent("asteroid_hit", { asteroidId: a.id, damage: power });
         return;
@@ -1569,7 +1647,7 @@ export class GameScene extends Phaser.Scene {
         if (!u) return;
         if (u.hp - dmgHp <= 0 && !this.predictedKills.has(u.id)) {
           this.predictedKills.set(u.id, now);
-          this.registerKill(SCORE.UFO_DESTROY, now, "ufo", u.x, u.y);
+          this.registerKill(XP.UFO_DESTROY, now, "ufo", u.x, u.y);
         }
         this.netSendEvent("ufo_hit", { damage: dmgHp / 100 });
         return;
@@ -1789,7 +1867,10 @@ export class GameScene extends Phaser.Scene {
    *  (offline: the event loops straight back into the local host). */
   private startCollapse(b: Beam, now: number): void {
     if (b.collapseUntil > 0 || b.exploding || b.vanished) return;
-    b.collapseUntil = now + SINGULARITY_PULL_MS;
+    // GRAVITON WELL herds far longer than SINGULARITY; the pull duration rides
+    // the shared `until` so guests/host agree without a wire shape change.
+    const pullMs = b.weapon.name === "GRAVITON WELL" ? GRAVITON_PULL_MS : SINGULARITY_PULL_MS;
+    b.collapseUntil = now + pullMs;
     b.diesAt = 0;
     b.tail = { ...b.head };
     this.netSendEvent("singularity", { x: b.head.x, y: b.head.y, until: b.collapseUntil });
@@ -1905,10 +1986,24 @@ export class GameScene extends Phaser.Scene {
         SHIELD_MOD_SPECS.siphon.tint,
       );
     }
+    // LEECH FIELD: enemy kills within range heal you (own kills only — simple,
+    // no overheal bank, capped at base shield).
+    if (
+      this.shieldMod === "leech" &&
+      this.alive &&
+      kind === "enemy" &&
+      dist2(x, y, this.shipX, this.shipY) <= LEECH_FIELD_RANGE * LEECH_FIELD_RANGE
+    ) {
+      this.shieldHp = Math.min(SHIELD_MAX, this.shieldHp + LEECH_FIELD_HEAL);
+      this.fx.sparks(this.shipX, this.shipY, 3, SHIELD_MOD_SPECS.leech.tint, {
+        lifeMin: 120,
+        lifeMax: 200,
+      });
+    }
     this.streak += 1;
     this.comboExpiresAt = now + COMBO_WINDOW_MS;
     const mult = comboMult(this.streak);
-    this.score += base * mult;
+    this.gainXp(base * mult, now);
     if (mult > this.comboTier && mult >= 2) {
       // Tier-up: the one allowed long effect (§9) + rising sfx + pill pop.
       sfx.play("combo_up", { rate: Math.pow(2, (2 * (mult - 2)) / 12) });
@@ -1932,6 +2027,61 @@ export class GameScene extends Phaser.Scene {
       }
     }
     this.comboTier = mult;
+  }
+
+  /** The single XP sink: add XP, roll up levels, fire the level-up feedback.
+   *  Kills route here combo-multiplied (via registerKill); orbs + asteroid
+   *  chips call this directly (flat). */
+  private gainXp(amount: number, now: number): void {
+    if (amount <= 0 || !this.alive) return;
+    this.xp += amount;
+    let leveled = false;
+    while (this.level < LEVEL_CAP && this.xp >= xpToNext(this.level)) {
+      this.xp -= xpToNext(this.level);
+      this.level += 1;
+      leveled = true;
+    }
+    if (this.level >= LEVEL_CAP) this.xp = 0; // at cap the bar empties — no hoard
+    if (leveled) this.onLevelUp(now);
+  }
+
+  /** Apply the new base loadout + the one allowed long FX (ring + converge +
+   *  sparks, reusing the combo-tier vocabulary) + a pitched cue + HUD pop. */
+  private onLevelUp(now: number): void {
+    this.applyBaseLoadout(now);
+    sfx.play("combo_up", { rate: 1.5 });
+    this.trauma.add(0.12);
+    const tint = this.myTint();
+    this.fx.ring(this.shipX, this.shipY, 8, 110, 450, tint, 0.9);
+    this.fx.converge(this.shipX, this.shipY, 16, 60, 320, 0xffffff);
+    this.fx.sparks(this.shipX, this.shipY, 16, tint, {
+      speedMin: 120,
+      speedMax: 280,
+      lifeMin: 250,
+      lifeMax: 450,
+    });
+  }
+
+  /** Set the level's shield-regen multiplier and, when no special is active,
+   *  the level's base weapon. Called on level-up, respawn, and special expiry. */
+  private applyBaseLoadout(now: number): void {
+    this.regenMult = baseRegenMult(this.level);
+    if (this.weaponUntil <= now) this.weapon = baseWeaponForLevel(this.level);
+  }
+
+  /** Death tax: lose XP_DEATH_PENALTY_FRAC of progress into the current level;
+   *  de-level at most XP_DEATH_MAX_DELEVELS, never below the level floor. The
+   *  leader pays the most absolute XP (anti-snowball); a fresh player barely
+   *  notices (cheap early levels). */
+  private applyDeathXpPenalty(): void {
+    this.xp -= Math.round(xpToNext(this.level) * XP_DEATH_PENALTY_FRAC);
+    let delevels = 0;
+    while (this.xp < 0 && this.level > 1 && delevels < XP_DEATH_MAX_DELEVELS) {
+      this.level -= 1;
+      this.xp += xpToNext(this.level);
+      delevels += 1;
+    }
+    if (this.xp < 0) this.xp = 0;
   }
 
   /**
@@ -1978,9 +2128,9 @@ export class GameScene extends Phaser.Scene {
           a.radius - ASTEROID_MAX_RADIUS * Math.min(b.weapon.power, 1) < ASTEROID_MIN_RADIUS;
         if (destroyed && !this.predictedKills.has(a.id)) {
           this.predictedKills.set(a.id, now);
-          this.registerKill(SCORE.ASTEROID_DESTROY, now, "asteroid", a.x, a.y);
+          this.registerKill(XP.ASTEROID_DESTROY, now, "asteroid", a.x, a.y);
         } else {
-          this.score += SCORE.ASTEROID_CHIP; // flat, never multiplied
+          this.gainXp(XP.ASTEROID_CHIP, now); // flat, never multiplied
         }
         if (sparksOk || destroyed) {
           this.fx.sparks(b.head.x, b.head.y, 6, b.weapon.tint, { lifeMin: 150, lifeMax: 250 });
@@ -2007,7 +2157,7 @@ export class GameScene extends Phaser.Scene {
         const killed = e.hp - dmg <= 0;
         if (killed && !this.predictedKills.has(e.id)) {
           this.predictedKills.set(e.id, now);
-          this.registerKill(ENEMY_SPECS[e.kind].score, now, "enemy", e.x, e.y);
+          this.registerKill(ENEMY_SPECS[e.kind].xp, now, "enemy", e.x, e.y);
         }
         e.blinkUntil = now + 150; // immediate local feedback; host echoes
         if (sparksOk || killed) {
@@ -2033,7 +2183,7 @@ export class GameScene extends Phaser.Scene {
           const killed = u.hp - b.weapon.power * 100 <= 0;
           if (killed && !this.predictedKills.has(u.id)) {
             this.predictedKills.set(u.id, now);
-            this.registerKill(SCORE.UFO_DESTROY, now, "ufo", u.x, u.y);
+            this.registerKill(XP.UFO_DESTROY, now, "ufo", u.x, u.y);
           }
           if (sparksOk || killed) {
             this.fx.sparks(b.head.x, b.head.y, 6, b.weapon.tint, { lifeMin: 150, lifeMax: 250 });
@@ -2133,6 +2283,13 @@ export class GameScene extends Phaser.Scene {
       sfx.play("shield_break", { gain: 0.6, rate: 1.25 });
       return "phased";
     }
+    // BULWARK: hits landing inside the frontal cone are mitigated; the rear is
+    // exposed. fromX/fromY is the hit source, so no extra wire data is needed.
+    if (this.shieldMod === "bulwark" && now < this.shieldModUntil) {
+      let rel = Math.atan2(fromY - this.shipY, fromX - this.shipX) - this.shipAngle;
+      rel = Math.atan2(Math.sin(rel), Math.cos(rel)); // wrap to [-π, π]
+      if (Math.abs(rel) <= ((BULWARK_CONE_DEG / 2) * Math.PI) / 180) amount *= BULWARK_FRONT_MULT;
+    }
     const wasLow = this.shieldHp < SHIELD_MAX * SHIELD_LOW_FRACTION;
     let rest = amount;
     if (this.overHp > 0) {
@@ -2174,6 +2331,7 @@ export class GameScene extends Phaser.Scene {
       }
       const rate =
         (SHIELD_MAX / (SHIELD_REGEN_FULL_MS / 1000)) *
+        this.regenMult * // levelling: faster recovery, not more max HP
         (this.shieldMod === "aegis" ? AEGIS_REGEN_MULT : 1);
       this.shieldHp = Math.min(SHIELD_MAX, this.shieldHp + rate * dt);
       if (this.shieldHp >= SHIELD_MAX) this.regenActive = false;
@@ -2229,7 +2387,7 @@ export class GameScene extends Phaser.Scene {
         if (a.radius <= RAM_ASTEROID_DESTROY_R) {
           if (!this.predictedKills.has(a.id)) {
             this.predictedKills.set(a.id, now);
-            this.registerKill(SCORE.ASTEROID_DESTROY, now, "asteroid", a.x, a.y);
+            this.registerKill(XP.ASTEROID_DESTROY, now, "asteroid", a.x, a.y);
           }
           this.netSendEvent("asteroid_hit", { asteroidId: a.id, damage: 1 });
           this.fx.sparks(a.x, a.y, 8, SHIELD_MOD_SPECS.ram.tint, { lifeMin: 150, lifeMax: 250 });
@@ -2237,7 +2395,7 @@ export class GameScene extends Phaser.Scene {
           this.trauma.add(0.1);
           continue;
         }
-        this.score += SCORE.ASTEROID_CHIP;
+        this.gainXp(XP.ASTEROID_CHIP, now);
         this.netSendEvent("asteroid_hit", { asteroidId: a.id, damage: RAM_ASTEROID_CHIP });
         this.bounceOff(a.x, a.y, 0.6);
         if (this.applyDamage(RAM_SELF_DRAIN, a.x, a.y, "ASTEROID", null, now) !== "drained") {
@@ -2280,7 +2438,7 @@ export class GameScene extends Phaser.Scene {
         this.ramImmunity.set(e.id, now + RAM_IMMUNITY_MS);
         if (e.hp - RAM_DAMAGE <= 0 && !this.predictedKills.has(e.id)) {
           this.predictedKills.set(e.id, now);
-          this.registerKill(ENEMY_SPECS[e.kind].score, now, "enemy", e.x, e.y);
+          this.registerKill(ENEMY_SPECS[e.kind].xp, now, "enemy", e.x, e.y);
         }
         this.netSendEvent("enemy_hit", {
           enemyId: e.id,
@@ -2304,7 +2462,9 @@ export class GameScene extends Phaser.Scene {
         ? DMG.LANCER_CHARGE
         : e.kind === "lancer"
           ? DMG.LANCER_HULL
-          : DMG.ENEMY_HULL;
+          : e.kind === "dreadnought"
+            ? BOSS_CONTACT_DMG
+            : DMG.ENEMY_HULL;
       const res = this.applyDamage(amount, e.x, e.y, ENEMY_SPECS[e.kind].name, null, now);
       if (res !== "drained") return;
       this.bounceOff(e.x, e.y, 0.5);
@@ -2336,9 +2496,9 @@ export class GameScene extends Phaser.Scene {
         SHIP_RADIUS,
       );
       if (!hit) continue;
-      // Shots aren't source-attributed on the wire; speed identifies the kind.
-      const slow = Math.hypot(s.vx, s.vy) <= (DRONE_SHOT_SPEED + WASP_SHOT_SPEED) / 2;
-      const cause = slow ? "DRONE" : "WASP";
+      // Shots aren't source-attributed on the wire; speed identifies the kind
+      // (drone/warden/boss-plasma → DRONE, wasp → WASP, sniper/boss-lance → SNIPER).
+      const { cause, dmg } = enemyShotHit(Math.hypot(s.vx, s.vy));
       this.consumeShot(s); // every shot that hits is consumed — same event
       if (this.reflectArmed()) {
         // Bounce: pay 12 shield instead of the damage, return the bolt.
@@ -2348,14 +2508,7 @@ export class GameScene extends Phaser.Scene {
         }
         continue;
       }
-      const res = this.applyDamage(
-        slow ? DMG.DRONE_SHOT : DMG.WASP_SHOT,
-        s.x,
-        s.y,
-        cause,
-        null,
-        now,
-      );
+      const res = this.applyDamage(dmg, s.x, s.y, cause, null, now);
       if (res !== "drained") return;
     }
     if (!this.alive) return;
@@ -2369,7 +2522,7 @@ export class GameScene extends Phaser.Scene {
           this.ramImmunity.set(u.id, now + RAM_IMMUNITY_MS);
           if (u.hp - RAM_DAMAGE <= 0 && !this.predictedKills.has(u.id)) {
             this.predictedKills.set(u.id, now);
-            this.registerKill(SCORE.UFO_DESTROY, now, "ufo", u.x, u.y);
+            this.registerKill(XP.UFO_DESTROY, now, "ufo", u.x, u.y);
           }
           this.netSendEvent("ufo_hit", { damage: RAM_DAMAGE / 100 });
           if (this.applyDamage(RAM_SELF_DRAIN, u.x, u.y, "UFO", null, now) !== "drained") return;
@@ -2517,9 +2670,12 @@ export class GameScene extends Phaser.Scene {
     this.invulnUntil = 0;
     this.beams = []; // mines included — they ride in beams[]
     this.sentry = null; // the turret dies with its owner
-    // Death drops: weapon reverts, mod + boosters lost, combo resets, score kept.
-    this.weapon = WEAPON_DEFAULT;
+    // Death tax: lose XP (and maybe one level), then revert to the new level's
+    // base weapon. Mod + boosters lost, combo resets.
+    this.applyDeathXpPenalty();
+    this.weapon = baseWeaponForLevel(this.level);
     this.weaponUntil = 0;
+    this.regenMult = baseRegenMult(this.level);
     this.shieldHp = 0;
     this.overHp = 0;
     this.shieldMod = null;
@@ -2531,7 +2687,7 @@ export class GameScene extends Phaser.Scene {
     this.phasedUntil = 0;
     this.streak = 0;
     this.comboTier = 1;
-    this.sessionBest = Math.max(this.sessionBest, this.score);
+    this.sessionBest = Math.max(this.sessionBest, this.level);
     this.deathCause = cause;
     const count = (this.deathCounts.get(cause) ?? 0) + 1;
     this.deathCounts.set(cause, count);
@@ -2661,18 +2817,19 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
-  /** Score shards: generous-radius hoover, +SHARD_SCORE each (flat, never
-   *  combo-multiplied, same rule as asteroid chips). Same claimer pattern
-   *  as items: collect locally, tell the host, guard reconciles. */
+  /** XP orbs (former score shards): generous-radius hoover, +XP.ORB each (flat,
+   *  never combo-multiplied; SALVAGE doubles it). Same claimer pattern as items:
+   *  collect locally, tell the host, guard reconciles. */
   private collectShards(now: number): void {
     if (!this.alive || !this.spawned || now < this.phasedUntil) return;
     const r2 = SHARD_PICKUP_RADIUS * SHARD_PICKUP_RADIUS;
     const shards = this.world.shards;
+    const orbXp = (this.boosts.get("salvage") ?? 0) > now ? XP.ORB * SALVAGE_MULT : XP.ORB;
     for (let i = shards.length - 1; i >= 0; i--) {
       const s = shards[i];
       if (!s || this.recentShardPickups.has(s.id)) continue;
       if (dist2(s.x, s.y, this.shipX, this.shipY) > r2) continue;
-      this.score += SHARD_SCORE;
+      this.gainXp(orbXp, now);
       this.recentShardPickups.set(s.id, now);
       this.netSendEvent("shard_pickup", { shardId: s.id });
       shards.splice(i, 1);
@@ -2746,7 +2903,8 @@ export class GameScene extends Phaser.Scene {
       vy: this.shipVY,
       alive: this.alive,
       invuln: now < this.invulnUntil,
-      score: this.score,
+      level: this.level,
+      xp: this.xp,
       streak: this.streak,
       weaponName: this.weapon.name,
       shieldHp: Math.max(0, Math.round(this.shieldHp)),
@@ -2771,7 +2929,7 @@ export class GameScene extends Phaser.Scene {
     if (event === "player_killed") {
       // The killer awards itself: every client hears the victim's report.
       if (p && p["killerId"] === this.myId) {
-        this.registerKill(SCORE.PLAYER_KILL, Date.now(), "player");
+        this.registerKill(XP.PLAYER_KILL, Date.now(), "player");
       }
       return;
     }
@@ -2941,6 +3099,9 @@ export class GameScene extends Phaser.Scene {
       // Keep the most pessimistic blink (local prediction may be ahead).
       local.blinkUntil = Math.max(local.blinkUntil, e.blinkUntil);
       local.graceUntil = e.graceUntil;
+      local.maxHp = e.maxHp;
+      local.lances = e.lances; // sniper/boss laser sights
+      local.shielded = e.shielded; // warden shield state
       blendPos(local, e.x, e.y);
     }
     w.enemies = w.enemies.filter((x) => enemyIds.has(x.id));
@@ -3083,6 +3244,7 @@ export class GameScene extends Phaser.Scene {
     this.hostMagnetItems(now);
 
     this.hostSpawnEnemies(now, tSec, intensity, pressure, wave);
+    this.hostMaybeSpawnBoss(now, intensity);
     this.hostSimEnemies(now, dt);
     // After the sim: the pull overrides steering for dragged enemies.
     this.hostApplyPulls(now);
@@ -3283,6 +3445,8 @@ export class GameScene extends Phaser.Scene {
         wobblePhase: Math.random() * Math.PI * 2,
         kbVx: 0,
         kbVy: 0,
+        broodCount: 0,
+        broodParent: null,
       };
       this.enemySim.set(id, sim);
     }
@@ -3441,9 +3605,95 @@ export class GameScene extends Phaser.Scene {
           e.vy = Math.sin(e.angle) * SPLITTER_SPEED;
           break;
         }
+        case "warden": {
+          // Slow advance. Shield up except during the post-mortar vent window.
+          e.angle = rotateToward(e.angle, desired, WARDEN_TURN_DEG_PER_S * DEG * dt);
+          e.vx = Math.cos(e.angle) * WARDEN_SPEED;
+          e.vy = Math.sin(e.angle) * WARDEN_SPEED;
+          if (sim.fireAt > 0) {
+            if (now >= sim.fireAt) {
+              sim.fireAt = 0;
+              sim.nextBurstShotAt = now + WARDEN_VENT_MS; // vent: shield down
+              sim.nextAttackAt = now + WARDEN_COOLDOWN_MS;
+              e.shielded = false;
+              if (dist < WARDEN_FIRE_RANGE) {
+                this.hostSpawnShot(e.x, e.y, desired, WARDEN_SHOT_SPEED, now);
+              }
+            }
+          } else if (now < sim.nextBurstShotAt) {
+            e.shielded = false; // venting
+          } else if (now >= sim.nextAttackAt && dist < WARDEN_FIRE_RANGE) {
+            e.telegraphUntil = now + WARDEN_TELEGRAPH_MS;
+            sim.fireAt = e.telegraphUntil;
+            e.shielded = true; // shield up through the windup
+          } else {
+            e.shielded = true;
+          }
+          break;
+        }
+        case "sniper": {
+          // Kite to keep distance; charge a laser sight; fire one fast bolt.
+          e.angle = desired;
+          const err = dist - SNIPER_KEEP_DIST;
+          if (Math.abs(err) > 40) {
+            const sgn = err > 0 ? 1 : -1; // in if too far, out if too close
+            e.vx = (dx / dist) * SNIPER_SPEED * sgn;
+            e.vy = (dy / dist) * SNIPER_SPEED * sgn;
+          } else {
+            e.vx = -(dy / dist) * SNIPER_SPEED * sim.orbitDir; // strafe at range
+            e.vy = (dx / dist) * SNIPER_SPEED * sim.orbitDir;
+          }
+          if (sim.fireAt > 0) {
+            if (now >= sim.fireAt) {
+              sim.fireAt = 0;
+              sim.nextAttackAt = now + SNIPER_COOLDOWN_MS;
+              const aim = e.lances[0];
+              e.lances = [];
+              if (aim && dist < SNIPER_FIRE_RANGE) {
+                this.hostSpawnShot(
+                  e.x,
+                  e.y,
+                  Math.atan2(aim.y - e.y, aim.x - e.x),
+                  SNIPER_SHOT_SPEED,
+                  now,
+                );
+              }
+            } else {
+              e.vx *= 0.2; // plant while aiming
+              e.vy *= 0.2;
+            }
+          } else if (now >= sim.nextAttackAt && dist < SNIPER_FIRE_RANGE) {
+            e.telegraphUntil = now + SNIPER_AIM_MS;
+            sim.fireAt = e.telegraphUntil;
+            e.lances = [{ x: target.x, y: target.y }]; // lock current pos (no lead)
+          }
+          break;
+        }
+        case "spawner": {
+          // Drift slowly; birth a brood on a telegraphed pulse, self-capped.
+          e.angle = rotateToward(e.angle, desired, 30 * DEG * dt);
+          e.vx = Math.cos(e.angle) * SPAWNER_SPEED;
+          e.vy = Math.sin(e.angle) * SPAWNER_SPEED;
+          if (sim.fireAt > 0) {
+            if (now >= sim.fireAt) {
+              sim.fireAt = 0;
+              sim.nextAttackAt = now + SPAWNER_PULSE_MS;
+              this.hostBirthMites(e, SPAWNER_BROOD_PER_PULSE, now);
+            }
+          } else if (now >= sim.nextAttackAt && sim.broodCount < SPAWNER_BROOD_CAP) {
+            e.telegraphUntil = now + SPAWNER_TELEGRAPH_MS;
+            sim.fireAt = e.telegraphUntil;
+          }
+          break;
+        }
+        case "dreadnought": {
+          this.hostSimBoss(e, sim, players, dx, dy, dist, desired, now, dt);
+          break;
+        }
       }
       // Steering set vx/vy absolutely — ride the decaying knockback on top.
-      if (e.kind !== "lancer") {
+      // LANCER (mid-charge) and the BOSS own their velocity directly.
+      if (e.kind !== "lancer" && e.kind !== "dreadnought") {
         e.vx += sim.kbVx;
         e.vy += sim.kbVy;
       }
@@ -3533,6 +3783,155 @@ export class GameScene extends Phaser.Scene {
     this.dirty.ufo = true;
   }
 
+  /** DREADNOUGHT boss AI: HP-derived 3-phase pattern. Owns its own velocity. */
+  private hostSimBoss(
+    e: EnemyState,
+    sim: EnemySim,
+    players: Vec[],
+    dx: number,
+    dy: number,
+    dist: number,
+    desired: number,
+    now: number,
+    dt: number,
+  ): void {
+    const phase = bossPhase(e.hp, e.maxHp);
+    e.angle = rotateToward(e.angle, desired, 60 * DEG * dt); // turret faces nearest
+    // Centroid of the living crowd (the boss orbits the group, not one ship).
+    let cx = 0;
+    let cy = 0;
+    for (const p of players) {
+      cx += p.x;
+      cy += p.y;
+    }
+    if (players.length > 0) {
+      cx /= players.length;
+      cy /= players.length;
+    }
+    const dC = Math.hypot(cx - e.x, cy - e.y) || 1;
+    const inX = (cx - e.x) / dC;
+    const inY = (cy - e.y) / dC;
+
+    if (phase === 1) {
+      // Orbit at BOSS_ORBIT_RADIUS, broadside a spread fan.
+      const radial = Phaser.Math.Clamp((dC - BOSS_ORBIT_RADIUS) / 200, -1, 1);
+      let mx = -inY * sim.orbitDir + inX * radial;
+      let my = inX * sim.orbitDir + inY * radial;
+      const ml = Math.hypot(mx, my) || 1;
+      e.vx = (mx / ml) * BOSS_SPEED;
+      e.vy = (my / ml) * BOSS_SPEED;
+      if (sim.fireAt > 0) {
+        if (now >= sim.fireAt) {
+          sim.fireAt = 0;
+          sim.nextAttackAt = now + BOSS_P1_CYCLE_MS;
+          const base = desired - (BOSS_P1_SPREAD_DEG * DEG) / 2;
+          const step = (BOSS_P1_SPREAD_DEG * DEG) / (BOSS_P1_SPREAD_COUNT - 1);
+          for (let i = 0; i < BOSS_P1_SPREAD_COUNT; i++) {
+            this.hostSpawnShot(e.x, e.y, base + step * i, BOSS_SHOT_SPEED, now);
+          }
+        }
+      } else if (now >= sim.nextAttackAt) {
+        e.telegraphUntil = now + BOSS_P1_TELEGRAPH_MS;
+        sim.fireAt = e.telegraphUntil;
+      }
+    } else if (phase === 2) {
+      // Strafe faster; lock + fire triple sniper-speed lances at nearest players.
+      e.vx = -inY * BOSS_SPEED * 1.4 * sim.orbitDir;
+      e.vy = inX * BOSS_SPEED * 1.4 * sim.orbitDir;
+      if (sim.fireAt > 0) {
+        if (now >= sim.fireAt) {
+          sim.fireAt = 0;
+          sim.nextAttackAt = now + BOSS_P2_CYCLE_MS;
+          for (const aim of e.lances) {
+            this.hostSpawnShot(e.x, e.y, Math.atan2(aim.y - e.y, aim.x - e.x), SNIPER_SHOT_SPEED, now);
+          }
+          e.lances = [];
+        }
+      } else if (now >= sim.nextAttackAt) {
+        // eslint-disable-next-line unicorn/no-array-sort -- sorts a throwaway mapped array
+        const ranked = players
+          .map((p) => ({ p, d: dist2(p.x, p.y, e.x, e.y) }))
+          .sort((a, b) => a.d - b.d);
+        e.lances = ranked.slice(0, BOSS_P2_LANCES).map(({ p }) => ({ x: p.x, y: p.y }));
+        e.telegraphUntil = now + BOSS_P2_AIM_MS;
+        sim.fireAt = e.telegraphUntil;
+      }
+    } else {
+      // Phase 3 enrage: plant, vent a radial nova + birth a mite wave.
+      e.vx *= Math.exp(-3 * dt);
+      e.vy *= Math.exp(-3 * dt);
+      if (sim.fireAt > 0) {
+        if (now >= sim.fireAt) {
+          sim.fireAt = 0;
+          sim.nextAttackAt = now + BOSS_P3_CYCLE_MS;
+          for (let i = 0; i < BOSS_P3_NOVA_COUNT; i++) {
+            this.hostSpawnShot(e.x, e.y, (Math.PI * 2 * i) / BOSS_P3_NOVA_COUNT, BOSS_SHOT_SPEED, now);
+          }
+          this.hostBirthMites(e, BOSS_P3_MITES, now);
+        }
+      } else if (now >= sim.nextAttackAt) {
+        e.telegraphUntil = now + BOSS_P3_TELEGRAPH_MS;
+        sim.fireAt = e.telegraphUntil;
+      }
+    }
+    void dx;
+    void dy;
+    void dist;
+  }
+
+  /** SPAWNER / BOSS: birth `n` mites (grace'd drones) around the parent. They
+   *  bypass enemyCap like splitter children; broodCount self-caps the spawner. */
+  private hostBirthMites(parent: EnemyState, n: number, now: number): void {
+    const w = this.world;
+    const psim = this.simFor(parent.id);
+    for (let i = 0; i < n; i++) {
+      const ang = parent.angle + (Math.PI * 2 * i) / Math.max(1, n) + Math.random() * 0.4;
+      const m = spawnEnemyState(
+        "drone",
+        parent.x + Math.cos(ang) * 18,
+        parent.y + Math.sin(ang) * 18,
+      );
+      m.angle = ang;
+      m.vx = Math.cos(ang) * SPLITTER_CHILD_SPEED;
+      m.vy = Math.sin(ang) * SPLITTER_CHILD_SPEED;
+      m.graceUntil = now + MITE_GRACE_MS;
+      const msim = this.simFor(m.id);
+      msim.nextAttackAt = m.graceUntil + 400;
+      msim.broodParent = parent.id;
+      w.enemies.push(m);
+      psim.broodCount += 1;
+    }
+    this.dirty.enemies = true;
+  }
+
+  /** Boss spawn trigger: near a wave peak, in a busy room (or after the cooldown
+   *  in a quiet one). One boss arena-wide. Called each host tick. */
+  private hostMaybeSpawnBoss(now: number, intensity: number): void {
+    const w = this.world;
+    // Recompute from the world so a migrated host adopts the flag.
+    this.bossAlive = w.enemies.some((e) => e.kind === "dreadnought");
+    if (this.bossAlive) return;
+    if (intensity < BOSS_SPAWN_INTENSITY) return;
+    if (this.lastBossKilledAt !== 0 && now - this.lastBossKilledAt < BOSS_SPAWN_COOLDOWN_MS) return;
+    const players = this.livingPlayers();
+    const busy = Object.keys(this.peers).length >= BOSS_SPAWN_MIN_PLAYERS;
+    // Quiet rooms only get one once the cooldown has fully elapsed since the last.
+    if (!busy && this.lastBossKilledAt === 0 && now < BOSS_SPAWN_COOLDOWN_MS) return;
+    let placed: { x: number; y: number; ang: number } | null = null;
+    for (let i = 0; i < 8 && !placed; i++) {
+      const c = edgeSpawn(30);
+      if (players.every((p) => Math.hypot(p.x - c.x, p.y - c.y) >= ENEMY_SPAWN_CLEARANCE)) placed = c;
+    }
+    if (!placed) return;
+    const e = spawnEnemyState("dreadnought", placed.x, placed.y);
+    e.angle = placed.ang;
+    e.hp = bossHp(Math.max(1, Object.keys(this.peers).length));
+    e.maxHp = e.hp;
+    w.enemies.push(e);
+    this.bossAlive = true;
+    this.dirty.enemies = true;
+  }
+
   /** Apply reported damage + knockback; kill (split, loot) at ≤0 HP. */
   private hostDamageEnemy(id: string, damageHp: number, kx: number, ky: number): void {
     const w = this.world;
@@ -3540,12 +3939,18 @@ export class GameScene extends Phaser.Scene {
     if (idx === -1) return;
     const e = w.enemies[idx];
     if (!e) return;
-    e.hp -= damageHp;
+    // WARDEN: heavy damage reduction while shielded; extra during the vent window.
+    let dmg = damageHp;
+    if (e.kind === "warden") dmg *= e.shielded ? WARDEN_SHIELDED_DR : WARDEN_VENT_DR;
+    e.hp -= dmg;
     // LANCER's phases persist vx/vy, so direct knockback works; the others get
     // steering-overwritten every sim tick, so the impulse lives in the sim.
+    // The boss owns its velocity too — don't let beams shove it off its orbit.
     if (e.kind === "lancer") {
       e.vx += kx;
       e.vy += ky;
+    } else if (e.kind === "dreadnought") {
+      // no knockback
     } else {
       const sim = this.simFor(e.id);
       sim.kbVx += kx;
@@ -3560,9 +3965,27 @@ export class GameScene extends Phaser.Scene {
     const w = this.world;
     const e = w.enemies[idx];
     if (!e) return;
+    // A dying mite frees a slot in its parent's brood cap.
+    const broodParent = this.enemySim.get(e.id)?.broodParent;
+    if (broodParent) {
+      const psim = this.enemySim.get(broodParent);
+      if (psim) psim.broodCount = Math.max(0, psim.broodCount - 1);
+    }
     w.enemies.splice(idx, 1);
     this.enemySim.delete(e.id);
     const now = Date.now();
+    if (e.kind === "dreadnought") {
+      // Marquee reward: an XP fountain (2 bursts to dodge the live-shard cap) +
+      // two guaranteed drops. Free the arena-wide slot + arm the cooldown.
+      this.hostSpawnShards(e.x, e.y, Math.floor(BOSS_REWARD_SHARDS / 2));
+      this.hostSpawnShards(e.x, e.y, Math.ceil(BOSS_REWARD_SHARDS / 2));
+      this.hostRollLoot(e.x, e.y, 1, true);
+      this.hostRollLoot(e.x, e.y, 1, true);
+      this.bossAlive = false;
+      this.lastBossKilledAt = now;
+      this.dirty.enemies = true;
+      return;
+    }
     if (e.kind === "splitter") {
       // Death is the attack: 3 drones pop outward, briefly harmless.
       for (let i = 0; i < SPLITTER_CHILDREN; i++) {
@@ -4149,7 +4572,14 @@ export class GameScene extends Phaser.Scene {
       // Telegraph audio: LANCER windup + WASP burst, on-screen only (§6.1).
       if (e.telegraphUntil > now && rec.lastTelegraphUntil !== e.telegraphUntil) {
         rec.lastTelegraphUntil = e.telegraphUntil;
-        if ((e.kind === "lancer" || e.kind === "wasp") && this.onScreen(e.x, e.y)) {
+        if (
+          (e.kind === "lancer" ||
+            e.kind === "wasp" ||
+            e.kind === "warden" ||
+            e.kind === "sniper" ||
+            e.kind === "dreadnought") &&
+          this.onScreen(e.x, e.y)
+        ) {
           sfx.play("telegraph_warn");
         }
       }
@@ -4185,12 +4615,18 @@ export class GameScene extends Phaser.Scene {
       this.fx.shatter(x, y, enemyHullPoints(rec.kind), rec.gfx.rotation, spec.tint);
       this.fx.sparks(x, y, 8, spec.tint, { lifeMin: 200, lifeMax: 350 });
       const big = spec.hp >= 80;
-      if (rec.kind === "lancer" || rec.kind === "splitter") {
-        this.fx.ring(x, y, 6, 60, 350, spec.tint, 0.8);
+      const boss = rec.kind === "dreadnought";
+      if (rec.kind === "lancer" || rec.kind === "splitter" || boss) {
+        this.fx.ring(x, y, boss ? 16 : 6, boss ? 240 : 60, boss ? 700 : 350, spec.tint, 0.85);
+      }
+      if (boss) {
+        // Big multi-ring death blast for the marquee kill.
+        this.fx.ring(x, y, 10, 140, 500, 0xffffff, 0.9);
+        this.fx.sparks(x, y, 40, spec.tint, { speedMin: 120, speedMax: 360, lifeMin: 300, lifeMax: 600 });
       }
       if (this.onScreen(x, y)) {
-        sfx.play("enemy_death", big ? { gain: 1.3, rate: 0.8 } : {});
-        this.trauma.add(big ? 0.18 : 0.1);
+        sfx.play("enemy_death", boss ? { gain: 1.5, rate: 0.6 } : big ? { gain: 1.3, rate: 0.8 } : {});
+        this.trauma.add(boss ? 0.5 : big ? 0.18 : 0.1);
       }
       rec.gfx.destroy();
       this.enemyObjs.delete(id);
@@ -4202,6 +4638,15 @@ export class GameScene extends Phaser.Scene {
     const g = this.telegraphGfx;
     g.clear();
     for (const e of this.world.enemies) {
+      // WARDEN shield arc is always visible (not just during a telegraph): solid
+      // when up, strobing when venting — so players read the punish window.
+      if (e.kind === "warden") {
+        const venting = !e.shielded;
+        if (!venting || Math.floor(now / 60) % 2 === 0) {
+          g.lineStyle(2, venting ? 0xffffff : ENEMY_SPECS.warden.tint, venting ? 0.5 : 0.9);
+          g.strokeCircle(e.x, e.y, ENEMY_SPECS.warden.hitRadius + 6);
+        }
+      }
       if (e.telegraphUntil <= now) continue;
       if (e.kind === "drone") {
         // Nose dot grows 1→4px across the windup.
@@ -4222,6 +4667,36 @@ export class GameScene extends Phaser.Scene {
         }
         g.lineStyle(1, ENEMY_SPECS.lancer.tint, 0.7);
         dashedLine(g, e.x, e.y, e.angle, LANCER_CHARGE_RANGE, 8, 6);
+      } else if (e.kind === "sniper") {
+        // Strobing laser sight to each locked point.
+        if (Math.floor(now / 50) % 2 === 0) {
+          for (const aim of e.lances) {
+            g.lineStyle(1, ENEMY_SPECS.sniper.tint, 0.9);
+            g.lineBetween(e.x, e.y, aim.x, aim.y);
+            g.fillStyle(ENEMY_SPECS.sniper.tint, 0.9).fillCircle(aim.x, aim.y, 4);
+          }
+        }
+      } else if (e.kind === "spawner") {
+        // Expanding pulse ring as the brood charges.
+        const p = 1 - (e.telegraphUntil - now) / SPAWNER_TELEGRAPH_MS;
+        g.lineStyle(1, ENEMY_SPECS.spawner.tint, 0.8);
+        g.strokeCircle(e.x, e.y, ENEMY_SPECS.spawner.hitRadius + 4 + 14 * p);
+      } else if (e.kind === "dreadnought") {
+        if (e.lances.length > 0) {
+          // Phase-2 triple lances.
+          if (Math.floor(now / 45) % 2 === 0) {
+            for (const aim of e.lances) {
+              g.lineStyle(2, 0xffffff, 0.85);
+              g.lineBetween(e.x, e.y, aim.x, aim.y);
+              g.fillStyle(ENEMY_SPECS.dreadnought.tint, 0.9).fillCircle(aim.x, aim.y, 6);
+            }
+          }
+        } else {
+          // Phase-1/3 muzzle bloom during the windup.
+          const p = Math.min(1, (e.telegraphUntil - now) / 600);
+          g.fillStyle(ENEMY_SPECS.dreadnought.tint, 0.5);
+          g.fillCircle(e.x + Math.cos(e.angle) * 40, e.y + Math.sin(e.angle) * 40, 4 + 10 * (1 - p));
+        }
       }
     }
   }
@@ -4420,10 +4895,16 @@ export class GameScene extends Phaser.Scene {
   }
 
   private makeEnemyGfx(kind: EnemyKind): Phaser.GameObjects.Graphics {
-    const g = this.add.graphics().setDepth(7);
-    g.lineStyle(1, ENEMY_SPECS[kind].tint, 1);
+    const g = this.add.graphics().setDepth(kind === "dreadnought" ? 8 : 7);
+    g.lineStyle(kind === "dreadnought" ? 3 : kind === "warden" ? 2 : 1, ENEMY_SPECS[kind].tint, 1);
     const pts = enemyHullPoints(kind);
     strokeClosed(g, pts);
+    if (kind === "dreadnought") {
+      // Bridge dot + cross-struts so the capital ship reads as a boss.
+      g.fillStyle(0xffffff, 0.9).fillCircle(10, 0, 5);
+      g.lineStyle(1, ENEMY_SPECS.dreadnought.tint, 0.7);
+      g.lineBetween(-54, 0, 36, 0);
+    }
     if (kind === "splitter") {
       // Inner pentagram: connect every other vertex.
       for (let i = 0; i < 5; i++) {
@@ -4587,13 +5068,29 @@ export class GameScene extends Phaser.Scene {
   }
 
   private updateHud(now: number): void {
-    setText(this.scoreEl, String(this.score));
+    // Boss HP bar: shown whenever a dreadnought is live in the arena.
+    if (this.bossBarEl && this.bossHpEl) {
+      const boss = this.world.enemies.find((e) => e.kind === "dreadnought");
+      if (boss && boss.maxHp > 0) {
+        this.bossBarEl.style.opacity = "1";
+        this.bossHpEl.style.width = `${(Math.max(0, boss.hp / boss.maxHp) * 100).toFixed(1)}%`;
+      } else {
+        this.bossBarEl.style.opacity = "0";
+      }
+    }
+    if (this.xpBarEl) {
+      // At the cap the bar reads full; otherwise it's progress into this level.
+      const frac =
+        this.level >= LEVEL_CAP ? 1 : Math.max(0, Math.min(1, this.xp / xpToNext(this.level)));
+      this.xpBarEl.style.width = `${(frac * 100).toFixed(1)}%`;
+    }
     setText(this.weaponEl, this.weapon.name);
     if (this.weaponBarEl) {
-      // Stacked pickups can push the timer past one base duration: clamp the
-      // bar full; the extra time drains invisibly until under 20s again.
+      // A special is active iff weaponUntil is in the future; base weapons show
+      // no bar. Stacked pickups can push the timer past one base duration: clamp
+      // the bar full; the extra time drains invisibly until under 20s again.
       const frac =
-        this.weapon === WEAPON_DEFAULT
+        this.weaponUntil <= now
           ? 0
           : Math.min(1, Math.max(0, (this.weaponUntil - now) / SPECIAL_WEAPON_DURATION_MS));
       this.weaponBarEl.style.width = `${(frac * 100).toFixed(1)}%`;
@@ -4668,7 +5165,7 @@ export class GameScene extends Phaser.Scene {
     if (dead) {
       setText(this.causeEl, this.deathCause ? `— ${this.deathCause}` : "");
       setText(this.hintEl, this.deathHint);
-      setText(this.replayEl, `BEST ${fmtScore(this.sessionBest)} — YOU ${fmtScore(this.score)}`);
+      setText(this.replayEl, `LEVEL ${this.level} — BEST ${this.sessionBest}`);
     }
     const secs = dead ? Math.max(0, Math.ceil((this.respawnAt - now) / 1000)) : 0;
     setText(this.countdownEl, secs > 0 ? `Respawning in ${secs}...` : "");
@@ -4771,7 +5268,9 @@ export class GameScene extends Phaser.Scene {
         arenaIntensity(Math.max(0, (Date.now() - this.world.arenaEpoch) / 1000)),
       summary: (): Record<string, unknown> => ({
         alive: this.alive,
-        score: this.score,
+        level: this.level,
+        xp: this.xp,
+        xpToNext: xpToNext(this.level),
         streak: this.streak,
         weapon: this.weapon.name,
         weaponUntil: this.weaponUntil,
@@ -4906,6 +5405,31 @@ function enemyHullPoints(kind: EnemyKind): ReadonlyArray<Vec> {
         return { x: Math.cos(a) * 12, y: Math.sin(a) * 12 };
       });
     }
+    case "warden":
+      // Hex bunker, wide, flat-fronted (nose at +x).
+      return hexagonPoints(16);
+    case "sniper":
+      // Long thin arrowhead, longer than the lancer, nose at +x.
+      return [
+        { x: 14, y: 0 },
+        { x: -8, y: -5 },
+        { x: -4, y: 0 },
+        { x: -8, y: 5 },
+      ];
+    case "spawner":
+      // Hexagonal hive.
+      return hexagonPoints(14);
+    case "dreadnought":
+      // Capital ship: elongated heptagon, nose at +x, ~120 long.
+      return [
+        { x: 60, y: 0 },
+        { x: 36, y: -22 },
+        { x: -20, y: -30 },
+        { x: -54, y: -16 },
+        { x: -54, y: 16 },
+        { x: -20, y: 30 },
+        { x: 36, y: 22 },
+      ];
   }
 }
 
@@ -5122,7 +5646,8 @@ function readNetState(player: Player | undefined): PlayerNetState | null {
       beams.push(beam);
     }
   }
-  const score = s["score"];
+  const level = s["level"];
+  const xp = s["xp"];
   const streak = s["streak"];
   const weaponName = s["weaponName"];
   const vx = s["vx"];
@@ -5171,7 +5696,8 @@ function readNetState(player: Player | undefined): PlayerNetState | null {
     vy: typeof vy === "number" ? vy : 0,
     alive: s["alive"] !== false,
     invuln: s["invuln"] === true,
-    score: typeof score === "number" ? score : 0,
+    level: typeof level === "number" ? level : 1,
+    xp: typeof xp === "number" ? xp : 0,
     streak: typeof streak === "number" ? streak : 0,
     weaponName: typeof weaponName === "string" ? weaponName : "",
     shieldHp: typeof shieldHp === "number" ? shieldHp : SHIELD_MAX,
@@ -5312,10 +5838,6 @@ function strokeDiamond(g: Phaser.GameObjects.Graphics, x: number, y: number, r: 
 
 function hexCss(tint: number): string {
   return `#${tint.toString(16).padStart(6, "0")}`;
-}
-
-function fmtScore(v: number): string {
-  return v.toLocaleString("en-US").replace(/,/g, " ");
 }
 
 function setText(el: HTMLElement | null, text: string): void {

--- a/games/starfall/src/scenes/game-scene.ts
+++ b/games/starfall/src/scenes/game-scene.ts
@@ -29,8 +29,12 @@ import {
   asteroidShardCount,
   asteroidSpawnIntervalMs,
   asteroidSpeed,
+  BASE_WORLD_H,
+  BASE_WORLD_W,
   baseRegenMult,
   baseWeaponForLevel,
+  playHeightForPlayers,
+  playWidthForPlayers,
   BOOSTER_KINDS,
   BOOSTER_SPECS,
   BULWARK_CONE_DEG,
@@ -314,6 +318,8 @@ type Beam = {
 type ShipObjs = {
   gfx: Phaser.GameObjects.Graphics;
   tint: number;
+  /** Level the hull was last built for; rebuild on change (ships grow per level). */
+  level: number;
   alive: boolean;
   /** False until the first state snapshot lands (remote ships snap, not glide). */
   seenState: boolean;
@@ -441,6 +447,8 @@ function emptyShared(): SharedState {
     shards: [],
     pulls: [],
     arenaEpoch: Date.now(),
+    playW: BASE_WORLD_W,
+    playH: BASE_WORLD_H,
   };
 }
 
@@ -591,6 +599,8 @@ export class GameScene extends Phaser.Scene {
   // boss (host-private; recomputed from the world each tick so migration adopts it)
   private bossAlive = false;
   private lastBossKilledAt = 0;
+  /** Set when host grows the play bounds — flushed into the next shared patch. */
+  private playBoundsDirty = false;
 
   // death bookkeeping (overlay cause + adaptive hints)
   private deathCause = "";
@@ -647,7 +657,6 @@ export class GameScene extends Phaser.Scene {
   private remoteTrailCount = 0;
 
   // HUD (DOM, owned by index.html)
-  private xpBarEl: HTMLElement | null = null;
   private bossBarEl: HTMLElement | null = null;
   private bossHpEl: HTMLElement | null = null;
   private weaponEl: HTMLElement | null = null;
@@ -675,7 +684,6 @@ export class GameScene extends Phaser.Scene {
   }
 
   create(): void {
-    this.xpBarEl = document.getElementById("xpbar");
     this.bossBarEl = document.getElementById("bossbar");
     this.bossHpEl = document.getElementById("bosshp");
     this.weaponEl = document.getElementById("weapon");
@@ -784,7 +792,7 @@ export class GameScene extends Phaser.Scene {
   override update(time: number, delta: number): void {
     const dt = Math.min(delta, 100) / 1000; // clamp tab-switch spikes
     this.starfield.update(dt, time);
-    this.barrier.update(time);
+    this.barrier.update(time, this.world.playW, this.world.playH);
     if (!this.live) {
       this.maybeGoOffline(Date.now());
       if (!this.live) return;
@@ -946,12 +954,12 @@ export class GameScene extends Phaser.Scene {
     this.shipX += this.shipVX * dt;
     this.shipY += this.shipVY * dt;
     // Wall clamp kills the perpendicular component: slide along edges.
-    if (this.shipX < 0 || this.shipX > WORLD_W) {
-      this.shipX = Phaser.Math.Clamp(this.shipX, 0, WORLD_W);
+    if (this.shipX < 0 || this.shipX > this.world.playW) {
+      this.shipX = Phaser.Math.Clamp(this.shipX, 0, this.world.playW);
       this.shipVX = 0;
     }
-    if (this.shipY < 0 || this.shipY > WORLD_H) {
-      this.shipY = Phaser.Math.Clamp(this.shipY, 0, WORLD_H);
+    if (this.shipY < 0 || this.shipY > this.world.playH) {
+      this.shipY = Phaser.Math.Clamp(this.shipY, 0, this.world.playH);
       this.shipVY = 0;
     }
   }
@@ -1729,7 +1737,7 @@ export class GameScene extends Phaser.Scene {
         b.head.y += Math.sin(b.angle) * step;
         b.tail.x = b.head.x - Math.cos(b.angle) * b.weapon.length;
         b.tail.y = b.head.y - Math.sin(b.angle) * b.weapon.length;
-        if (!inWorld(b.head.x, b.head.y, BEAM_CULL_MARGIN)) b.vanished = true;
+        if (!inWorld(b.head.x, b.head.y, BEAM_CULL_MARGIN, this.world.playW, this.world.playH)) b.vanished = true;
         continue;
       }
       // HOMING: steer toward the live lock, capped turn rate.
@@ -1755,10 +1763,10 @@ export class GameScene extends Phaser.Scene {
         continue;
       }
       // RICOCHET: bounce off the world edge while bounces remain.
-      if (b.bouncesLeft > 0 && !inWorld(b.head.x, b.head.y, 0)) {
+      if (b.bouncesLeft > 0 && !inWorld(b.head.x, b.head.y, 0, this.world.playW, this.world.playH)) {
         this.ricochetEdgeBounce(b);
       }
-      if (!inWorld(b.head.x, b.head.y, BEAM_CULL_MARGIN)) {
+      if (!inWorld(b.head.x, b.head.y, BEAM_CULL_MARGIN, this.world.playW, this.world.playH)) {
         b.vanished = true;
         continue;
       }
@@ -1897,11 +1905,11 @@ export class GameScene extends Phaser.Scene {
     let nx = 0;
     let ny = 0;
     if (b.head.x < 0) nx = 1;
-    else if (b.head.x > WORLD_W) nx = -1;
+    else if (b.head.x > this.world.playW) nx = -1;
     if (b.head.y < 0) ny = 1;
-    else if (b.head.y > WORLD_H) ny = -1;
-    b.head.x = Phaser.Math.Clamp(b.head.x, 0, WORLD_W);
-    b.head.y = Phaser.Math.Clamp(b.head.y, 0, WORLD_H);
+    else if (b.head.y > this.world.playH) ny = -1;
+    b.head.x = Phaser.Math.Clamp(b.head.x, 0, this.world.playW);
+    b.head.y = Phaser.Math.Clamp(b.head.y, 0, this.world.playH);
     const len = Math.hypot(nx, ny) || 1;
     this.ricochetBounce(b, nx / len, ny / len);
   }
@@ -3035,6 +3043,8 @@ export class GameScene extends Phaser.Scene {
     if (!s) return;
     const w = this.world;
     if (typeof s.arenaEpoch === "number") w.arenaEpoch = s.arenaEpoch;
+    if (typeof s.playW === "number") w.playW = s.playW;
+    if (typeof s.playH === "number") w.playH = s.playH;
 
     const asteroidIds = new Set<string>();
     for (const a of s.asteroids) {
@@ -3178,8 +3188,8 @@ export class GameScene extends Phaser.Scene {
       s.y += s.vy * dt;
     }
     for (const e of this.world.enemies) {
-      e.x = Phaser.Math.Clamp(e.x + e.vx * dt, -40, WORLD_W + 40);
-      e.y = Phaser.Math.Clamp(e.y + e.vy * dt, -40, WORLD_H + 40);
+      e.x = Phaser.Math.Clamp(e.x + e.vx * dt, -40, this.world.playW + 40);
+      e.y = Phaser.Math.Clamp(e.y + e.vy * dt, -40, this.world.playH + 40);
     }
     for (const s of this.world.enemyShots) {
       s.x += s.vx * dt;
@@ -3201,19 +3211,31 @@ export class GameScene extends Phaser.Scene {
     const d = this.dirty;
     const tSec = Math.max(0, (now - w.arenaEpoch) / 1000);
     const intensity = arenaIntensity(tSec);
-    const pressure = playerPressure(Math.max(1, Object.keys(this.peers).length));
+    const pc = Math.max(1, Object.keys(this.peers).length);
+    const pressure = playerPressure(pc);
     const wave = wavePulse(tSec);
+    // Grow the play area with player count (grow-only within an arena, so it
+    // never yanks ships inward; resets to BASE on a fresh arena). Broadcast on
+    // change so every client clamps/spawns/culls to the same bounds.
+    const wantW = playWidthForPlayers(pc);
+    if (wantW > w.playW) {
+      w.playW = wantW;
+      w.playH = playHeightForPlayers(pc);
+      this.playBoundsDirty = true;
+    }
 
     if (
       w.asteroids.length < asteroidCap(intensity, pressure, wave) &&
       now - this.lastAsteroidSpawnAt > asteroidSpawnIntervalMs(intensity)
     ) {
-      w.asteroids.push(spawnAsteroidState());
+      w.asteroids.push(spawnAsteroidState(w.playW, w.playH));
       this.lastAsteroidSpawnAt = now;
       d.asteroids = true;
     }
 
-    const kept = w.asteroids.filter((a) => inWorld(a.x, a.y, ASTEROID_CULL_MARGIN));
+    const kept = w.asteroids.filter((a) =>
+      inWorld(a.x, a.y, ASTEROID_CULL_MARGIN, w.playW, w.playH),
+    );
     if (kept.length !== w.asteroids.length) {
       w.asteroids = kept;
       d.asteroids = true;
@@ -3222,12 +3244,12 @@ export class GameScene extends Phaser.Scene {
     // UFO is the weapon piñata; the v2 gate relaxes to < 2 weapon items live.
     const weaponItemsInFlight = w.items.filter((it) => it.kind === "weapon").length;
     if (!w.ufo && weaponItemsInFlight < 2 && Math.random() < UFO_SPAWN_RATE * dt) {
-      w.ufo = spawnUfoState();
+      w.ufo = spawnUfoState(w.playW, w.playH);
       d.ufo = true;
     }
     if (w.ufo && w.ufo.x === w.ufo.destX && w.ufo.y === w.ufo.destY) {
-      w.ufo.destX = Math.random() * WORLD_W;
-      w.ufo.destY = Math.random() * WORLD_H;
+      w.ufo.destX = Math.random() * w.playW;
+      w.ufo.destY = Math.random() * w.playH;
       d.ufo = true;
     }
 
@@ -3255,7 +3277,9 @@ export class GameScene extends Phaser.Scene {
     }
     this.hostDespawnBreather(now, intensity, pressure, wave);
 
-    const liveShots = w.enemyShots.filter((s) => s.diesAt > now && inWorld(s.x, s.y, 60));
+    const liveShots = w.enemyShots.filter(
+      (s) => s.diesAt > now && inWorld(s.x, s.y, 60, w.playW, w.playH),
+    );
     if (liveShots.length !== w.enemyShots.length) {
       w.enemyShots = liveShots;
       d.enemyShots = true;
@@ -3280,6 +3304,11 @@ export class GameScene extends Phaser.Scene {
     if (d.enemies) patch["enemies"] = w.enemies;
     if (d.enemyShots) patch["enemyShots"] = w.enemyShots;
     if (d.pulls) patch["pulls"] = w.pulls;
+    if (this.playBoundsDirty) {
+      patch["playW"] = w.playW;
+      patch["playH"] = w.playH;
+      this.playBoundsDirty = false;
+    }
     if (!this.offline && Object.keys(patch).length > 0) this.client.updateSharedState(patch);
     this.dirty = {
       asteroids: false,
@@ -3415,7 +3444,7 @@ export class GameScene extends Phaser.Scene {
     const players = this.livingPlayers();
     let placed: { x: number; y: number; ang: number } | null = null;
     for (let i = 0; i < 5 && !placed; i++) {
-      const c = edgeSpawn(30);
+      const c = edgeSpawn(30, this.world.playW, this.world.playH);
       const clear = players.every((p) => Math.hypot(p.x - c.x, p.y - c.y) >= ENEMY_SPAWN_CLEARANCE);
       if (clear) placed = c;
     }
@@ -3577,9 +3606,9 @@ export class GameScene extends Phaser.Scene {
               if (
                 now >= sim.phaseUntil ||
                 e.x <= 0 ||
-                e.x >= WORLD_W ||
+                e.x >= this.world.playW ||
                 e.y <= 0 ||
-                e.y >= WORLD_H
+                e.y >= this.world.playH
               ) {
                 sim.lancerPhase = "recover";
                 sim.phaseUntil = now + LANCER_RECOVER_MS;
@@ -3848,11 +3877,19 @@ export class GameScene extends Phaser.Scene {
           e.lances = [];
         }
       } else if (now >= sim.nextAttackAt) {
-        // eslint-disable-next-line unicorn/no-array-sort -- sorts a throwaway mapped array
-        const ranked = players
-          .map((p) => ({ p, d: dist2(p.x, p.y, e.x, e.y) }))
-          .sort((a, b) => a.d - b.d);
-        e.lances = ranked.slice(0, BOSS_P2_LANCES).map(({ p }) => ({ x: p.x, y: p.y }));
+        // Lock the BOSS_P2_LANCES nearest players (repeated-min select; no sort).
+        const cands = players.map((p) => ({ x: p.x, y: p.y, d: dist2(p.x, p.y, e.x, e.y) }));
+        const picks: Vec[] = [];
+        for (let k = 0; k < BOSS_P2_LANCES && cands.length > 0; k++) {
+          let bi = 0;
+          for (let i = 1; i < cands.length; i++) {
+            if ((cands[i]?.d ?? Infinity) < (cands[bi]?.d ?? Infinity)) bi = i;
+          }
+          const best = cands[bi];
+          if (best) picks.push({ x: best.x, y: best.y });
+          cands.splice(bi, 1);
+        }
+        e.lances = picks;
         e.telegraphUntil = now + BOSS_P2_AIM_MS;
         sim.fireAt = e.telegraphUntil;
       }
@@ -3919,7 +3956,7 @@ export class GameScene extends Phaser.Scene {
     if (!busy && this.lastBossKilledAt === 0 && now < BOSS_SPAWN_COOLDOWN_MS) return;
     let placed: { x: number; y: number; ang: number } | null = null;
     for (let i = 0; i < 8 && !placed; i++) {
-      const c = edgeSpawn(30);
+      const c = edgeSpawn(30, this.world.playW, this.world.playH);
       if (players.every((p) => Math.hypot(p.x - c.x, p.y - c.y) >= ENEMY_SPAWN_CLEARANCE)) placed = c;
     }
     if (!placed) return;
@@ -4124,9 +4161,11 @@ export class GameScene extends Phaser.Scene {
           trail = this.makeTrailEmitter(tint);
           this.remoteTrailCount += 1;
         }
+        const lvl0 = id === myId ? this.level : 1;
         rec = {
-          gfx: this.makeShipGfx(tint),
+          gfx: this.makeShipGfx(tint, lvl0),
           tint,
+          level: lvl0,
           alive: true,
           seenState: false,
           trail,
@@ -4138,6 +4177,7 @@ export class GameScene extends Phaser.Scene {
         this.ships.set(id, rec);
       }
       if (id === myId) {
+        this.ensureShipLevel(rec, this.level);
         this.configureTrail(rec, this.boosts.has("nitro"), throttled);
         rec.gfx.setPosition(this.shipX, this.shipY).setRotation(this.shipAngle);
         rec.gfx.setVisible(this.spawned && this.alive);
@@ -4190,6 +4230,7 @@ export class GameScene extends Phaser.Scene {
         if (rec.trail) rec.trail.emitting = false;
         continue;
       }
+      this.ensureShipLevel(rec, st.level); // remotes grow with their level too
       if (!rec.seenState) {
         // First snapshot: snap into place (no glide from the origin) and adopt
         // alive as-is (no death FX for players who were already dead).
@@ -4875,11 +4916,46 @@ export class GameScene extends Phaser.Scene {
 
   // ---- display-object factories ---------------------------------------------------------
 
-  private makeShipGfx(tint: number): Phaser.GameObjects.Graphics {
+  /** Hull grows + gains detail per level (1..5): wings at L2, a cockpit at L3,
+   *  an inner frame at L4, nose spike + wingtip nodes at L5. */
+  private makeShipGfx(tint: number, level = 1): Phaser.GameObjects.Graphics {
     const g = this.add.graphics().setDepth(10);
+    const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
+    const s = shipScaleForLevel(L);
     g.lineStyle(1, tint, 1);
-    strokeClosed(g, shipHullPoints());
+    strokeClosed(g, shipHullPoints(L));
+    if (L >= 2) {
+      g.lineBetween(-2 * s, -3 * s, -9 * s, -7 * s);
+      g.lineBetween(-2 * s, 3 * s, -9 * s, 7 * s);
+    }
+    if (L >= 3) {
+      g.fillStyle(tint, 0.9).fillCircle(2 * s, 0, 1.4 * s);
+    }
+    if (L >= 4) {
+      g.lineStyle(1, tint, 0.4);
+      strokeClosed(
+        g,
+        shipHullPoints(L).map((p) => ({ x: p.x * 0.55, y: p.y * 0.55 })),
+      );
+      g.lineStyle(1, tint, 1);
+    }
+    if (L >= 5) {
+      g.lineBetween(SHIP_RADIUS * s, 0, (SHIP_RADIUS + 4) * s, 0);
+      g.fillStyle(0xffffff, 0.9);
+      g.fillCircle(-9 * s, -7 * s, 1.2 * s);
+      g.fillCircle(-9 * s, 7 * s, 1.2 * s);
+    }
     return g;
+  }
+
+  /** Rebuild a ship's hull when its level changes (preserve transform/visibility). */
+  private ensureShipLevel(rec: ShipObjs, level: number): void {
+    if (rec.level === level) return;
+    rec.level = level;
+    const { x, y, rotation, alpha, visible } = rec.gfx;
+    rec.gfx.destroy();
+    rec.gfx = this.makeShipGfx(rec.tint, level);
+    rec.gfx.setPosition(x, y).setRotation(rotation).setAlpha(alpha).setVisible(visible);
   }
 
   private makeUfoGfx(): Phaser.GameObjects.Graphics {
@@ -5015,21 +5091,24 @@ export class GameScene extends Phaser.Scene {
     const y0 = this.scale.height - MINIMAP_H - MINIMAP_PAD;
     g.fillStyle(0x000000, 0.6).fillRoundedRect(x0, y0, MINIMAP_W, MINIMAP_H, 4);
     g.lineStyle(1, 0xffffff, 0.15).strokeRoundedRect(x0, y0, MINIMAP_W, MINIMAP_H, 4);
-    const sx = MINIMAP_W / WORLD_W;
-    const sy = MINIMAP_H / WORLD_H;
+    // Map the live PLAY area (not the fixed max) onto the minimap box.
+    const pw = this.world.playW;
+    const ph = this.world.playH;
+    const sx = MINIMAP_W / pw;
+    const sy = MINIMAP_H / ph;
 
     for (const a of this.world.asteroids) {
-      if (!inWorld(a.x, a.y, 0)) continue; // no auto-clip on Graphics
+      if (!inWorld(a.x, a.y, 0, pw, ph)) continue; // no auto-clip on Graphics
       g.fillStyle(0xffffff, 0.3);
       g.fillCircle(x0 + a.x * sx, y0 + a.y * sy, Math.max(1, a.radius * sx * 0.3));
     }
     for (const e of this.world.enemies) {
-      if (!inWorld(e.x, e.y, 0)) continue;
+      if (!inWorld(e.x, e.y, 0, pw, ph)) continue;
       g.fillStyle(ENEMY_SHOT_TINT, 1);
       g.fillRect(x0 + e.x * sx - 1, y0 + e.y * sy - 1, 2, 2);
     }
     for (const it of this.world.items) {
-      if (!inWorld(it.x, it.y, 0)) continue;
+      if (!inWorld(it.x, it.y, 0, pw, ph)) continue;
       g.fillStyle(itemTint(it), 1);
       const px = x0 + it.x * sx;
       const py = y0 + it.y * sy;
@@ -5077,12 +5156,6 @@ export class GameScene extends Phaser.Scene {
       } else {
         this.bossBarEl.style.opacity = "0";
       }
-    }
-    if (this.xpBarEl) {
-      // At the cap the bar reads full; otherwise it's progress into this level.
-      const frac =
-        this.level >= LEVEL_CAP ? 1 : Math.max(0, Math.min(1, this.xp / xpToNext(this.level)));
-      this.xpBarEl.style.width = `${(frac * 100).toFixed(1)}%`;
     }
     setText(this.weaponEl, this.weapon.name);
     if (this.weaponBarEl) {
@@ -5442,9 +5515,17 @@ function hexagonPoints(radius: number): Vec[] {
   return pts;
 }
 
-function shipHullPoints(): Array<{ x: number; y: number }> {
+/** Visual ship scale by level (collision hitbox stays SHIP_RADIUS — leveling
+ *  makes you LOOK bigger/tougher, not easier to hit). L1 1.0 → L5 ~1.52. */
+function shipScaleForLevel(level: number): number {
+  const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
+  return 1 + (L - 1) * 0.13;
+}
+
+function shipHullPoints(level = 1): Array<{ x: number; y: number }> {
+  const s = shipScaleForLevel(level);
   return SHIP_HULL_DEG.map((deg) => {
-    const r = deg === 180 ? SHIP_RADIUS / 2 : SHIP_RADIUS;
+    const r = (deg === 180 ? SHIP_RADIUS / 2 : SHIP_RADIUS) * s;
     return { x: Math.cos(deg * DEG) * r, y: Math.sin(deg * DEG) * r };
   });
 }
@@ -5736,8 +5817,14 @@ function blinkAlpha(now: number): number {
   return Math.floor(now / INVULN_BLINK_MS) % 2 === 0 ? 0.9 : 0.3;
 }
 
-function inWorld(x: number, y: number, margin: number): boolean {
-  return x >= -margin && x <= WORLD_W + margin && y >= -margin && y <= WORLD_H + margin;
+function inWorld(
+  x: number,
+  y: number,
+  margin: number,
+  w = WORLD_W,
+  h = WORLD_H,
+): boolean {
+  return x >= -margin && x <= w + margin && y >= -margin && y <= h + margin;
 }
 
 function dist2(ax: number, ay: number, bx: number, by: number): number {

--- a/games/starfall/src/scenes/game-scene.ts
+++ b/games/starfall/src/scenes/game-scene.ts
@@ -33,6 +33,7 @@ import {
   BASE_WORLD_W,
   baseRegenMult,
   baseWeaponForLevel,
+  scaleWeaponForLevel,
   playHeightForPlayers,
   playWidthForPlayers,
   BOOSTER_KINDS,
@@ -487,6 +488,9 @@ export class GameScene extends Phaser.Scene {
   private invulnUntil = 0;
   private weapon: Weapon = WEAPON_DEFAULT;
   private weaponUntil = 0;
+  /** Unscaled base of the held special (null on base weapon) — re-scaled per
+   *  level so specials grow with you without compounding. */
+  private specialBase: Weapon | null = null;
   private shootCooldown = 0;
   /** Levelling: you level by destroying things; XP is into the current level. */
   private level = 1;
@@ -594,7 +598,6 @@ export class GameScene extends Phaser.Scene {
   private streak = 0;
   private comboExpiresAt = 0;
   private comboTier = 1;
-  private sessionBest = 0;
 
   // boss (host-private; recomputed from the world each tick so migration adopts it)
   private bossAlive = false;
@@ -675,7 +678,6 @@ export class GameScene extends Phaser.Scene {
   private overlayEl: HTMLElement | null = null;
   private causeEl: HTMLElement | null = null;
   private hintEl: HTMLElement | null = null;
-  private replayEl: HTMLElement | null = null;
   private countdownEl: HTMLElement | null = null;
   private attractEl: HTMLElement | null = null;
 
@@ -701,7 +703,6 @@ export class GameScene extends Phaser.Scene {
     this.overlayEl = document.getElementById("overlay");
     this.causeEl = document.getElementById("cause");
     this.hintEl = document.getElementById("hint");
-    this.replayEl = document.getElementById("replay");
     this.countdownEl = document.getElementById("countdown");
     this.attractEl = document.getElementById("attract");
 
@@ -819,6 +820,7 @@ export class GameScene extends Phaser.Scene {
     this.tickShield(now, dt);
     // Special expired → revert to the CURRENT level's base weapon, not L1.
     if (this.weaponUntil !== 0 && now >= this.weaponUntil) {
+      this.specialBase = null;
       this.weapon = baseWeaponForLevel(this.level);
       this.weaponUntil = 0;
     }
@@ -2070,11 +2072,17 @@ export class GameScene extends Phaser.Scene {
     });
   }
 
-  /** Set the level's shield-regen multiplier and, when no special is active,
-   *  the level's base weapon. Called on level-up, respawn, and special expiry. */
+  /** Apply the level's regen + weapon. A held special is re-scaled for the new
+   *  level (from its unscaled base, so it never compounds); otherwise the level
+   *  base weapon. Called on level-up, respawn, and special expiry. */
   private applyBaseLoadout(now: number): void {
     this.regenMult = baseRegenMult(this.level);
-    if (this.weaponUntil <= now) this.weapon = baseWeaponForLevel(this.level);
+    if (this.weaponUntil > now && this.specialBase) {
+      this.weapon = scaleWeaponForLevel(this.specialBase, this.level);
+    } else {
+      this.specialBase = null;
+      this.weapon = baseWeaponForLevel(this.level);
+    }
   }
 
   /** Death tax: lose XP_DEATH_PENALTY_FRAC of progress into the current level;
@@ -2681,6 +2689,7 @@ export class GameScene extends Phaser.Scene {
     // Death tax: lose XP (and maybe one level), then revert to the new level's
     // base weapon. Mod + boosters lost, combo resets.
     this.applyDeathXpPenalty();
+    this.specialBase = null;
     this.weapon = baseWeaponForLevel(this.level);
     this.weaponUntil = 0;
     this.regenMult = baseRegenMult(this.level);
@@ -2695,7 +2704,6 @@ export class GameScene extends Phaser.Scene {
     this.phasedUntil = 0;
     this.streak = 0;
     this.comboTier = 1;
-    this.sessionBest = Math.max(this.sessionBest, this.level);
     this.deathCause = cause;
     const count = (this.deathCounts.get(cause) ?? 0) + 1;
     this.deathCounts.set(cause, count);
@@ -2739,7 +2747,9 @@ export class GameScene extends Phaser.Scene {
             now + ITEM_STACK_CAP_MS,
           );
         } else {
-          this.weapon = weapon;
+          // Keep the unscaled base so a later level-up re-scales it (no compounding).
+          this.specialBase = weapon;
+          this.weapon = scaleWeaponForLevel(weapon, this.level);
           this.weaponUntil = now + SPECIAL_WEAPON_DURATION_MS; // replace resets the timer
           this.windupAcc = 0;
         }
@@ -4916,8 +4926,8 @@ export class GameScene extends Phaser.Scene {
 
   // ---- display-object factories ---------------------------------------------------------
 
-  /** Hull grows + gains detail per level (1..5): wings at L2, a cockpit at L3,
-   *  an inner frame at L4, nose spike + wingtip nodes at L5. */
+  /** Hull grows + gains detail per level (1..3): L2 adds swept wings + a
+   *  cockpit; L3 adds an inner frame, a nose spike + wingtip nodes. */
   private makeShipGfx(tint: number, level = 1): Phaser.GameObjects.Graphics {
     const g = this.add.graphics().setDepth(10);
     const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
@@ -4925,24 +4935,20 @@ export class GameScene extends Phaser.Scene {
     g.lineStyle(1, tint, 1);
     strokeClosed(g, shipHullPoints(L));
     if (L >= 2) {
-      g.lineBetween(-2 * s, -3 * s, -9 * s, -7 * s);
+      g.lineBetween(-2 * s, -3 * s, -9 * s, -7 * s); // swept wings
       g.lineBetween(-2 * s, 3 * s, -9 * s, 7 * s);
+      g.fillStyle(tint, 0.9).fillCircle(2 * s, 0, 1.4 * s); // cockpit
     }
     if (L >= 3) {
-      g.fillStyle(tint, 0.9).fillCircle(2 * s, 0, 1.4 * s);
-    }
-    if (L >= 4) {
-      g.lineStyle(1, tint, 0.4);
+      g.lineStyle(1, tint, 0.4); // inner frame
       strokeClosed(
         g,
         shipHullPoints(L).map((p) => ({ x: p.x * 0.55, y: p.y * 0.55 })),
       );
       g.lineStyle(1, tint, 1);
-    }
-    if (L >= 5) {
-      g.lineBetween(SHIP_RADIUS * s, 0, (SHIP_RADIUS + 4) * s, 0);
+      g.lineBetween(SHIP_RADIUS * s, 0, (SHIP_RADIUS + 4) * s, 0); // nose spike
       g.fillStyle(0xffffff, 0.9);
-      g.fillCircle(-9 * s, -7 * s, 1.2 * s);
+      g.fillCircle(-9 * s, -7 * s, 1.2 * s); // wingtip nodes
       g.fillCircle(-9 * s, 7 * s, 1.2 * s);
     }
     return g;
@@ -5238,7 +5244,6 @@ export class GameScene extends Phaser.Scene {
     if (dead) {
       setText(this.causeEl, this.deathCause ? `— ${this.deathCause}` : "");
       setText(this.hintEl, this.deathHint);
-      setText(this.replayEl, `LEVEL ${this.level} — BEST ${this.sessionBest}`);
     }
     const secs = dead ? Math.max(0, Math.ceil((this.respawnAt - now) / 1000)) : 0;
     setText(this.countdownEl, secs > 0 ? `Respawning in ${secs}...` : "");
@@ -5299,7 +5304,8 @@ export class GameScene extends Phaser.Scene {
             ? WEAPONS_SPECIAL[ref]
             : WEAPONS_SPECIAL.find((w) => w.name === ref);
         if (!weapon) return;
-        this.weapon = weapon;
+        this.specialBase = weapon;
+        this.weapon = scaleWeaponForLevel(weapon, this.level);
         this.weaponUntil = Date.now() + SPECIAL_WEAPON_DURATION_MS;
         this.windupAcc = 0;
       },
@@ -5519,7 +5525,7 @@ function hexagonPoints(radius: number): Vec[] {
  *  makes you LOOK bigger/tougher, not easier to hit). L1 1.0 → L5 ~1.52. */
 function shipScaleForLevel(level: number): number {
   const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
-  return 1 + (L - 1) * 0.13;
+  return 1 + (L - 1) * 0.2; // L1 1.0 → L3 1.4 (a clear size jump each level)
 }
 
 function shipHullPoints(level = 1): Array<{ x: number; y: number }> {

--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -1,11 +1,33 @@
 // ---- world -------------------------------------------------------------------
 
+// WORLD_W/H is the fixed VISUAL/MAX extent — the starfield + off-world mask are
+// built to this size. The live PLAY bounds (SharedState.playW/playH) scale from
+// the 1-player BASE up to this max with player count; the area between the play
+// barrier and this extent is just star-bleed.
 export const WORLD_W = 7680;
 export const WORLD_H = 4320;
+/** 1-player play size (the arena felt right at this for solo). */
+export const BASE_WORLD_W = 3840;
+export const BASE_WORLD_H = 2160;
 /** How far past the world edge the starfield scatters and the void fades — the
  *  single knob for the bleed ring (starfield + masks reference it). Keeps the
  *  arena from looking hard-cut at the boundary. */
 export const WORLD_BLEED_PX = 1200;
+
+/** Play-area linear scale from player count: 1.0 at 1p → 2.0 at 32p (so the
+ *  play box grows from BASE_WORLD to the full WORLD max). sqrt so each added
+ *  player widens the arena less than the last. Both dims scale equally, so the
+ *  16:9 aspect (and the minimap) is preserved. */
+export function worldScaleForPlayers(playerCount: number): number {
+  const n = Math.max(1, playerCount);
+  return Math.min(2, 1 + (Math.sqrt(n) - 1) / (Math.sqrt(32) - 1));
+}
+export function playWidthForPlayers(playerCount: number): number {
+  return Math.min(WORLD_W, Math.round(BASE_WORLD_W * worldScaleForPlayers(playerCount)));
+}
+export function playHeightForPlayers(playerCount: number): number {
+  return Math.min(WORLD_H, Math.round(BASE_WORLD_H * worldScaleForPlayers(playerCount)));
+}
 
 // All speeds are px/second (the legacy build used px/tick at 60Hz; ×60 here).
 
@@ -193,10 +215,11 @@ export const XP = {
 } as const;
 
 /** Bounded so the base loadout plateaus below special-weapon power — caps the
- *  snowball: past L12 only picked-up specials make you stronger. */
-export const LEVEL_CAP = 12;
-export const XP_BASE = 40;
-export const XP_GROWTH = 1.28;
+ *  snowball: past the cap only picked-up specials make you stronger. Short (5)
+ *  so each level is a visible step (the ship hull upgrades each level). */
+export const LEVEL_CAP = 5;
+export const XP_BASE = 60;
+export const XP_GROWTH = 1.45;
 /** XP needed to go from `level` → `level+1`. Super-linear: fast early ramp
  *  (L1→2 = 40), grindy top end (L11→12 ≈ 457), ~2000 total to cap. */
 export function xpToNext(level: number): number {
@@ -221,7 +244,7 @@ export function comboMult(streak: number): number {
  *  HP, so the PvP eHP gap to a fresh player stays narrow. */
 export function baseRegenMult(level: number): number {
   const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
-  return 1 + 0.036 * (L - 1);
+  return 1 + 0.075 * (L - 1); // L1 1.0 → L5 1.3
 }
 
 // ---- weapons (§4) ----------------------------------------------------------------
@@ -340,20 +363,20 @@ export const WEAPON_DEFAULT: Weapon = {
  *  Specials override temporarily; on expiry/respawn you revert to THIS, not L1. */
 export function baseWeaponForLevel(level: number): Weapon {
   const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
-  const power = 0.25 + 0.0155 * (L - 1); // L1 .25 → L12 .42 (below BLASTER .9)
-  const intervalMs = Math.round(250 - 5.5 * (L - 1)); // L1 250 → L12 ~189
-  const pellets = L >= 9 ? 2 : 1; // L9+: a tight 2-shot spread for crowd clear
-  const tint = L >= 12 ? 0xfff1a8 : L >= 8 ? 0xeaf6ff : 0xffffff; // warms as you level
+  const power = 0.25 + 0.0375 * (L - 1); // L1 .25 → L5 .40 (below BLASTER .9)
+  const intervalMs = Math.round(250 - 13 * (L - 1)); // L1 250 → L5 ~198
+  const pellets = L >= 4 ? 2 : 1; // L4+: a tight 2-shot spread for crowd clear
+  const tint = L >= 5 ? 0xfff1a8 : L >= 3 ? 0xeaf6ff : 0xffffff; // warms as you level
   return {
     ...WEAPON_DEFAULT,
     name: L <= 1 ? "BEAM" : `BEAM Lv${L}`,
     power,
     intervalMs,
-    width: L >= 9 ? 2 : 1,
+    width: L >= 5 ? 2 : 1,
     pellets,
     spreadDeg: pellets > 1 ? 6 : 0,
     jitterDeg: pellets > 1 ? 2 : 1,
-    mirror: L >= 12, // capstone: a rear shot like MIRROR
+    mirror: L >= 5, // capstone: a rear shot like MIRROR
     tint,
     sfx: "pulse",
   };
@@ -1854,6 +1877,12 @@ export type SharedState = {
   /** Epoch-ms wall clock of arena start — the intensity director's t=0.
    *  Lives in sharedState so it survives host migration. */
   arenaEpoch: number;
+  /** Play-area bounds (host-owned, grow-only with player count). All clients
+   *  clamp/spawn/cull/render the barrier to these so they agree. The VISUAL
+   *  extent (starfield + mask) stays the fixed WORLD_W/H max; the gap between
+   *  the barrier and the max just reads as more star-bleed. */
+  playW: number;
+  playH: number;
 };
 
 /** Beam snapshot in another player's state — drawn raw, never simulated. */
@@ -1926,10 +1955,14 @@ export type PlayerNetState = {
 
 // ---- pure world-gen helpers -----------------------------------------------------
 
-export function randomWorldPoint(margin = RESPAWN_EDGE_MARGIN): Vec {
+export function randomWorldPoint(
+  margin = RESPAWN_EDGE_MARGIN,
+  w = BASE_WORLD_W,
+  h = BASE_WORLD_H,
+): Vec {
   return {
-    x: margin + Math.random() * (WORLD_W - margin * 2),
-    y: margin + Math.random() * (WORLD_H - margin * 2),
+    x: margin + Math.random() * (w - margin * 2),
+    y: margin + Math.random() * (h - margin * 2),
   };
 }
 
@@ -1943,24 +1976,28 @@ export function makeAsteroidVerts(radius: number): Vec[] {
   return verts;
 }
 
-/** Pick a point just past a random world edge, plus an inward heading. */
-export function edgeSpawn(margin: number): { x: number; y: number; ang: number } {
+/** Pick a point just past a random play-area edge, plus an inward heading. */
+export function edgeSpawn(
+  margin: number,
+  w = BASE_WORLD_W,
+  h = BASE_WORLD_H,
+): { x: number; y: number; ang: number } {
   const side = Math.floor(Math.random() * 4);
   const spread = Math.random() * (Math.PI / 2); // 90° fan, aimed inward below
   if (side <= 1) {
-    const y = -margin + Math.random() * (WORLD_H + margin * 2);
-    const x = side === 0 ? -margin : WORLD_W + margin;
+    const y = -margin + Math.random() * (h + margin * 2);
+    const x = side === 0 ? -margin : w + margin;
     const ang = side === 0 ? spread - Math.PI * 0.25 : spread + Math.PI * 0.75;
     return { x, y, ang };
   }
-  const x = -margin + Math.random() * (WORLD_W + margin * 2);
-  const y = side === 2 ? -margin : WORLD_H + margin;
+  const x = -margin + Math.random() * (w + margin * 2);
+  const y = side === 2 ? -margin : h + margin;
   const ang = side === 2 ? spread + Math.PI * 0.25 : spread - Math.PI * 0.75;
   return { x, y, ang };
 }
 
-export function spawnAsteroidState(): AsteroidState {
-  const { x, y, ang } = edgeSpawn(ASTEROID_MAX_RADIUS);
+export function spawnAsteroidState(w = BASE_WORLD_W, h = BASE_WORLD_H): AsteroidState {
+  const { x, y, ang } = edgeSpawn(ASTEROID_MAX_RADIUS, w, h);
   const radius = ASTEROID_MIN_RADIUS + Math.random() * (ASTEROID_MAX_RADIUS - ASTEROID_MIN_RADIUS);
   const speed = asteroidSpeed(radius);
   return {
@@ -1975,14 +2012,14 @@ export function spawnAsteroidState(): AsteroidState {
   };
 }
 
-export function spawnUfoState(): UfoState {
-  const { x, y } = edgeSpawn(30);
+export function spawnUfoState(w = BASE_WORLD_W, h = BASE_WORLD_H): UfoState {
+  const { x, y } = edgeSpawn(30, w, h);
   return {
     id: crypto.randomUUID(),
     x,
     y,
-    destX: Math.random() * WORLD_W,
-    destY: Math.random() * WORLD_H,
+    destX: Math.random() * w,
+    destY: Math.random() * h,
     hp: UFO_HP,
     blinkUntil: 0,
   };

--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -214,12 +214,12 @@ export const XP = {
   ORB: 4,
 } as const;
 
-/** Bounded so the base loadout plateaus below special-weapon power — caps the
- *  snowball: past the cap only picked-up specials make you stronger. Short (5)
- *  so each level is a visible step (the ship hull upgrades each level). */
-export const LEVEL_CAP = 5;
-export const XP_BASE = 60;
-export const XP_GROWTH = 1.45;
+/** Bounded so the base loadout stays a notch below specials — caps the
+ *  snowball. Short (3) so each level is a big, visible step: the ship hull
+ *  upgrades AND every weapon (base + picked-up specials) scales each level. */
+export const LEVEL_CAP = 3;
+export const XP_BASE = 70;
+export const XP_GROWTH = 1.6;
 /** XP needed to go from `level` → `level+1`. Super-linear: fast early ramp
  *  (L1→2 = 40), grindy top end (L11→12 ≈ 457), ~2000 total to cap. */
 export function xpToNext(level: number): number {
@@ -244,7 +244,7 @@ export function comboMult(streak: number): number {
  *  HP, so the PvP eHP gap to a fresh player stays narrow. */
 export function baseRegenMult(level: number): number {
   const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
-  return 1 + 0.075 * (L - 1); // L1 1.0 → L5 1.3
+  return 1 + 0.15 * (L - 1); // L1 1.0 → L3 1.3
 }
 
 // ---- weapons (§4) ----------------------------------------------------------------
@@ -363,22 +363,41 @@ export const WEAPON_DEFAULT: Weapon = {
  *  Specials override temporarily; on expiry/respawn you revert to THIS, not L1. */
 export function baseWeaponForLevel(level: number): Weapon {
   const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
-  const power = 0.25 + 0.0375 * (L - 1); // L1 .25 → L5 .40 (below BLASTER .9)
-  const intervalMs = Math.round(250 - 13 * (L - 1)); // L1 250 → L5 ~198
-  const pellets = L >= 4 ? 2 : 1; // L4+: a tight 2-shot spread for crowd clear
-  const tint = L >= 5 ? 0xfff1a8 : L >= 3 ? 0xeaf6ff : 0xffffff; // warms as you level
+  const power = 0.25 + 0.075 * (L - 1); // L1 .25 → L3 .40 (below BLASTER .9)
+  const intervalMs = Math.round(250 - 26 * (L - 1)); // L1 250 → L3 ~198
+  const tint = L >= 3 ? 0xfff1a8 : L >= 2 ? 0xeaf6ff : 0xffffff; // warms as you level
   return {
     ...WEAPON_DEFAULT,
     name: L <= 1 ? "BEAM" : `BEAM Lv${L}`,
     power,
     intervalMs,
-    width: L >= 5 ? 2 : 1,
-    pellets,
-    spreadDeg: pellets > 1 ? 6 : 0,
-    jitterDeg: pellets > 1 ? 2 : 1,
-    mirror: L >= 5, // capstone: a rear shot like MIRROR
+    width: L >= 3 ? 2 : 1,
+    pellets: L >= 3 ? 2 : 1, // L3 (cap): a tight 2-shot spread for crowd clear
+    spreadDeg: L >= 3 ? 6 : 0,
+    jitterDeg: L >= 3 ? 2 : 1,
+    mirror: L >= 3, // capstone: a rear shot like MIRROR
     tint,
     sfx: "pulse",
+  };
+}
+
+/** Per-level multiplier applied to a PICKED-UP special weapon, so specials get
+ *  stronger as you level too (the base weapon scales via baseWeaponForLevel). */
+export function weaponLevelMult(level: number): number {
+  const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
+  return 1 + (L - 1) * 0.18; // L1 1.0 → L3 1.36 power
+}
+
+/** Return a level-scaled clone of a special weapon (more power + a bit faster).
+ *  Same `name`, so HUD + pickup-stacking still match. L1 returns the input ref. */
+export function scaleWeaponForLevel(w: Weapon, level: number): Weapon {
+  const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
+  if (L <= 1) return w;
+  const fireMult = 1 + (L - 1) * 0.07; // L3 ~1.14× fire rate
+  return {
+    ...w,
+    power: w.power * weaponLevelMult(L),
+    intervalMs: Math.max(40, Math.round(w.intervalMs / fireMult)),
   };
 }
 

--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -146,12 +146,12 @@ export const SPECIAL_WEAPON_DURATION_MS = 20_000;
  *  replacing; the extended expiry never reaches past now + this cap. */
 export const ITEM_STACK_CAP_MS = 60_000;
 
-// ---- score shards (v3 universal drops) ---------------------------------------------
+// ---- XP orbs (v5: former score shards) ---------------------------------------------
 
-// Lightweight pickup: tiny wireframe crystal, +5 score, drifts slowly, dies
-// in 8 sec. Lives in sharedState.shards, a SEPARATE capped array, so the
-// item-in-flight cap (ITEMS_MAX_LIVE = 6) is unaffected.
-export const SHARD_SCORE = 5;
+// Lightweight pickup: tiny wireframe crystal, grants XP.ORB, drifts slowly,
+// dies in 8 sec. Lives in sharedState.shards, a SEPARATE capped array, so the
+// item-in-flight cap (ITEMS_MAX_LIVE = 6) is unaffected. (Wire/field name stays
+// `shards` to avoid a gratuitous shape change; conceptually these are XP orbs.)
 export const SHARD_LIFETIME_MS = 8_000;
 /** Generous pickup radius (items are 15): shards are hoover candy. */
 export const SHARD_PICKUP_RADIUS = 40;
@@ -170,25 +170,58 @@ export function asteroidShardCount(radius: number): number {
   return Math.max(1, Math.min(5, Math.round(radius / 15)));
 }
 
-// ---- scoring + combo (§8) -------------------------------------------------------
+// ---- XP / levelling (§8, v5: replaces scoring) ----------------------------------
+//
+// You level up by destroying things. XP comes from kills (combo-multiplied) and
+// orb pickups + asteroid chips (flat). Levelling raises your BASE loadout — the
+// base weapon and shield regen — but stays deliberately BELOW picked-up specials
+// so a fresh player with a lucky drop still out-guns a max-level base. Bounded
+// cap + a super-linear curve + a death tax keep the veteran↔newcomer power gap
+// narrow in a 32-player arena.
 
-export const SCORE = {
-  /** Flat per chip hit, never multiplied. */
-  ASTEROID_CHIP: 5,
-  ASTEROID_DESTROY: 30,
-  DRONE: 25,
-  WASP: 60,
-  SPLITTER: 80,
-  LANCER: 100,
-  UFO_DESTROY: 300,
-  PLAYER_KILL: 250,
+/** Non-enemy XP awards. Enemy per-kill XP lives in ENEMY_SPECS[kind].xp. */
+export const XP = {
+  /** Flat per asteroid chip hit, never combo-multiplied. */
+  ASTEROID_CHIP: 1,
+  ASTEROID_DESTROY: 6,
+  UFO_DESTROY: 60,
+  /** The boss: a marquee XP event without one-shotting you to the cap. */
+  BOSS_DESTROY: 600,
+  PLAYER_KILL: 45,
+  /** Orb (former score shard) pickup. Flat, never combo-multiplied. */
+  ORB: 4,
 } as const;
+
+/** Bounded so the base loadout plateaus below special-weapon power — caps the
+ *  snowball: past L12 only picked-up specials make you stronger. */
+export const LEVEL_CAP = 12;
+export const XP_BASE = 40;
+export const XP_GROWTH = 1.28;
+/** XP needed to go from `level` → `level+1`. Super-linear: fast early ramp
+ *  (L1→2 = 40), grindy top end (L11→12 ≈ 457), ~2000 total to cap. */
+export function xpToNext(level: number): number {
+  return Math.round(XP_BASE * Math.pow(XP_GROWTH, Math.max(1, level) - 1));
+}
+/** On death: lose this fraction of progress INTO the current level. Absolute
+ *  loss scales with level cost, so the leader pays the most (anti-snowball);
+ *  floor-protected to drop at most XP_DEATH_MAX_DELEVELS. */
+export const XP_DEATH_PENALTY_FRAC = 0.35;
+export const XP_DEATH_MAX_DELEVELS = 1;
 
 /** Kill-streak window; refreshed per kill, hard reset on expiry/death. */
 export const COMBO_WINDOW_MS = 4_000;
 
+/** Combo multiplier — now multiplies XP gain on kills (not orbs/chips). */
 export function comboMult(streak: number): number {
   return streak >= 15 ? 5 : streak >= 10 ? 4 : streak >= 6 ? 3 : streak >= 3 ? 2 : 1;
+}
+
+/** Shield-regen speed multiplier for a given level. Gentle (1.0 → 1.4 at cap):
+ *  levelling makes your shield recover faster between fights without raising max
+ *  HP, so the PvP eHP gap to a fresh player stays narrow. */
+export function baseRegenMult(level: number): number {
+  const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
+  return 1 + 0.036 * (L - 1);
 }
 
 // ---- weapons (§4) ----------------------------------------------------------------
@@ -299,6 +332,32 @@ export const WEAPON_DEFAULT: Weapon = {
   singularity: false,
   sfx: "pulse",
 };
+
+/** Your BASE weapon at a given level: an upgraded NORMAL BEAM (more power, faster
+ *  cadence, +width and a 2-pellet spread at the top, a rear mirror shot at the
+ *  cap). Tuned to stay a clear notch BELOW the special weapons — picking up a
+ *  special is always still an upgrade — so the level power gap stays narrow.
+ *  Specials override temporarily; on expiry/respawn you revert to THIS, not L1. */
+export function baseWeaponForLevel(level: number): Weapon {
+  const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
+  const power = 0.25 + 0.0155 * (L - 1); // L1 .25 → L12 .42 (below BLASTER .9)
+  const intervalMs = Math.round(250 - 5.5 * (L - 1)); // L1 250 → L12 ~189
+  const pellets = L >= 9 ? 2 : 1; // L9+: a tight 2-shot spread for crowd clear
+  const tint = L >= 12 ? 0xfff1a8 : L >= 8 ? 0xeaf6ff : 0xffffff; // warms as you level
+  return {
+    ...WEAPON_DEFAULT,
+    name: L <= 1 ? "BEAM" : `BEAM Lv${L}`,
+    power,
+    intervalMs,
+    width: L >= 9 ? 2 : 1,
+    pellets,
+    spreadDeg: pellets > 1 ? 6 : 0,
+    jitterDeg: pellets > 1 ? 2 : 1,
+    mirror: L >= 12, // capstone: a rear shot like MIRROR
+    tint,
+    sfx: "pulse",
+  };
+}
 
 export const WEAPONS_SPECIAL: Weapon[] = [
   {
@@ -983,6 +1042,163 @@ export const WEAPONS_SPECIAL: Weapon[] = [
     singularity: true,
     sfx: "singularity",
   },
+  // ---- v5 additions (APPEND-ONLY — weaponIdx is positional + serialized) ----------
+  // GRAVITON WELL — a long, gentle pull that herds a swarm into one cluster for a
+  // follow-up AoE, with a weak pop. Reuses the singularity path; only the pull
+  // duration differs (see startCollapse). A setup/utility weapon, not a nuke.
+  {
+    name: "GRAVITON WELL",
+    power: 0.6,
+    speed: 200,
+    length: 0,
+    width: 2,
+    tint: 0x4338ca, // indigo, cooler than SINGULARITY
+    intervalMs: 2600,
+    through: false,
+    explosion: { range: 120, growth: 600 },
+    pellets: 1,
+    spreadDeg: 0,
+    jitterDeg: 0,
+    homing: null,
+    arc: null,
+    boomerang: null,
+    windupMs: 0,
+    mine: false,
+    ricochet: null,
+    flak: null,
+    cluster: null,
+    range: 220,
+    phasesRock: false,
+    mirror: false,
+    aura: false,
+    sentry: false,
+    singularity: true,
+    sfx: "singularity",
+  },
+  // SUPERNOVA — telegraphed screen-wide panic clear. Reuses the NOVA branch
+  // (explosion + speed 0); windupMs is honored generically in handleShooting.
+  {
+    name: "SUPERNOVA",
+    power: 1.0,
+    speed: 0,
+    length: 0,
+    width: 1,
+    tint: 0xfde047, // solar yellow
+    intervalMs: 2000,
+    through: false,
+    explosion: { range: 360, growth: 1100 }, // screen-wide (NOVA is 140)
+    pellets: 1,
+    spreadDeg: 0,
+    jitterDeg: 0,
+    homing: null,
+    arc: null,
+    boomerang: null,
+    windupMs: 500, // telegraphed; charging nose-glow is free
+    mine: false,
+    ricochet: null,
+    flak: null,
+    cluster: null,
+    range: 0,
+    phasesRock: false,
+    mirror: false,
+    aura: false,
+    sentry: false,
+    singularity: false,
+    sfx: "nova",
+  },
+  // SEEKER SWARM — sustained lock-spam: 6 staggered homing missiles that saturate
+  // a crowd. Distinct from CLUSTER (3 tight) and HOMING (1 burst).
+  {
+    name: "SEEKER SWARM",
+    power: 0.22,
+    speed: 340,
+    length: 8,
+    width: 2,
+    tint: 0xf472b6, // pink
+    intervalMs: 1400,
+    through: false,
+    explosion: null,
+    pellets: 1,
+    spreadDeg: 0,
+    jitterDeg: 0,
+    homing: { turnDegPerSec: 260, acquireRange: 440 },
+    arc: null,
+    boomerang: null,
+    windupMs: 0,
+    mine: false,
+    ricochet: null,
+    flak: null,
+    cluster: { missiles: 6, staggerMs: 90 },
+    range: 0,
+    phasesRock: false,
+    mirror: false,
+    aura: false,
+    sentry: false,
+    singularity: false,
+    sfx: "seek",
+  },
+  // CHAIN REACTOR — screen-wide lightning web (arc, 6 jumps). Strong against a
+  // packed swarm, weak 1v1 — self-balancing for a 32p brawl.
+  {
+    name: "CHAIN REACTOR",
+    power: 0.3,
+    speed: 0, // hitscan (arc)
+    length: 0,
+    width: 2,
+    tint: 0x22d3ee, // bright cyan
+    intervalMs: 650,
+    through: false,
+    explosion: null,
+    pellets: 1,
+    spreadDeg: 0,
+    jitterDeg: 0,
+    homing: null,
+    arc: { castRange: 460, hopRange: 320, jumps: 6, falloff: 0.78 },
+    boomerang: null,
+    windupMs: 0,
+    mine: false,
+    ricochet: null,
+    flak: null,
+    cluster: null,
+    range: 0,
+    phasesRock: false,
+    mirror: false,
+    aura: false,
+    sentry: false,
+    singularity: false,
+    sfx: "arc",
+  },
+  // PLASMA STORM — 360° close-range airburst cloud (flak, 14 frags, close burst).
+  // Brutal point-blank, whiffs at range — the close trade is the balancer.
+  {
+    name: "PLASMA STORM",
+    power: 0.4,
+    speed: 520,
+    length: 12,
+    width: 2,
+    tint: 0xa3e635, // lime
+    intervalMs: 700,
+    through: false,
+    explosion: null,
+    pellets: 1,
+    spreadDeg: 0,
+    jitterDeg: 1,
+    homing: null,
+    arc: null,
+    boomerang: null,
+    windupMs: 0,
+    mine: false,
+    ricochet: null,
+    flak: { burstDist: 110, fragments: 14, fragRange: 150 },
+    cluster: null,
+    range: 0,
+    phasesRock: false,
+    mirror: false,
+    aura: false,
+    sentry: false,
+    singularity: false,
+    sfx: "boom",
+  },
 ];
 
 /** FLAK fragments: ordinary beams (own hitIds, serialized, PvP-live) spawned
@@ -1049,6 +1265,8 @@ export const SINGULARITY_PULL_RANGE = 220;
 /** Drag speed at the fringe; scaled down near the center (d/100 clamp) so
  *  targets gather at the point instead of slingshotting through it. */
 export const SINGULARITY_PULL_SPEED = 260;
+/** GRAVITON WELL holds far longer than SINGULARITY (0.8s) — it herds, not nukes. */
+export const GRAVITON_PULL_MS = 2400;
 
 // ---- base shield (v2 §A) ----------------------------------------------------------
 
@@ -1068,7 +1286,18 @@ export const DMG = {
   LANCER_HULL: 45, // touching a non-charging lancer
   ENEMY_HULL: 35, // drone/wasp/splitter hull contact
   UFO_HULL: 50,
+  WARDEN_MORTAR: 40, // slow lob; dodge-or-pay
+  SNIPER_BOLT: 55, // fast rail; breaking the laser-sight line avoids it
+  BOSS_LANCE: 70, // 3 simultaneous in boss phase 2
 } as const;
+
+/** Enemy shots aren't source-tagged on the wire — speed identifies the kind, so
+ *  each kind's shot damage and death cause are recovered from its bolt speed. */
+export function enemyShotHit(speed: number): { cause: string; dmg: number } {
+  if (speed >= 600) return { cause: "SNIPER", dmg: DMG.SNIPER_BOLT }; // sniper + boss lance
+  if (speed <= 270) return { cause: "DRONE", dmg: DMG.DRONE_SHOT }; // drone, warden, boss plasma/nova
+  return { cause: "WASP", dmg: DMG.WASP_SHOT };
+}
 
 /** Asteroid contact scales with rock size: r=5→25 … r=50→50 … r=80→68. */
 export function asteroidContactDamage(r: number): number {
@@ -1088,9 +1317,17 @@ export const CONTACT_IFRAME_MS = 500;
 /** Pickups are timed modifiers on top of the base shield, one at a time. */
 export const SHIELD_MOD_DURATION_MS = 20_000;
 
-export type ShieldModKind = "overshield" | "reflect" | "ram" | "phase" | "siphon" | "aegis";
+export type ShieldModKind =
+  | "overshield"
+  | "reflect"
+  | "ram"
+  | "phase"
+  | "siphon"
+  | "aegis"
+  | "bulwark"
+  | "leech";
 
-/** Index order on the wire (`ItemState.shieldIdx`). */
+/** Index order on the wire (`ItemState.shieldIdx`) — APPEND-ONLY. */
 export const SHIELD_MOD_KINDS: readonly ShieldModKind[] = [
   "overshield",
   "reflect",
@@ -1098,6 +1335,8 @@ export const SHIELD_MOD_KINDS: readonly ShieldModKind[] = [
   "phase",
   "siphon",
   "aegis",
+  "bulwark",
+  "leech",
 ];
 
 export type ShieldModSpec = { name: string; tint: number };
@@ -1109,7 +1348,17 @@ export const SHIELD_MOD_SPECS: Record<ShieldModKind, ShieldModSpec> = {
   phase: { name: "PHASE", tint: 0xe2e8f0 },
   siphon: { name: "SIPHON", tint: 0x34d399 },
   aegis: { name: "AEGIS", tint: 0xfacc15 },
+  bulwark: { name: "BULWARK", tint: 0x94a3b8 },
+  leech: { name: "LEECH FIELD", tint: 0x4ade80 },
 };
+
+/** BULWARK: incoming hits inside a frontal cone take BULWARK_FRONT_MULT damage;
+ *  the rear is exposed (positional play). */
+export const BULWARK_CONE_DEG = 140;
+export const BULWARK_FRONT_MULT = 0.35;
+/** LEECH FIELD: each of YOUR enemy kills within range heals this much. */
+export const LEECH_FIELD_RANGE = 240;
+export const LEECH_FIELD_HEAL = 10;
 
 /** Base shield ring radius (hull r=8; mod halos sit at r=15). */
 export const SHIELD_RING_RADIUS = 12;
@@ -1167,15 +1416,16 @@ export const AEGIS_REGEN_MULT = 1.6; // 106.7 HP/s → full in ~0.94s
 
 // ---- boosters (v2 §D — third drop class) --------------------------------------------
 
-export type BoosterKind = "overdrive" | "nitro" | "repair" | "twin" | "magnet";
+export type BoosterKind = "overdrive" | "nitro" | "repair" | "twin" | "magnet" | "salvage";
 
-/** Index order on the wire (`ItemState.boosterIdx`). */
+/** Index order on the wire (`ItemState.boosterIdx`) — APPEND-ONLY. */
 export const BOOSTER_KINDS: readonly BoosterKind[] = [
   "overdrive",
   "nitro",
   "repair",
   "twin",
   "magnet",
+  "salvage",
 ];
 
 export type BoosterSpec = { name: string; tint: number; durationMs: number };
@@ -1186,7 +1436,11 @@ export const BOOSTER_SPECS: Record<BoosterKind, BoosterSpec> = {
   repair: { name: "REPAIR", tint: 0x4ade80, durationMs: 0 }, // instant
   twin: { name: "TWIN", tint: 0xa78bfa, durationMs: 20_000 },
   magnet: { name: "MAGNET", tint: 0x38bdf8, durationMs: 25_000 },
+  salvage: { name: "SALVAGE", tint: 0xfbbf24, durationMs: 20_000 },
 };
+
+/** SALVAGE: XP-orb pickups are worth this multiple while held. */
+export const SALVAGE_MULT = 2;
 
 /** intervalMs & windupMs × this at fire time (+50% rate). */
 export const OVERDRIVE_RATE_MULT = 0.667;
@@ -1230,6 +1484,8 @@ export const LOOT_SHIELD_WEIGHTS: Record<ShieldModKind, number> = {
   phase: 3,
   siphon: 3,
   aegis: 2,
+  bulwark: 3,
+  leech: 2,
 };
 export const LOOT_BOOSTER_WEIGHTS: Record<BoosterKind, number> = {
   overdrive: 4,
@@ -1237,6 +1493,7 @@ export const LOOT_BOOSTER_WEIGHTS: Record<BoosterKind, number> = {
   repair: 3,
   twin: 3,
   magnet: 2,
+  salvage: 3,
 };
 
 /** Per-class pity: a kill that doesn't drop class X increments X's counter;
@@ -1273,14 +1530,23 @@ export function rollWeightedKey<K extends string>(weights: Record<K, number>): K
 
 // ---- enemies (§6) -----------------------------------------------------------------
 
-export type EnemyKind = "drone" | "wasp" | "lancer" | "splitter";
+export type EnemyKind =
+  | "drone"
+  | "wasp"
+  | "lancer"
+  | "splitter"
+  | "warden"
+  | "sniper"
+  | "spawner"
+  | "dreadnought";
 
 export type EnemySpec = {
   name: string;
   tint: number;
   hitRadius: number;
   hp: number;
-  score: number;
+  /** XP awarded on kill (combo-multiplied via registerKill). */
+  xp: number;
 };
 
 /** v3 fodder rule: one NORMAL BEAM hit = power 0.25 x 100 = 25 HP, so
@@ -1290,10 +1556,15 @@ export type EnemySpec = {
  *  untouched by hp tuning: a lone DRONE still can't kill a dodging
  *  full-shield player (30 dmg / 2.8s cooldown vs 2.5s regen delay). */
 export const ENEMY_SPECS: Record<EnemyKind, EnemySpec> = {
-  drone: { name: "DRONE", tint: 0xff7a6b, hitRadius: 7, hp: 20, score: SCORE.DRONE },
-  wasp: { name: "WASP", tint: 0xff4757, hitRadius: 8, hp: 25, score: SCORE.WASP },
-  lancer: { name: "LANCER", tint: 0xd90429, hitRadius: 9, hp: 80, score: SCORE.LANCER },
-  splitter: { name: "SPLITTER", tint: 0xff9580, hitRadius: 12, hp: 120, score: SCORE.SPLITTER },
+  drone: { name: "DRONE", tint: 0xff7a6b, hitRadius: 7, hp: 20, xp: 5 },
+  wasp: { name: "WASP", tint: 0xff4757, hitRadius: 8, hp: 25, xp: 12 },
+  lancer: { name: "LANCER", tint: 0xd90429, hitRadius: 9, hp: 80, xp: 20 },
+  splitter: { name: "SPLITTER", tint: 0xff9580, hitRadius: 12, hp: 120, xp: 16 },
+  warden: { name: "WARDEN", tint: 0xffb347, hitRadius: 16, hp: 220, xp: 28 },
+  sniper: { name: "SNIPER", tint: 0xff5ec7, hitRadius: 8, hp: 35, xp: 14 },
+  spawner: { name: "HIVE", tint: 0xc77dff, hitRadius: 14, hp: 130, xp: 24 },
+  // hp is a placeholder; the host overwrites e.hp = bossHp(players) at spawn.
+  dreadnought: { name: "DREADNOUGHT", tint: 0xff2d2d, hitRadius: 60, hp: 4000, xp: 600 },
 };
 
 /** Enemies never fire unless their target is within this range (≈ on screen). */
@@ -1334,6 +1605,74 @@ export const SPLITTER_CHILDREN = 3;
 export const SPLITTER_CHILD_SPEED = 150;
 export const SPLITTER_GRACE_MS = 600;
 
+// ---- WARDEN (v5: vent-window tank) -----------------------------------------------
+// Slow armored advance. Shield up = heavy flat damage reduction; after it lobs a
+// mortar it VENTS (shield down) for a window where it takes 2× — burst it then.
+export const WARDEN_SPEED = 55;
+export const WARDEN_TURN_DEG_PER_S = 45;
+export const WARDEN_SHIELDED_DR = 0.2; // ×0.2 damage while shielded (80% mitigation)
+export const WARDEN_VENT_DR = 2.0; // ×2 damage during the vent window
+export const WARDEN_VENT_MS = 1_400;
+export const WARDEN_COOLDOWN_MS = 3_200;
+export const WARDEN_TELEGRAPH_MS = 700;
+export const WARDEN_SHOT_SPEED = 220; // slow lob → DRONE-tier cause
+export const WARDEN_FIRE_RANGE = 700;
+
+// ---- SNIPER (v5: long-range glass cannon) ----------------------------------------
+// Kites to keep distance, charges a laser sight locked on your current position,
+// then fires one very fast high-damage rail bolt. Break the line to dodge it.
+export const SNIPER_SPEED = 130;
+export const SNIPER_KEEP_DIST = 520;
+export const SNIPER_AIM_MS = 900;
+export const SNIPER_COOLDOWN_MS = 2_600;
+export const SNIPER_SHOT_SPEED = 720; // fastest projectile in the game
+export const SNIPER_FIRE_RANGE = 1_100;
+
+// ---- SPAWNER / HIVE (v5: swarm-spawner) ------------------------------------------
+// Barely drifts; periodically births mites on a telegraphed pulse, self-capping
+// its brood. Kill it to stop the bleed — priority target.
+export const SPAWNER_SPEED = 35;
+export const SPAWNER_PULSE_MS = 4_200;
+export const SPAWNER_TELEGRAPH_MS = 650;
+export const SPAWNER_BROOD_PER_PULSE = 2;
+export const SPAWNER_BROOD_CAP = 6;
+export const MITE_GRACE_MS = 500;
+
+// ---- DREADNOUGHT (v5: 3-phase boss, modeled as an EnemyKind) ----------------------
+export const BOSS_HP_BASE = 4_000;
+export const BOSS_HP_PER_PLAYER = 650;
+export const BOSS_SPEED = 70;
+export const BOSS_ORBIT_RADIUS = 700;
+export const BOSS_P1_CYCLE_MS = 2_200;
+export const BOSS_P1_TELEGRAPH_MS = 600;
+export const BOSS_P1_SPREAD_COUNT = 7;
+export const BOSS_P1_SPREAD_DEG = 60;
+export const BOSS_P2_CYCLE_MS = 2_600;
+export const BOSS_P2_AIM_MS = 1_100;
+export const BOSS_P2_LANCES = 3;
+export const BOSS_P3_CYCLE_MS = 1_900;
+export const BOSS_P3_TELEGRAPH_MS = 700;
+export const BOSS_P3_NOVA_COUNT = 16;
+export const BOSS_P3_MITES = 4;
+export const BOSS_SHOT_SPEED = 260; // plasma/nova → DRONE-tier cause
+export const BOSS_CONTACT_DMG = 60;
+/** Boss spawns only near a wave peak (max intensity 2.6) … */
+export const BOSS_SPAWN_INTENSITY = 2.3;
+/** … and only in a busy room; small rooms wait out the cooldown then get one. */
+export const BOSS_SPAWN_MIN_PLAYERS = 4;
+export const BOSS_SPAWN_COOLDOWN_MS = 150_000;
+export const BOSS_REWARD_SHARDS = 30;
+
+/** Boss HP scales with the room so a zerg can't delete it instantly. */
+export function bossHp(playerCount: number): number {
+  return BOSS_HP_BASE + Math.max(0, playerCount - 1) * BOSS_HP_PER_PLAYER;
+}
+/** Phase is DERIVED from HP, so a migrated host resumes the right phase free. */
+export function bossPhase(hp: number, maxHp: number): 1 | 2 | 3 {
+  const f = maxHp > 0 ? hp / maxHp : 1;
+  return f > 0.66 ? 1 : f > 0.33 ? 2 : 3;
+}
+
 export const ENEMY_SHOT_TINT = 0xff3b30; // red is reserved: nothing friendly is ever red
 export const ENEMY_SHOT_LEN = 8;
 export const ENEMY_SHOT_WIDTH = 2;
@@ -1353,10 +1692,27 @@ export function enemySpawnWeight(kind: EnemyKind, intensity: number): number {
       return 7 * Math.max(0, intensity - 0.9);
     case "splitter":
       return 5 * Math.max(0, intensity - 1.2);
+    case "sniper":
+      return 6 * Math.max(0, intensity - 1.0);
+    case "warden":
+      return 4 * Math.max(0, intensity - 1.4);
+    case "spawner":
+      return 3.5 * Math.max(0, intensity - 1.5);
+    case "dreadnought":
+      return 0; // dedicated trigger only — never in the weighted roll
   }
 }
 
-export const ENEMY_KINDS: readonly EnemyKind[] = ["drone", "wasp", "lancer", "splitter"];
+/** The ROLLABLE enemy kinds (boss is excluded — it has a dedicated trigger). */
+export const ENEMY_KINDS: readonly EnemyKind[] = [
+  "drone",
+  "wasp",
+  "lancer",
+  "splitter",
+  "sniper",
+  "warden",
+  "spawner",
+];
 
 /** Breather rule: once the live count exceeds the cap by this slack (splitter
  *  children bypass the cap), the host quietly despawns the enemy farthest from
@@ -1441,6 +1797,13 @@ export type EnemyState = {
   blinkUntil: number;
   /** SPLITTER children: can't fire/kill while flashing in. */
   graceUntil: number;
+  /** WARDEN/BOSS: max HP, for the HP-bar render + boss phase derivation. 0 = N/A. */
+  maxHp: number;
+  /** SNIPER/BOSS laser sights: locked target points during a telegraph; cleared
+   *  after firing. Empty otherwise. */
+  lances: Vec[];
+  /** WARDEN: shield up (heavy DR) vs venting (extra damage). */
+  shielded: boolean;
 };
 
 export type EnemyShotState = {
@@ -1539,7 +1902,10 @@ export type PlayerNetState = {
   vy: number;
   alive: boolean;
   invuln: boolean;
-  score: number;
+  /** Current level (1..LEVEL_CAP); the new nameplate-worthy field. */
+  level: number;
+  /** XP into the current level; remotes can render a progress bar. */
+  xp: number;
   streak: number;
   weaponName: string;
   /** Base shield 0–100; remotes render the ring straight from this. */
@@ -1672,6 +2038,9 @@ export function spawnEnemyState(kind: EnemyKind, x: number, y: number): EnemySta
     chargeUntil: 0,
     blinkUntil: 0,
     graceUntil: 0,
+    maxHp: ENEMY_SPECS[kind].hp,
+    lances: [],
+    shielded: kind === "warden",
   };
 }
 


### PR DESCRIPTION
Large gameplay expansion for `games/starfall`. Builds on Slice 1 (already on `main`: bigger world, neon border + star-bleed, 32-player cap, swarm/wave difficulty).

## What's in this branch
- **XP / levels (scoring removed).** Shards → XP orbs; combo multiplies XP. You level by destroying things. **Cap 3** (short, big steps). Base weapon + shield-regen scale per level; **picked-up specials scale too** (`scaleWeaponForLevel`, off an unscaled base so re-leveling never compounds). Death tax: lose 35% of current-level XP, max 1 de-level — keeps the veteran↔newcomer gap narrow.
- **Ships grow + gain detail per level** (wings → cockpit → inner frame + nose), local and remote; collision hitbox unchanged.
- **+5 weapons** (Graviton Well, Supernova, Seeker Swarm, Chain Reactor, Plasma Storm), **+2 shield mods** (Bulwark, Leech), **+1 booster** (Salvage). All reuse existing serialization.
- **+3 enemies** (Warden vent-window tank, Sniper, Hive spawner) + **Dreadnought boss** (3 HP-derived phases, modeled as an `EnemyKind`; reward = XP fountain + 2 drops; boss HP bar).
- **Map scales with player count** — play bounds (`SharedState.playW/playH`, host-owned, grow-only per arena) go 1p=3840×2160 → 32p=7680×4320; the fixed `WORLD` max stays the visual/starfield/mask extent.
- **HUD** trimmed to the user's spec: no top-left level bar, no boss-name/death-screen LEVEL labels — level reads from the ship + the `BEAM Lvx` weapon name.
- Room `v4 → v5` (PlayerNetState + EnemyState + SharedState shape changes).

## Verification
Typecheck + lint + build clean. **Solo-headless-verified only** (level math, weapon/special scaling, WARDEN DR, boss phases + reward, map bounds all confirmed via the dev hooks). Deferred: BEACON/BARRIER weapons, the 32p wire-bandwidth optimization (a future v6 wire change).

## Needs a multiplayer pass before deploy
Host-authoritative paths I couldn't test headlessly: WARDEN DR adjudication across clients, boss across clients + host migration mid-fight, the `enemyShotHit(speed)` classifier, owner-side LEECH/SALVAGE/BULWARK under reconciliation, and play-bounds agreement (grow shouldn't strand entities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Host-authoritative net shape changes (v5 room, play bounds, enemy state, XP sync) plus untested multiplayer paths for boss migration, Warden DR, shot classification, and owner-side mods under reconciliation.
> 
> **Overview**
> **Starfall v5** is a large gameplay expansion: progression, combat content, arena scaling, and HUD/network shape changes, with the room bumped to `starfall-arena-v5` so older clients don’t mix state.
> 
> **Progression replaces scoring.** Kills and orbs feed **XP** (combo still multiplies kill XP). **Levels cap at 3** and upgrade the base beam, shield regen, and visual ship hull; held specials are re-scaled from an unscaled base so they don’t compound. Death applies an XP penalty and optional de-level. Net state swaps `score` for `level`/`xp`; shards are XP orbs.
> 
> **New threats and a boss.** **Warden**, **Sniper**, and **Hive** spawner join the roster with host AI, telegraphs, and shot typing via `enemyShotHit(speed)`. **Dreadnought** is a one-per-arena boss with HP-derived three phases, brood mites, a top **boss HP bar**, and a heavy XP/drop reward.
> 
> **Arena grows with headcount.** Host-owned `playW`/`playH` grow from solo base size toward the fixed visual `WORLD` max; clamping, spawns, culling, minimap, and the **energy barrier** all follow live play bounds.
> 
> **More pickups (append-only wire indices).** Five specials (e.g. Graviton Well, Supernova), shield mods **Bulwark** / **Leech**, and **Salvage** booster; client-side Bulwark cone mitigation and Leech heals on your kills in range.
> 
> **HUD trim.** Top-left score and death-screen best/replay are removed; combo sits lower to clear the boss bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9034a7d89d6d23b7513a96d62f60f67b65895e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Major v5 content drop for `games/starfall`: XP/levels replace score, ships level up, new weapons/enemies plus a 3-phase boss, and the play area scales with player count. HUD is simplified, and the room moves to v5 with state shape changes.

- New Features
  - XP/levels: shards become XP orbs; combo multiplies XP on kills; cap 3; base weapon and shield-regen scale per level; picked-up specials scale via `scaleWeaponForLevel`; death tax −35% XP (max 1 delevel).
  - Ships grow visually by level (wings/cockpit/frame), hitbox unchanged.
  - +5 weapons: Graviton Well, Supernova, Seeker Swarm, Chain Reactor, Plasma Storm. +2 shield mods: Bulwark (frontal DR), Leech (on-kill heal). +1 booster: Salvage (double orb XP).
  - +3 enemies: Warden (vent window), Sniper (laser-sight rail), Spawner (hive). New Dreadnought boss (HP-scaled, 3 phases, XP fountain + 2 drops). Boss HP bar added.
  - Play area scales with player count; host owns `playW/playH` (grow-only); barrier/minimap/clamps use play bounds; world max remains for visuals.
  - HUD trimmed: score/level labels removed; special timer only; boss bar shown when alive.

- Migration
  - Room `v4` → `v5`. State changes: PlayerNetState `score` → `level`/`xp`; EnemyState adds `maxHp`, `lances`, `shielded`; SharedState adds `playW`/`playH`; new `EnemyKind` values (`warden`, `sniper`, `spawner`, `dreadnought`).
  - API updates: `EnergyBarrier.update(time, worldW, worldH)`; world helpers accept play-size; use play bounds in in-world checks/spawns.
  - Multiplayer to verify: Warden DR across clients, boss behavior + host migration, `enemyShotHit` classification, owner-side Bulwark/Leech/Salvage under reconciliation, and play-bounds agreement.

<sup>Written for commit dc9034a7d89d6d23b7513a96d62f60f67b65895e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

