### PR TITLE
fix(starfall): v5 review-pass + multiplayer-test fixes

### DIFF
--- a/games/starfall/src/scenes/game-scene.ts
+++ b/games/starfall/src/scenes/game-scene.ts
@@ -40,7 +40,9 @@ import {
   BOOSTER_SPECS,
   BULWARK_CONE_DEG,
   BULWARK_FRONT_MULT,
+  BOSS_BROOD_CAP,
   BOSS_CONTACT_DMG,
+  BOSS_LANCE_SHOT_SPEED,
   BOSS_ORBIT_RADIUS,
   BOSS_P1_CYCLE_MS,
   BOSS_P1_SPREAD_COUNT,
@@ -177,6 +179,7 @@ import {
   RESPAWN_ATTEMPTS,
   RESPAWN_CLEARANCE,
   RESPAWN_DELAY_MS,
+  RESPAWN_EDGE_MARGIN,
   rollLootClass,
   rollWeightedKey,
   SENTRY_FIRE_MS,
@@ -887,10 +890,11 @@ export class GameScene extends Phaser.Scene {
 
   /** Re-roll until clear of enemies + big asteroids; ≤8 attempts, take best. */
   private pickRespawnPoint(): Vec {
-    let best = randomWorldPoint();
+    const { playW, playH } = this.world; // respawn within the LIVE (scaled) play area
+    let best = randomWorldPoint(RESPAWN_EDGE_MARGIN, playW, playH);
     let bestClearance = -1;
     for (let i = 0; i < RESPAWN_ATTEMPTS; i++) {
-      const p = randomWorldPoint();
+      const p = randomWorldPoint(RESPAWN_EDGE_MARGIN, playW, playH);
       let minD = Infinity;
       for (const e of this.world.enemies) {
         minD = Math.min(minD, Math.hypot(e.x - p.x, e.y - p.y));
@@ -3029,19 +3033,30 @@ export class GameScene extends Phaser.Scene {
    * of resetting it.
    */
   private ensureSeeded(): void {
+    // Seed the opening asteroid field within the play bounds for the current
+    // player count (so a multi-player arena opens fully populated, not just the
+    // base 1-player box).
+    const seedField = (s: SharedState): void => {
+      const pc = Math.max(1, Object.keys(this.peers).length);
+      s.playW = playWidthForPlayers(pc);
+      s.playH = playHeightForPlayers(pc);
+      for (let i = 0; i < ASTEROID_SEED_COUNT; i++) {
+        s.asteroids.push(spawnAsteroidState(s.playW, s.playH));
+      }
+    };
     if (this.offline) {
       // Solo arena: seed the local world directly, nothing to broadcast.
       if (!this.offlineSeeded) {
         this.offlineSeeded = true;
         const seeded = emptyShared();
-        for (let i = 0; i < ASTEROID_SEED_COUNT; i++) seeded.asteroids.push(spawnAsteroidState());
+        seedField(seeded);
         this.world = seeded;
       }
       return;
     }
     if (this.amHost && this.client.connectionStatus === "connected" && !this.shared()) {
       const seeded = emptyShared();
-      for (let i = 0; i < ASTEROID_SEED_COUNT; i++) seeded.asteroids.push(spawnAsteroidState());
+      seedField(seeded);
       this.world = seeded;
       this.client.updateSharedState(seeded as unknown as Record<string, unknown>);
     }
@@ -3053,8 +3068,9 @@ export class GameScene extends Phaser.Scene {
     if (!s) return;
     const w = this.world;
     if (typeof s.arenaEpoch === "number") w.arenaEpoch = s.arenaEpoch;
-    if (typeof s.playW === "number") w.playW = s.playW;
-    if (typeof s.playH === "number") w.playH = s.playH;
+    // Clamp to valid bounds — never trust an out-of-range value from the host.
+    if (typeof s.playW === "number") w.playW = Phaser.Math.Clamp(s.playW, BASE_WORLD_W, WORLD_W);
+    if (typeof s.playH === "number") w.playH = Phaser.Math.Clamp(s.playH, BASE_WORLD_H, WORLD_H);
 
     const asteroidIds = new Set<string>();
     for (const a of s.asteroids) {
@@ -3314,11 +3330,13 @@ export class GameScene extends Phaser.Scene {
     if (d.enemies) patch["enemies"] = w.enemies;
     if (d.enemyShots) patch["enemyShots"] = w.enemyShots;
     if (d.pulls) patch["pulls"] = w.pulls;
-    if (this.playBoundsDirty) {
+    // Piggyback play bounds on ANY outgoing patch (cheap — 2 ints) so guests and
+    // a freshly-promoted host stay in sync; force a send if ONLY bounds changed.
+    if (this.playBoundsDirty || Object.keys(patch).length > 0) {
       patch["playW"] = w.playW;
       patch["playH"] = w.playH;
-      this.playBoundsDirty = false;
     }
+    this.playBoundsDirty = false;
     if (!this.offline && Object.keys(patch).length > 0) this.client.updateSharedState(patch);
     this.dirty = {
       asteroids: false,
@@ -3767,6 +3785,7 @@ export class GameScene extends Phaser.Scene {
     for (let i = 0; i < w.enemies.length; i++) {
       const e = w.enemies[i];
       if (!e) continue;
+      if (e.kind === "dreadnought") continue; // the boss is never auto-despawned
       let minD = Infinity;
       for (const p of players) minD = Math.min(minD, Math.hypot(e.x - p.x, e.y - p.y));
       if (minD > farDist) {
@@ -3882,7 +3901,13 @@ export class GameScene extends Phaser.Scene {
           sim.fireAt = 0;
           sim.nextAttackAt = now + BOSS_P2_CYCLE_MS;
           for (const aim of e.lances) {
-            this.hostSpawnShot(e.x, e.y, Math.atan2(aim.y - e.y, aim.x - e.x), SNIPER_SHOT_SPEED, now);
+            this.hostSpawnShot(
+              e.x,
+              e.y,
+              Math.atan2(aim.y - e.y, aim.x - e.x),
+              BOSS_LANCE_SHOT_SPEED, // distinct speed → BOSS_LANCE damage (70), not sniper 55
+              now,
+            );
           }
           e.lances = [];
         }
@@ -3914,7 +3939,8 @@ export class GameScene extends Phaser.Scene {
           for (let i = 0; i < BOSS_P3_NOVA_COUNT; i++) {
             this.hostSpawnShot(e.x, e.y, (Math.PI * 2 * i) / BOSS_P3_NOVA_COUNT, BOSS_SHOT_SPEED, now);
           }
-          this.hostBirthMites(e, BOSS_P3_MITES, now);
+          // Cap the brood so a long phase-3 can't balloon enemies[] unbounded.
+          if (sim.broodCount < BOSS_BROOD_CAP) this.hostBirthMites(e, BOSS_P3_MITES, now);
         }
       } else if (now >= sim.nextAttackAt) {
         e.telegraphUntil = now + BOSS_P3_TELEGRAPH_MS;
@@ -3961,6 +3987,7 @@ export class GameScene extends Phaser.Scene {
     if (intensity < BOSS_SPAWN_INTENSITY) return;
     if (this.lastBossKilledAt !== 0 && now - this.lastBossKilledAt < BOSS_SPAWN_COOLDOWN_MS) return;
     const players = this.livingPlayers();
+    if (players.length === 0) return; // never spawn a boss with nobody to fight it
     const busy = Object.keys(this.peers).length >= BOSS_SPAWN_MIN_PLAYERS;
     // Quiet rooms only get one once the cooldown has fully elapsed since the last.
     if (!busy && this.lastBossKilledAt === 0 && now < BOSS_SPAWN_COOLDOWN_MS) return;

--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -1333,10 +1333,16 @@ export const DMG = {
   BOSS_LANCE: 70, // 3 simultaneous in boss phase 2
 } as const;
 
+/** Boss phase-2 lances ride a distinct (faster) speed than the SNIPER so the
+ *  speed→damage classifier can give them their heavier BOSS_LANCE damage. */
+export const BOSS_LANCE_SHOT_SPEED = 820;
+
 /** Enemy shots aren't source-tagged on the wire — speed identifies the kind, so
- *  each kind's shot damage and death cause are recovered from its bolt speed. */
+ *  each kind's shot damage and death cause are recovered from its bolt speed.
+ *  (Both host and victim run this on the same serialized vx/vy, so they agree.) */
 export function enemyShotHit(speed: number): { cause: string; dmg: number } {
-  if (speed >= 600) return { cause: "SNIPER", dmg: DMG.SNIPER_BOLT }; // sniper + boss lance
+  if (speed >= 800) return { cause: "DREADNOUGHT", dmg: DMG.BOSS_LANCE }; // boss lance (820)
+  if (speed >= 600) return { cause: "SNIPER", dmg: DMG.SNIPER_BOLT }; // sniper (720)
   if (speed <= 270) return { cause: "DRONE", dmg: DMG.DRONE_SHOT }; // drone, warden, boss plasma/nova
   return { cause: "WASP", dmg: DMG.WASP_SHOT };
 }
@@ -1696,6 +1702,9 @@ export const BOSS_P3_CYCLE_MS = 1_900;
 export const BOSS_P3_TELEGRAPH_MS = 700;
 export const BOSS_P3_NOVA_COUNT = 16;
 export const BOSS_P3_MITES = 4;
+/** Max live mites the boss can sustain (phase 3 births stop adding past this —
+ *  prevents unbounded enemies[] growth over a long phase-3). */
+export const BOSS_BROOD_CAP = 16;
 export const BOSS_SHOT_SPEED = 260; // plasma/nova → DRONE-tier cause
 export const BOSS_CONTACT_DMG = 60;
 /** Boss spawns only near a wave peak (max intensity 2.6) … */


### PR DESCRIPTION
Post-merge correctness pass on the Starfall v5 expansion: an adversarial multi-agent review (26 candidates → 20 confirmed) plus a **live 2-client multiplayer test** (two real clients against the party server). Fixes the real bugs found; several "findings" were false positives or by-design (WARDEN uses flat vent-window DR, not knockback; SALVAGE is an orb-only multiplier by design) and are not changed.

## Fixed
- **Boss culled by breather despawn** (found live — a 24k-HP boss vanished mid-fight). Boss now exempt.
- **Boss could spawn with 0 living players** → dormant immortal fixture (worse now that it never auto-despawns). Guarded.
- **Boss phase-2 lances dealt 55 not 70** — they fired at SNIPER speed (720) so the speed→damage classifier gave sniper damage. Now ride a distinct 820 → BOSS_LANCE 70.
- **Boss phase-3 mites unbounded** — `enemies[]` could balloon over a long phase 3. Capped (`BOSS_BROOD_CAP`).
- **Respawn confined to the base 1-player box** in grown arenas — players respawned outside the visible barrier. Now uses live `playW/playH`.
- **Opening asteroid field seeded at base bounds** — now seeded for the current player count.
- **playW/playH sync** — piggybacked on every shared patch (host-migration safety) + clamped on receive (defensive).

## Verified
Typecheck + lint + build clean. Live 2-client re-test: boss persists through breather cycles + syncs (HP bar on guest), leveled remote ships render, map scaling syncs. Solo dev-hook checks: respawn reaches the grown arena (maxX 7351 in a 7680 arena), boss lance speed = 820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0f2f118e84988f3be429d3e9e2b8e7929189e212. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctness pass for Starfall v5 after an adversarial review and a live 2‑client test. Fixes boss lifecycle, projectile damage, spawn/respawn bounds, and playfield sync to improve multiplayer stability.

- **Bug Fixes**
  - Boss exempt from breather auto-despawn.
  - Boss won’t spawn with zero living players.
  - Boss phase‑2 lances use `BOSS_LANCE_SHOT_SPEED` (820) so damage is 70, not sniper 55.
  - Cap phase‑3 mites with `BOSS_BROOD_CAP` to prevent unbounded enemy growth.
  - Respawn points use live `playW`/`playH` with margin, not the base 1‑player box.
  - Seed the opening asteroid field within current player‑count bounds.
  - Always piggyback `playW`/`playH` in shared patches and clamp on receive for safe, consistent sync.

<sup>Written for commit 0f2f118e84988f3be429d3e9e2b8e7929189e212. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

