### PR TITLE
starfall: base weapon fires forward at all levels

### DIFF
--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -357,9 +357,10 @@ export const WEAPON_DEFAULT: Weapon = {
 };
 
 /** Your BASE weapon at a given level: an upgraded NORMAL BEAM (more power, faster
- *  cadence, +width and a 2-pellet spread at the top, a rear mirror shot at the
- *  cap). Tuned to stay a clear notch BELOW the special weapons — picking up a
- *  special is always still an upgrade — so the level power gap stays narrow.
+ *  cadence, +width and an extra forward pellet per level). Tuned to stay a clear
+ *  notch BELOW the special weapons — picking up a special is always still an
+ *  upgrade — so the level power gap stays narrow. All pellets fire FORWARD; the
+ *  level count is the pellet count (L1 → 1, L2 → 2, L3 → 3) fanned tightly.
  *  Specials override temporarily; on expiry/respawn you revert to THIS, not L1. */
 export function baseWeaponForLevel(level: number): Weapon {
   const L = Math.max(1, Math.min(LEVEL_CAP, Math.round(level)));
@@ -372,10 +373,10 @@ export function baseWeaponForLevel(level: number): Weapon {
     power,
     intervalMs,
     width: L >= 3 ? 2 : 1,
-    pellets: L >= 3 ? 2 : 1, // L3 (cap): a tight 2-shot spread for crowd clear
-    spreadDeg: L >= 3 ? 6 : 0,
+    pellets: L, // L1 → 1, L2 → 2, L3 → 3 forward shots
+    spreadDeg: (L - 1) * 7, // tight forward fan: L2 7°, L3 14° (center stays straight)
     jitterDeg: L >= 3 ? 2 : 1,
-    mirror: L >= 3, // capstone: a rear shot like MIRROR
+    mirror: false, // base weapon never fires backward
     tint,
     sfx: "pulse",
   };


### PR DESCRIPTION
## What

In starfall, the level-3 base ship weapon fired a rear (backward) shot via the `mirror` flag. This changes the level-based base weapon so it only ever adds **forward** firepower:

- **Level 1** → 1 shot
- **Level 2** → 2 shots (tight 7° forward fan)
- **Level 3** → 3 shots (tight 14° forward fan, center stays straight)

The backward `mirror` shot at the cap is removed.

## Why

Per request: "level 3 ships shouldn't shoot backwards. level 2 = 2 shots, 3 = 3 shots, all shoot forwards."

## Changes

`games/starfall/src/shared/constants.ts` — `baseWeaponForLevel()`:
- `pellets`: now `L` (was `L >= 3 ? 2 : 1`)
- `spreadDeg`: now `(L - 1) * 7` for a tight forward fan (was `L >= 3 ? 6 : 0`)
- `mirror`: now always `false` (was `L >= 3`)

Picked-up special weapons are unaffected — `MIRROR` and others keep their own behavior.

## Verification

- `pnpm --filter @repo/starfall typecheck` passes.

https://claude.ai/code/session_01VGYjk6xcffg5QgjrU1tn2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGYjk6xcffg5QgjrU1tn2F)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-function gameplay tuning in weapon constants; no networking, persistence, or special-weapon behavior changes.
> 
> **Overview**
> **Starfall** retunes the level-scaled default **BEAM** in `baseWeaponForLevel()` so higher levels add **forward** firepower only—no backward shots.
> 
> **Pellet count** now follows ship level (**L1 → 1**, **L2 → 2**, **L3 → 3**) instead of capping at two pellets at L3. **Spread** uses a tight forward fan (`spreadDeg: (L - 1) * 7`, so 7° at L2 and 14° at L3). **`mirror` is always `false`** for the base weapon, removing the L3 rear shot that previously mimicked the **MIRROR** special.
> 
> Picked-up specials (including **MIRROR**) are unchanged; only the default leveled beam stats change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adda9411f78c95950398b7fb9a91dbf85e3db6a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Base weapon now fires only forward at all levels. L1=1 shot, L2=2 shots in a tight 7° fan, L3=3 shots in a 14° forward fan; removed the L3 rear mirror shot.

<sup>Written for commit adda9411f78c95950398b7fb9a91dbf85e3db6a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

