### PR TITLE
Document remote-session vg setup (no SessionStart hook)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Re-run `pnpm dogfood` after adding or removing a skill, then commit the symlink 
 
 Remote sessions clone the repo fresh into an ephemeral container. The committed `.claude/skills/` symlinks mean **skills resolve without any setup** — but `node_modules` and the `vg` CLI are not present, and `vg` is not on PATH. Most sessions (editing web/party/game code, running `pnpm typecheck`/`lint`/tests) only need `pnpm install`.
 
-There's deliberately **no SessionStart hook** — full end-to-end `vg` testing is an explicit activity, not something every session should pay for. When you actually need to exercise the CLI end-to-end (`vg deploy`, `vg generate`, `vg whoami`), run the one-shot setup yourself:
+Full end-to-end `vg` testing is an explicit activity, not something every session needs, so setup isn't automated. When you actually need to exercise the CLI end-to-end (`vg deploy`, `vg generate`, `vg whoami`), run the one-shot setup yourself:
 
 ```bash
 pnpm install && pnpm dogfood   # installs deps, builds + npm-links vg, syncs skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,20 @@ Schema workflow: edit `packages/db/src/drizzle-schema*.ts` → `pnpm db:push-loc
 `pnpm dogfood` builds + npm-links the local `vg` CLI and syncs `.claude/skills/` to match `plugins/*/skills/*` (creates new relative symlinks, removes stale ones). Symlinks are committed, so a fresh clone gets working skills automatically — only the `npm link` step is per-machine. `pnpm dogfood:reset` undoes the link.
 
 Re-run `pnpm dogfood` after adding or removing a skill, then commit the symlink change in `.claude/skills/`.
+
+## Claude Code on the web (remote sessions)
+
+Remote sessions clone the repo fresh into an ephemeral container. The committed `.claude/skills/` symlinks mean **skills resolve without any setup** — but `node_modules` and the `vg` CLI are not present, and `vg` is not on PATH. Most sessions (editing web/party/game code, running `pnpm typecheck`/`lint`/tests) only need `pnpm install`.
+
+There's deliberately **no SessionStart hook** — full end-to-end `vg` testing is an explicit activity, not something every session should pay for. When you actually need to exercise the CLI end-to-end (`vg deploy`, `vg generate`, `vg whoami`), run the one-shot setup yourself:
+
+```bash
+pnpm install && pnpm dogfood   # installs deps, builds + npm-links vg, syncs skills
+```
+
+For `vg` to reach the backend from a remote session you also need:
+
+- **Auth:** set `VG_TOKEN` as an environment secret on the cloud environment. Device-code `vg login` needs a browser and will block an agent. `VG_API_URL` defaults to prod (`vibedgames.com`); override it for local/staging. (See the headless-auth note above for the local seeded token.)
+- **Network:** the environment's network policy must allow egress to `registry.npmjs.org` (for `pnpm install`) and the target API host.
+
+Heed the prod-R2 footgun above: a successful `vg deploy` writes to **production** R2 regardless of which D1 the API points at.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,17 +119,8 @@ Re-run `pnpm dogfood` after adding or removing a skill, then commit the symlink 
 
 ## Claude Code on the web (remote sessions)
 
-Remote sessions clone the repo fresh into an ephemeral container. The committed `.claude/skills/` symlinks mean **skills resolve without any setup** — but `node_modules` and the `vg` CLI are not present, and `vg` is not on PATH. Most sessions (editing web/party/game code, running `pnpm typecheck`/`lint`/tests) only need `pnpm install`.
+A fresh remote clone resolves `.claude/skills/` automatically (the symlinks are committed), but `node_modules` and the `vg` CLI are not present and `vg` is not on PATH. Most sessions only need `pnpm install`; for end-to-end CLI testing (`vg deploy`/`generate`/`whoami`) run `pnpm install && pnpm dogfood` (see Dogfooding above). To reach the backend you also need:
 
-Full end-to-end `vg` testing is an explicit activity, not something every session needs, so setup isn't automated. When you actually need to exercise the CLI end-to-end (`vg deploy`, `vg generate`, `vg whoami`), run the one-shot setup yourself:
-
-```bash
-pnpm install && pnpm dogfood   # installs deps, builds + npm-links vg, syncs skills
-```
-
-For `vg` to reach the backend from a remote session you also need:
-
-- **Auth:** set `VG_TOKEN` as an environment secret on the cloud environment. Device-code `vg login` needs a browser and will block an agent. `VG_API_URL` defaults to prod (`vibedgames.com`); override it for local/staging. (See the headless-auth note above for the local seeded token.)
-- **Network:** the environment's network policy must allow egress to `registry.npmjs.org` (for `pnpm install`) and the target API host.
-
-Heed the prod-R2 footgun above: a successful `vg deploy` writes to **production** R2 regardless of which D1 the API points at.
+- **Auth:** `VG_TOKEN` set as an environment secret (device-code `vg login` needs a browser and blocks an agent). `VG_API_URL` defaults to prod; override for local/staging.
+- **Network:** egress allowed to `registry.npmjs.org` and the target API host.
+- **Prod-R2 footgun (above):** a successful `vg deploy` writes to **production** R2 regardless of which D1 the API points at.


### PR DESCRIPTION
## What

Adds a **Claude Code on the web (remote sessions)** section to `CLAUDE.md` documenting how to get the `vg` CLI working end-to-end in a remote container — instead of an always-on `SessionStart` hook.

## Why not a hook (changed from the original approach)

The first cut added a `SessionStart` hook that ran `pnpm install && pnpm dogfood` on every remote session. That's overkill:

- **Skills already work without setup.** The `.claude/skills/` symlinks are committed, so every skill resolves on a fresh clone with zero setup.
- **The only thing requiring execution is linking `vg` to PATH** (for `deploy`/`generate`/`fork`/`release`), and that's only needed when actually doing **full end-to-end testing** — a deliberate, occasional activity, not every session.
- An always-on hook taxes every session (build + link) for something most sessions never use.

So: no hook. Document the one-shot setup and the auth/network prerequisites instead.

## Changes

- **`CLAUDE.md`** — new section covering:
  - what a fresh remote clone has (skills ✅) vs. lacks (`node_modules`, `vg` on PATH)
  - the one-shot `pnpm install && pnpm dogfood` for e2e CLI testing
  - `VG_TOKEN` as an environment secret (device-code `vg login` needs a browser → blocks an agent); `VG_API_URL` defaults to prod
  - network egress requirements (`registry.npmjs.org` + API host)
  - pointer to the existing prod-R2 deploy footgun

No code or config behavior changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or deploy behavior changes.
> 
> **Overview**
> Adds a **Claude Code on the web (remote sessions)** section to `CLAUDE.md` so agents know what works out of the box vs. what needs a one-shot setup.
> 
> It states that committed `.claude/skills/` symlinks resolve on clone without `dogfood`, while `node_modules` and a PATH-visible `vg` require `pnpm install` (and `pnpm install && pnpm dogfood` only for full e2e CLI flows like `deploy`/`generate`/`whoami`). It also documents **`VG_TOKEN`** as an env secret instead of browser `vg login`, optional **`VG_API_URL`**, required egress to npm and the API host, and a cross-link to the existing **prod R2 deploy** footgun.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a49acfc67de8787c24b1ba460a043d3ffd39769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->