### PR TITLE
Migrate cn() to cnfast

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -5,7 +5,7 @@ Shared UI components, hooks, and global styles for the web app.
 ## Stack
 
 - [Base UI](https://base-ui.com) primitives, shadcn-style component wrappers
-- [Tailwind CSS 4](https://tailwindcss.com) + `class-variance-authority` + `tailwind-merge`
+- [Tailwind CSS 4](https://tailwindcss.com) + `class-variance-authority` + `cnfast`
 - [motion](https://motion.dev) for animation, [sonner](https://sonner.emilkowal.ski) for toasts
 
 ## Usage

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,12 +17,11 @@
   "dependencies": {
     "@base-ui/react": "^1.5.0",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cnfast": "^0.0.8",
     "lucide-react": "^1.16.0",
     "motion": "^12.40.0",
     "shadcn": "^4.8.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "web-haptics": "^0.0.6"
   },

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cnfast";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,9 +605,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cnfast:
+        specifier: ^0.0.8
+        version: 0.0.8
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.6)
@@ -623,9 +623,6 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -4128,6 +4125,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cnfast@0.0.8:
+    resolution: {integrity: sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==}
+    hasBin: true
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -11107,6 +11108,8 @@ snapshots:
     optional: true
 
   clsx@2.1.1: {}
+
+  cnfast@0.0.8: {}
 
   code-block-writer@13.0.3: {}
 


### PR DESCRIPTION
## What

Migrates the `cn()` class-merging utility in `@repo/ui` from the `clsx` + `tailwind-merge` combo to [`cnfast`](https://github.com/aidenybai/cnfast) — a drop-in replacement that benchmarks ~3.8x faster than `tailwind-merge` with identical output across 113k+ real-world test cases.

## Changes

- `packages/ui/src/lib/utils.ts` — now simply re-exports `cn` from `cnfast`:
  ```ts
  export { cn } from "cnfast";
  ```
- `packages/ui/package.json` — add `cnfast`, drop the `clsx` and `tailwind-merge` direct deps.
  - `clsx` stays in the tree transitively via `class-variance-authority`; `tailwind-merge` via `shadcn`. No other source file imported either directly (only `utils.ts` did).
- `packages/ui/README.md` — stack note updated.
- `pnpm-lock.yaml` — refreshed.

## Verification

- `pnpm --filter @repo/ui typecheck` passes.
- Runtime sanity check confirms identical merge behavior, including Tailwind conflict resolution:
  - `cn("px-2 py-1", { "text-red-500": true }, "px-4")` → `py-1 text-red-500 px-4`
  - `cn("p-2", "p-4")` → `p-4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHA5PNuPQoy4HAgBGsh1fZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHA5PNuPQoy4HAgBGsh1fZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Drop-in utility swap with unchanged public API; main risk is subtle Tailwind class-merge behavior differences if cnfast diverges from tailwind-merge in edge cases.
> 
> **Overview**
> **@repo/ui** swaps the internal implementation of **`cn()`** for **[`cnfast`](https://github.com/aidenybai/cnfast)** while keeping the same import path (`@repo/ui/lib/utils`).
> 
> `utils.ts` no longer wraps **`clsx`** + **`tailwind-merge`**; it re-exports **`cn`** from **`cnfast`**. Direct dependencies **`clsx`** and **`tailwind-merge`** are removed from **`package.json`** (they may still appear transitively via other packages). The README stack line documents **`cnfast`** instead of **`tailwind-merge`**, and the lockfile is updated accordingly.
> 
> No component import sites change—callers still use **`cn`** from **`@repo/ui/lib/utils`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d1c228f84ed9ed8e266ab3520570267144e976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the `cn()` utility in `@repo/ui` to `cnfast` for faster class merging with identical output. No API changes or migration needed.

- **Refactors**
  - `packages/ui/src/lib/utils.ts`: re-export `cn` from `cnfast`.
  - Update `packages/ui/README.md` stack note.

- **Dependencies**
  - Add `cnfast`.
  - Remove direct `clsx` and `tailwind-merge` in `@repo/ui` (still present transitively via `class-variance-authority` and `shadcn`).

<sup>Written for commit 28d1c228f84ed9ed8e266ab3520570267144e976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

