### PR TITLE
docs(cli): surface agent-native framing in CLI help and README

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,6 +1,11 @@
 # vibedgames (CLI)
 
-CLI tool for building and deploying games on vibedgames: scaffolding, asset generation, and deploys.
+The `vg` CLI is designed to be driven by a coding agent, not a human. A human
+prompts their agent ("build me a bomberman game"); the agent runs `vg` + the
+bundled skills to scaffold, generate assets, add multiplayer, and deploy.
+Machine-readable output (`--json`), deterministic exit codes, and self-describing
+errors are first-class — optimised so an agent never gets stuck on friction a
+human would tolerate.
 
 ## Install
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -23,7 +23,8 @@ const main = defineCommand({
   meta: {
     name: "vg",
     version: pkg.version,
-    description: "vibedgames CLI",
+    description:
+      "vibedgames CLI — agent-native game deploy & asset tooling (use --json for machine-readable output)",
   },
   subCommands: {
     new: newCommand,


### PR DESCRIPTION
## What

Makes the CLI's agent-first positioning explicit in the two user-facing surfaces where it was previously missing.

The fact that **`vg` is built to be driven by a coding agent, not a human** is the product's core differentiator — but it was only stated in `CLAUDE.md`, which the actual audience (agents, and people evaluating the tool) doesn't read. Everywhere public it was left implicit.

## Changes

- **`apps/cli/src/index.ts`** — top-level `vg --help` description goes from `"vibedgames CLI"` to `"vibedgames CLI — agent-native game deploy & asset tooling (use --json for machine-readable output)"`. This is the highest-leverage spot: an agent inspecting an unfamiliar CLI runs `--help` first.
- **`apps/cli/README.md`** — replaces the neutral opening line with the agent-native framing (human prompts agent → agent runs `vg` + skills), drawn directly from the philosophy in `CLAUDE.md`.

## Why

Surfaces the positioning where it'll actually be seen, with no behavior change — docs/help text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjfDND7knDS4V59MSnysiE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help and README text only; no logic, auth, or deploy paths touched.
> 
> **Overview**
> **Documentation-only:** makes the agent-first positioning visible on public surfaces instead of only in internal docs.
> 
> **`apps/cli/README.md`** replaces the generic “CLI tool for building and deploying games” intro with explicit agent-native framing: humans prompt an agent, the agent runs `vg` and bundled skills, with `--json`, exit codes, and clear errors called out as first-class for agents.
> 
> **`apps/cli/src/index.ts`** updates the root `vg --help` `meta.description` from `"vibedgames CLI"` to text that names agent-native deploy/asset tooling and points agents at `--json` for machine-readable output.
> 
> No runtime or command behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6dddb5e28259026d6fba7e08b71047b419cfcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `vg` CLI’s agent-native positioning explicit in `vg --help` and the CLI README. Emphasizes that `vg` is driven by coding agents and highlights `--json` machine-readable output, deterministic exit codes, and self-describing errors; docs-only change.

<sup>Written for commit df6dddb5e28259026d6fba7e08b71047b419cfcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

