### PR TITLE
Autonomous game studio: a multi-agent loop that builds and evolves a game (apps/agents)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -44,7 +44,7 @@ Run in parallel:
   LAST=$(git tag --list '<tag-prefix>*' --sort=-v:refname | head -1)
   git log --oneline ${LAST:+$LAST..}HEAD -- <pkg-path>
   ```
-  If the log is empty and `--force` was not passed, **drop that package from the release set** with a note. Release whatever remains — a single changed package (e.g. only `@vibedgames/gamepad`) still ships. Stop only if *every* candidate drops (nothing to release).
+  If the log is empty and `--force` was not passed, **drop that package from the release set** with a note. Release whatever remains — a single changed package (e.g. only `@vibedgames/gamepad`) still ships. Stop only if _every_ candidate drops (nothing to release).
 
 ### 2. Bump
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ yarn-error.log*
 # turbo
 .turbo
 
+# autonomous game studio (apps/agents) — generated game workspaces
+apps/agents/.workspaces/
+
 # Supabase
 .branches
 .temp

--- a/apps/agents/.gitignore
+++ b/apps/agents/.gitignore
@@ -1,0 +1,5 @@
+# Generated game workspaces (the autonomous studio writes here).
+.workspaces/
+dist
+node_modules
+.turbo

--- a/apps/agents/.gitignore
+++ b/apps/agents/.gitignore
@@ -1,5 +1,0 @@
-# Generated game workspaces (the autonomous studio writes here).
-.workspaces/
-dist
-node_modules
-.turbo

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -1,0 +1,101 @@
+# @repo/agents — autonomous game studio
+
+A long-running, multi-agent orchestrator that builds **one** browser game
+end-to-end and then **polishes it forever** — with no human in the loop. You
+start it with a one-line idea; it keeps running until you stop it.
+
+It does not reimplement any game knowledge. It drives the **vibedgames skills**
+and the **`vg` CLI** by spawning headless Claude Code sessions (`claude -p`),
+one specialist at a time.
+
+```
+vg-studio start neon-slasher --idea "a top-down neon slasher where every hit shakes the screen"
+# …builds, generates art, ships to neon-slasher.vibedgames.com, then iterates forever…
+vg-studio status neon-slasher     # peek at progress
+vg-studio stop   neon-slasher     # graceful stop (or just Ctrl-C the running process)
+```
+
+## How it works
+
+A single Node process runs a **phase machine**. Each phase invokes one
+specialist as a fresh headless Claude Code session with a role-specific system
+prompt, the dogfooded skills, and the `vg` CLI available:
+
+| Phase      | Specialist        | Does                                                    |
+| ---------- | ----------------- | ------------------------------------------------------- |
+| `spec`     | 🧭 Designer       | Turns the seed idea into a build-ready `spec.md`        |
+| `scaffold` | 🛠️ Engineer       | `vg new` the engine (phaser/threejs) + install          |
+| `assets`   | 🎨 Artist         | `vg generate` the first art set (sprites, VFX, bg)      |
+| `build`    | 🛠️ Engineer       | Core loop + mandatory craft pass                        |
+| `playtest` | 🔎 QA             | Drives the build, files findings + bugs                 |
+| `ship`     | 🚀 Shipper        | `vg deploy ./dist` → `{slug}.vibedgames.com`            |
+
+After the first ship it enters the **forever loop**:
+
+```
+plan (🎬 Director picks the highest-leverage task) → work (the assigned specialist) → playtest → ship → plan → …
+```
+
+### Coordination: the blackboard
+
+Specialists never talk directly — they coordinate through files in
+`<workspace>/.studio/`, which is also the orchestrator's durable memory (so the
+loop survives restarts and individual context windows):
+
+- `state.json` — orchestrator-owned phase / cycle / iteration / deploy URL
+- `spec.md` — the game design (designer)
+- `backlog.json` — prioritized work, `[{id,title,detail,role,priority,status}]` (director)
+- `next.json` — the current assignment `{role, task}` (director → work phase)
+- `playtest.md` — QA findings
+- `journal.md` — append-only history every specialist writes to
+- `STOP` — sentinel; `vg-studio stop` writes it, the loop halts after the current step
+
+The game itself is scaffolded directly into the workspace root (default
+`apps/agents/.workspaces/<slug>/`, gitignored).
+
+## Prerequisites
+
+1. **Claude Code CLI** logged in on your machine (`claude` on `PATH`, or set
+   `CLAUDE_BIN`). The studio uses your existing Claude subscription/login — it
+   shells out to `claude -p`.
+2. **`vg` CLI + skills linked locally:** run `pnpm dogfood` once at the repo
+   root. The orchestrator runs each agent with its cwd inside this repo so
+   Claude Code resolves the skills from `<repo>/.claude/skills`.
+3. Anything `vg generate` / `vg deploy` need (a logged-in `vg`, env from
+   `.env`). The agents call `vg login`-gated commands.
+
+## Install & run
+
+```bash
+pnpm -F @repo/agents build
+node apps/agents/dist/index.js start <slug> --idea "<one-line idea>"
+# or, after `pnpm dogfood` / npm-link, just:  vg-studio start <slug> --idea "..."
+```
+
+### `start` options
+
+| Flag            | Default                          | Meaning                                                              |
+| --------------- | -------------------------------- | ------------------------------------------------------------------- |
+| `--idea`        | — (required for a new game)      | Seed idea. Optional when resuming an existing workspace.            |
+| `--model`       | `sonnet`                         | `claude --model` alias. Try `opus` for higher-craft (pricier) runs. |
+| `--max-cycles`  | `0` (forever)                    | Stop after N specialist runs.                                       |
+| `--max-turns`   | `40`                             | Per-specialist agentic turn ceiling.                                |
+| `--interval`    | `0`                              | ms to pause between specialist runs.                                |
+| `--no-ship`     | off                              | Skip deploys — no production R2 writes (use while testing).         |
+| `--workspace`   | `apps/agents/.workspaces/<slug>` | Override the game workspace dir.                                     |
+| `--guarded`     | off                              | Do **not** auto-approve tools — for debugging only; breaks autonomy.|
+
+Re-running `start <slug>` **resumes** from the saved phase.
+
+## ⚠️ Safety & cost
+
+For unattended autonomy the studio runs each agent with
+`--dangerously-skip-permissions` (disable with `--guarded`, but then it will
+block waiting for approvals and is no longer autonomous). That means agents run
+shell/file tools, **`vg generate` (costs money)** and **`vg deploy` (writes to
+production R2 and publishes a live game)** without asking.
+
+- Use `--no-ship` and/or `--max-cycles` while you're trying it out.
+- Watch the streamed output; stop anytime with `Ctrl-C` or `vg-studio stop <slug>`.
+- `status --json` is machine-readable for monitoring.
+- Approximate spend is tracked in `state.json` (`totalCostUsd`).

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -11,10 +11,27 @@ one specialist at a time.
 
 ```
 vg-studio start neon-slasher --idea "a top-down neon slasher where every hit shakes the screen"
-# …builds, generates art, ships to neon-slasher.vibedgames.com, then iterates forever…
-vg-studio status neon-slasher     # peek at progress
-vg-studio stop   neon-slasher     # graceful stop (or just Ctrl-C the running process)
+# …builds, generates art, iterates forever — but does NOT publish until you approve…
+vg-studio status  neon-slasher    # peek at progress
+vg-studio approve neon-slasher    # publish the current build to neon-slasher.vibedgames.com
+vg-studio stop    neon-slasher    # graceful stop (or just Ctrl-C the running process)
 ```
+
+### Deploys need your approval
+
+By default **nothing goes live without you.** The studio builds, playtests, and
+keeps improving the game locally; when it reaches a release point it stops at the
+gate and waits. Run `vg-studio approve <slug>` to publish the current build —
+that grants **one** deployment, and the next release needs fresh approval. Pass
+`--auto-deploy` on `start` to opt into continuous, unattended deploys instead.
+
+### Choosing where the game lives
+
+The game's project directory defaults to `apps/agents/.workspaces/<slug>/`
+(gitignored). Pass `--dir <path>` to put it anywhere you like — e.g.
+`vg-studio start my-game --idea "…" --dir ~/games/my-game`. If you point it
+**outside this repo**, run `vg init` there first so Claude Code can resolve the
+vibedgames skills. (`stop`, `status`, and `approve` take the same `--dir`.)
 
 ## How it works
 
@@ -29,7 +46,7 @@ prompt, the dogfooded skills, and the `vg` CLI available:
 | `assets`   | 🎨 Artist         | `vg generate` the first art set (sprites, VFX, bg)      |
 | `build`    | 🛠️ Engineer       | Core loop + mandatory craft pass                        |
 | `playtest` | 🔎 QA             | Drives the build, files findings + bugs                 |
-| `ship`     | 🚀 Shipper        | `vg deploy ./dist` → `{slug}.vibedgames.com`            |
+| `ship`     | 🚀 Shipper        | Only with your approval: `vg deploy ./dist` → `{slug}.vibedgames.com` |
 
 After the first ship it enters the **forever loop**, where the Director runs the
 game like a product owner — triaging a typed backlog (bug / feature / gameplay /
@@ -50,13 +67,14 @@ loop survives restarts and individual context windows):
 - `state.json` — orchestrator-owned phase / cycle / iteration / deploy URL
 - `spec.md` — the game design (designer)
 - `backlog.json` — prioritized work, `[{id,title,detail,role,priority,status}]` (director)
-- `next.json` — the current assignment `{role, task}` (director → work phase)
+- `next.json` — the current assignment `{role, type, task}` (director → work phase)
 - `playtest.md` — QA findings
 - `journal.md` — append-only history every specialist writes to
 - `STOP` — sentinel; `vg-studio stop` writes it, the loop halts after the current step
+- `APPROVE` — one-shot deploy approval; `vg-studio approve` writes it, the next ship consumes it
 
-The game itself is scaffolded directly into the workspace root (default
-`apps/agents/.workspaces/<slug>/`, gitignored).
+The game itself is scaffolded directly into the game directory (default
+`apps/agents/.workspaces/<slug>/`, gitignored; override with `--dir`).
 
 ## Prerequisites
 
@@ -88,21 +106,33 @@ node apps/agents/dist/index.js start <slug> --idea "<one-line idea>"
 | `--idle-timeout`| `45`                             | Kill a specialist that emits no output for this many minutes (0 disables). |
 | `--session-timeout`| `120`                         | Absolute cap on a single specialist session, in minutes (0 disables). |
 | `--interval`    | `0`                              | ms to pause between specialist runs.                                |
-| `--skip-ship`     | off                              | Skip deploys — no production R2 writes (use while testing).         |
-| `--workspace`   | `apps/agents/.workspaces/<slug>` | Override the game workspace dir.                                     |
+| `--auto-deploy` | off                              | Deploy automatically. Default OFF — deploys wait for `vg-studio approve`. |
+| `--skip-ship`   | off                              | Never prepare a release at all (use while testing).                 |
+| `--dir`         | `apps/agents/.workspaces/<slug>` | Where the game lives — its project directory.                       |
 | `--guarded`     | off                              | Do **not** auto-approve tools — for debugging only; breaks autonomy.|
 
 Re-running `start <slug>` **resumes** from the saved phase.
+
+### Other commands
+
+```bash
+vg-studio approve <slug>   # grant one deployment of the current build
+vg-studio status  <slug>   # show phase / shipped / live URL / pending approval (--json for machine output)
+vg-studio stop    <slug>   # graceful stop after the current step
+```
 
 ## ⚠️ Safety & cost
 
 For unattended autonomy the studio runs each agent with
 `--dangerously-skip-permissions` (disable with `--guarded`, but then it will
 block waiting for approvals and is no longer autonomous). That means agents run
-shell/file tools, **`vg generate` (costs money)** and **`vg deploy` (writes to
-production R2 and publishes a live game)** without asking.
+shell/file tools and **`vg generate` (costs money)** without asking.
 
-- Use `--skip-ship` and/or `--max-cycles` while you're trying it out.
+- **Deploys are gated by default** — nothing publishes to production until you
+  run `vg-studio approve <slug>`. Only `--auto-deploy` lets the loop publish on
+  its own (it writes to production R2 and serves a live game).
+- Use `--max-cycles` while you're trying it out; `--skip-ship` if you never want
+  it to even prepare a release.
 - Watch the streamed output; stop anytime with `Ctrl-C` or `vg-studio stop <slug>`.
 - `status --json` is machine-readable for monitoring.
 - Approximate spend is tracked in `state.json` (`totalCostUsd`).

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -113,25 +113,25 @@ The game itself is scaffolded directly into the game directory (default
 3. Anything `vg generate` / `vg deploy` need (a logged-in `vg`, env from
    `.env`). The agents call `vg login`-gated commands.
 
-## Install & run
+## Run
 
-Build once, then drive it with the package's pnpm scripts. From `apps/agents/`:
+There's no build step — the scripts run the TypeScript sources directly with
+Node's built-in type stripping (Node ≥ 22.18). From `apps/agents/`:
 
 ```bash
-pnpm build
 pnpm start <slug> --idea "<one-line idea>"
 ```
 
 From the repo root, target the package with `-F`:
 
 ```bash
-pnpm -F @repo/agents build
 pnpm -F @repo/agents start <slug> --idea "<one-line idea>"
 ```
 
-The `start`, `stop`, `status`, and `approve` scripts map to the orchestrator's
-subcommands; everything after the script name (the slug and any flags) is passed
-straight through.
+The `start`, `stop`, `status`, and `approve` scripts each run `node
+src/index.ts <cmd>`; everything after the script name (the slug and any flags)
+is passed straight through. `pnpm typecheck` runs `tsc --noEmit` (the only
+TypeScript step — nothing is emitted).
 
 ### `start` options
 

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -135,20 +135,20 @@ straight through.
 
 ### `start` options
 
-| Flag                | Default                          | Meaning                                                                       |
-| ------------------- | -------------------------------- | ----------------------------------------------------------------------------- |
-| `--idea`            | — (one of idea/context/existing) | Seed idea. Optional with `--context` or when `--dir` has a project.           |
-| `--context`         | —                                | Extra brief: literal text, a file (read inline), or a directory (referenced). |
-| `--model`           | `sonnet`                         | `claude --model` alias. Try `opus` for higher-craft (pricier) runs.           |
-| `--max-cycles`      | `0` (forever)                    | Stop after N specialist runs.                                                 |
-| `--max-turns`       | `40`                             | Per-specialist agentic turn ceiling.                                          |
-| `--idle-timeout`    | `45`                             | Kill a specialist that emits no output for this many minutes (0 disables).    |
-| `--session-timeout` | `120`                            | Absolute cap on a single specialist session, in minutes (0 disables).         |
-| `--interval`        | `0`                              | ms to pause between specialist runs.                                          |
-| `--auto-deploy`     | off                              | Deploy automatically. Default OFF — deploys wait for `pnpm approve <slug>`.   |
-| `--skip-ship`       | off                              | Never prepare a release at all (use while testing).                           |
-| `--dir`             | `apps/agents/.workspaces/<slug>` | Where the game lives — its project directory.                                 |
-| `--guarded`         | off                              | Do **not** auto-approve tools — for debugging only; breaks autonomy.          |
+| Flag                | Default                          | Meaning                                                                          |
+| ------------------- | -------------------------------- | -------------------------------------------------------------------------------- |
+| `--idea`            | — (one of idea/context/existing) | Seed idea. Optional with `--context` or when `--dir` has a project.              |
+| `--context`         | —                                | Extra brief: literal text, a file (read inline), or a directory (referenced).    |
+| `--model`           | `claude-opus-4-8`                | `claude --model`. Defaults to the latest model; pass `sonnet` for a cheaper run. |
+| `--max-cycles`      | `0` (forever)                    | Stop after N specialist runs.                                                    |
+| `--max-turns`       | `40`                             | Per-specialist agentic turn ceiling.                                             |
+| `--idle-timeout`    | `45`                             | Kill a specialist that emits no output for this many minutes (0 disables).       |
+| `--session-timeout` | `120`                            | Absolute cap on a single specialist session, in minutes (0 disables).            |
+| `--interval`        | `0`                              | ms to pause between specialist runs.                                             |
+| `--auto-deploy`     | off                              | Deploy automatically. Default OFF — deploys wait for `pnpm approve <slug>`.      |
+| `--skip-ship`       | off                              | Never prepare a release at all (use while testing).                              |
+| `--dir`             | `apps/agents/.workspaces/<slug>` | Where the game lives — its project directory.                                    |
+| `--guarded`         | off                              | Do **not** auto-approve tools — for debugging only; breaks autonomy.             |
 
 Re-running `pnpm start <slug>` **resumes** from the saved phase.
 

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -20,10 +20,12 @@ vg-studio stop    neon-slasher    # graceful stop (or just Ctrl-C the running pr
 ### Deploys need your approval
 
 By default **nothing goes live without you.** The studio builds, playtests, and
-keeps improving the game locally; when it reaches a release point it stops at the
-gate and waits. Run `vg-studio approve <slug>` to publish the current build —
-that grants **one** deployment, and the next release needs fresh approval. Pass
-`--auto-deploy` on `start` to opt into continuous, unattended deploys instead.
+keeps improving the game locally; when it reaches a release point it does **not**
+publish — it just records that a build is ready. Run `vg-studio approve <slug>`
+and the studio ships the **current** build (after the in-flight step finishes,
+so what goes live is the build you approved, not a newer one). Approval grants
+**one** deployment; the next release needs fresh approval. Pass `--auto-deploy`
+on `start` to opt into continuous, unattended deploys instead.
 
 ### Choosing where the game lives
 

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -80,6 +80,7 @@ node apps/agents/dist/index.js start <slug> --idea "<one-line idea>"
 | `--model`       | `sonnet`                         | `claude --model` alias. Try `opus` for higher-craft (pricier) runs. |
 | `--max-cycles`  | `0` (forever)                    | Stop after N specialist runs.                                       |
 | `--max-turns`   | `40`                             | Per-specialist agentic turn ceiling.                                |
+| `--idle-timeout`| `45`                             | Kill a specialist that emits no output for this many minutes (0 disables). |
 | `--interval`    | `0`                              | ms to pause between specialist runs.                                |
 | `--skip-ship`     | off                              | Skip deploys — no production R2 writes (use while testing).         |
 | `--workspace`   | `apps/agents/.workspaces/<slug>` | Override the game workspace dir.                                     |

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -81,7 +81,7 @@ node apps/agents/dist/index.js start <slug> --idea "<one-line idea>"
 | `--max-cycles`  | `0` (forever)                    | Stop after N specialist runs.                                       |
 | `--max-turns`   | `40`                             | Per-specialist agentic turn ceiling.                                |
 | `--interval`    | `0`                              | ms to pause between specialist runs.                                |
-| `--no-ship`     | off                              | Skip deploys — no production R2 writes (use while testing).         |
+| `--skip-ship`     | off                              | Skip deploys — no production R2 writes (use while testing).         |
 | `--workspace`   | `apps/agents/.workspaces/<slug>` | Override the game workspace dir.                                     |
 | `--guarded`     | off                              | Do **not** auto-approve tools — for debugging only; breaks autonomy.|
 
@@ -95,7 +95,7 @@ block waiting for approvals and is no longer autonomous). That means agents run
 shell/file tools, **`vg generate` (costs money)** and **`vg deploy` (writes to
 production R2 and publishes a live game)** without asking.
 
-- Use `--no-ship` and/or `--max-cycles` while you're trying it out.
+- Use `--skip-ship` and/or `--max-cycles` while you're trying it out.
 - Watch the streamed output; stop anytime with `Ctrl-C` or `vg-studio stop <slug>`.
 - `status --json` is machine-readable for monitoring.
 - Approximate spend is tracked in `state.json` (`totalCostUsd`).

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -27,13 +27,33 @@ so what goes live is the build you approved, not a newer one). Approval grants
 **one** deployment; the next release needs fresh approval. Pass `--auto-deploy`
 on `start` to opt into continuous, unattended deploys instead.
 
-### Choosing where the game lives
+### Choosing where the game lives + building on existing files
 
 The game's project directory defaults to `apps/agents/.workspaces/<slug>/`
 (gitignored). Pass `--dir <path>` to put it anywhere you like — e.g.
 `vg-studio start my-game --idea "…" --dir ~/games/my-game`. If you point it
 **outside this repo**, run `vg init` there first so Claude Code can resolve the
 vibedgames skills. (`stop`, `status`, and `approve` take the same `--dir`.)
+
+If `--dir` points at a directory that **already contains a project**, the studio
+**builds upon it** instead of scaffolding fresh: it reads the existing source,
+adopts the stack/engine, makes it deployable, and evolves it. `--idea` is
+optional in that case.
+
+```bash
+vg-studio start my-proto --dir ~/code/my-proto   # adopt & evolve an existing game
+```
+
+### Giving it context
+
+Pass `--context` to steer the build with more than a one-liner. It accepts:
+
+- **literal text** — `--context "co-op only, controller-first, synthwave palette"`
+- **a file** — `--context ./design-brief.md` (read inline)
+- **a directory** — `--context ./references` (the agents get read access and build upon it)
+
+The brief is written to `<dir>/.studio/context.md` and every specialist reads it
+first. With `--context`, `--idea` is optional.
 
 ## How it works
 
@@ -69,6 +89,7 @@ loop survives restarts and individual context windows):
 - `state.json` — orchestrator-owned phase / cycle / iteration / deploy URL
 - `spec.md` — the game design (designer)
 - `backlog.json` — prioritized work, `[{id,title,detail,role,priority,status}]` (director)
+- `context.md` — optional operator brief / reference (from `--context`), read first by every specialist
 - `next.json` — the current assignment `{role, type, task}` (director → work phase)
 - `playtest.md` — QA findings
 - `journal.md` — append-only history every specialist writes to
@@ -101,7 +122,8 @@ node apps/agents/dist/index.js start <slug> --idea "<one-line idea>"
 
 | Flag            | Default                          | Meaning                                                              |
 | --------------- | -------------------------------- | ------------------------------------------------------------------- |
-| `--idea`        | — (required for a new game)      | Seed idea. Optional when resuming an existing workspace.            |
+| `--idea`        | — (one of idea/context/existing) | Seed idea. Optional with `--context` or when `--dir` has a project. |
+| `--context`     | —                                | Extra brief: literal text, a file (read inline), or a directory (referenced). |
 | `--model`       | `sonnet`                         | `claude --model` alias. Try `opus` for higher-craft (pricier) runs. |
 | `--max-cycles`  | `0` (forever)                    | Stop after N specialist runs.                                       |
 | `--max-turns`   | `40`                             | Per-specialist agentic turn ceiling.                                |

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -9,19 +9,22 @@ It does not reimplement any game knowledge. It drives the **vibedgames skills**
 and the **`vg` CLI** by spawning headless Claude Code sessions (`claude -p`),
 one specialist at a time.
 
+You run it with **pnpm scripts** from `apps/agents/` (or with `-F @repo/agents`
+from the repo root):
+
 ```
-vg-studio start neon-slasher --idea "a top-down neon slasher where every hit shakes the screen"
+pnpm start   neon-slasher --idea "a top-down neon slasher where every hit shakes the screen"
 # …builds, generates art, iterates forever — but does NOT publish until you approve…
-vg-studio status  neon-slasher    # peek at progress
-vg-studio approve neon-slasher    # publish the current build to neon-slasher.vibedgames.com
-vg-studio stop    neon-slasher    # graceful stop (or just Ctrl-C the running process)
+pnpm status  neon-slasher    # peek at progress
+pnpm approve neon-slasher    # publish the current build to neon-slasher.vibedgames.com
+pnpm stop    neon-slasher    # graceful stop (or just Ctrl-C the running process)
 ```
 
 ### Deploys need your approval
 
 By default **nothing goes live without you.** The studio builds, playtests, and
 keeps improving the game locally; when it reaches a release point it does **not**
-publish — it just records that a build is ready. Run `vg-studio approve <slug>`
+publish — it just records that a build is ready. Run `pnpm approve <slug>`
 and the studio ships the **current** build (after the in-flight step finishes,
 so what goes live is the build you approved, not a newer one). Approval grants
 **one** deployment; the next release needs fresh approval. Pass `--auto-deploy`
@@ -31,7 +34,7 @@ on `start` to opt into continuous, unattended deploys instead.
 
 The game's project directory defaults to `apps/agents/.workspaces/<slug>/`
 (gitignored). Pass `--dir <path>` to put it anywhere you like — e.g.
-`vg-studio start my-game --idea "…" --dir ~/games/my-game`. If you point it
+`pnpm start my-game --idea "…" --dir ~/games/my-game`. If you point it
 **outside this repo**, run `vg init` there first so Claude Code can resolve the
 vibedgames skills. (`stop`, `status`, and `approve` take the same `--dir`.)
 
@@ -41,7 +44,7 @@ adopts the stack/engine, makes it deployable, and evolves it. `--idea` is
 optional in that case.
 
 ```bash
-vg-studio start my-proto --dir ~/code/my-proto   # adopt & evolve an existing game
+pnpm start my-proto --dir ~/code/my-proto   # adopt & evolve an existing game
 ```
 
 ### Giving it context
@@ -61,19 +64,19 @@ A single Node process runs a **phase machine**. Each phase invokes one
 specialist as a fresh headless Claude Code session with a role-specific system
 prompt, the dogfooded skills, and the `vg` CLI available:
 
-| Phase      | Specialist        | Does                                                    |
-| ---------- | ----------------- | ------------------------------------------------------- |
-| `spec`     | 🧭 Designer       | Turns the seed idea into a build-ready `spec.md`        |
-| `scaffold` | 🛠️ Engineer       | `vg new` the engine (phaser/threejs) + install          |
-| `assets`   | 🎨 Artist         | `vg generate` the first art set (sprites, VFX, bg)      |
-| `build`    | 🛠️ Engineer       | Core loop + mandatory craft pass                        |
-| `playtest` | 🔎 QA             | Drives the build, files findings + bugs                 |
-| `ship`     | 🚀 Shipper        | Only with your approval: `vg deploy ./dist` → `{slug}.vibedgames.com` |
+| Phase      | Specialist  | Does                                                                  |
+| ---------- | ----------- | --------------------------------------------------------------------- |
+| `spec`     | 🧭 Designer | Turns the seed idea into a build-ready `spec.md`                      |
+| `scaffold` | 🛠️ Engineer | `vg new` the engine (phaser/threejs) + install                        |
+| `assets`   | 🎨 Artist   | `vg generate` the first art set (sprites, VFX, bg)                    |
+| `build`    | 🛠️ Engineer | Core loop + mandatory craft pass                                      |
+| `playtest` | 🔎 QA       | Drives the build, files findings + bugs                               |
+| `ship`     | 🚀 Shipper  | Only with your approval: `vg deploy ./dist` → `{slug}.vibedgames.com` |
 
 After the first ship it enters the **forever loop**, where the Director runs the
 game like a product owner — triaging a typed backlog (bug / feature / gameplay /
 balance / content / polish / art), fixing ship-stoppers first, then picking the
-highest-impact work for the game's current maturity so it keeps *growing*, not
+highest-impact work for the game's current maturity so it keeps _growing_, not
 just glistening:
 
 ```
@@ -93,8 +96,8 @@ loop survives restarts and individual context windows):
 - `next.json` — the current assignment `{role, type, task}` (director → work phase)
 - `playtest.md` — QA findings
 - `journal.md` — append-only history every specialist writes to
-- `STOP` — sentinel; `vg-studio stop` writes it, the loop halts after the current step
-- `APPROVE` — one-shot deploy approval; `vg-studio approve` writes it, the next ship consumes it
+- `STOP` — sentinel; `pnpm stop` writes it, the loop halts after the current step
+- `APPROVE` — one-shot deploy approval; `pnpm approve` writes it, the next ship consumes it
 
 The game itself is scaffolded directly into the game directory (default
 `apps/agents/.workspaces/<slug>/`, gitignored; override with `--dir`).
@@ -112,37 +115,49 @@ The game itself is scaffolded directly into the game directory (default
 
 ## Install & run
 
+Build once, then drive it with the package's pnpm scripts. From `apps/agents/`:
+
+```bash
+pnpm build
+pnpm start <slug> --idea "<one-line idea>"
+```
+
+From the repo root, target the package with `-F`:
+
 ```bash
 pnpm -F @repo/agents build
-node apps/agents/dist/index.js start <slug> --idea "<one-line idea>"
-# or, after `pnpm dogfood` / npm-link, just:  vg-studio start <slug> --idea "..."
+pnpm -F @repo/agents start <slug> --idea "<one-line idea>"
 ```
+
+The `start`, `stop`, `status`, and `approve` scripts map to the orchestrator's
+subcommands; everything after the script name (the slug and any flags) is passed
+straight through.
 
 ### `start` options
 
-| Flag            | Default                          | Meaning                                                              |
-| --------------- | -------------------------------- | ------------------------------------------------------------------- |
-| `--idea`        | — (one of idea/context/existing) | Seed idea. Optional with `--context` or when `--dir` has a project. |
-| `--context`     | —                                | Extra brief: literal text, a file (read inline), or a directory (referenced). |
-| `--model`       | `sonnet`                         | `claude --model` alias. Try `opus` for higher-craft (pricier) runs. |
-| `--max-cycles`  | `0` (forever)                    | Stop after N specialist runs.                                       |
-| `--max-turns`   | `40`                             | Per-specialist agentic turn ceiling.                                |
-| `--idle-timeout`| `45`                             | Kill a specialist that emits no output for this many minutes (0 disables). |
-| `--session-timeout`| `120`                         | Absolute cap on a single specialist session, in minutes (0 disables). |
-| `--interval`    | `0`                              | ms to pause between specialist runs.                                |
-| `--auto-deploy` | off                              | Deploy automatically. Default OFF — deploys wait for `vg-studio approve`. |
-| `--skip-ship`   | off                              | Never prepare a release at all (use while testing).                 |
-| `--dir`         | `apps/agents/.workspaces/<slug>` | Where the game lives — its project directory.                       |
-| `--guarded`     | off                              | Do **not** auto-approve tools — for debugging only; breaks autonomy.|
+| Flag                | Default                          | Meaning                                                                       |
+| ------------------- | -------------------------------- | ----------------------------------------------------------------------------- |
+| `--idea`            | — (one of idea/context/existing) | Seed idea. Optional with `--context` or when `--dir` has a project.           |
+| `--context`         | —                                | Extra brief: literal text, a file (read inline), or a directory (referenced). |
+| `--model`           | `sonnet`                         | `claude --model` alias. Try `opus` for higher-craft (pricier) runs.           |
+| `--max-cycles`      | `0` (forever)                    | Stop after N specialist runs.                                                 |
+| `--max-turns`       | `40`                             | Per-specialist agentic turn ceiling.                                          |
+| `--idle-timeout`    | `45`                             | Kill a specialist that emits no output for this many minutes (0 disables).    |
+| `--session-timeout` | `120`                            | Absolute cap on a single specialist session, in minutes (0 disables).         |
+| `--interval`        | `0`                              | ms to pause between specialist runs.                                          |
+| `--auto-deploy`     | off                              | Deploy automatically. Default OFF — deploys wait for `pnpm approve <slug>`.   |
+| `--skip-ship`       | off                              | Never prepare a release at all (use while testing).                           |
+| `--dir`             | `apps/agents/.workspaces/<slug>` | Where the game lives — its project directory.                                 |
+| `--guarded`         | off                              | Do **not** auto-approve tools — for debugging only; breaks autonomy.          |
 
-Re-running `start <slug>` **resumes** from the saved phase.
+Re-running `pnpm start <slug>` **resumes** from the saved phase.
 
 ### Other commands
 
 ```bash
-vg-studio approve <slug>   # grant one deployment of the current build
-vg-studio status  <slug>   # show phase / shipped / live URL / pending approval (--json for machine output)
-vg-studio stop    <slug>   # graceful stop after the current step
+pnpm approve <slug>   # grant one deployment of the current build
+pnpm status  <slug>   # show phase / shipped / live URL / pending approval (--json for machine output)
+pnpm stop    <slug>   # graceful stop after the current step
 ```
 
 ## ⚠️ Safety & cost
@@ -153,10 +168,10 @@ block waiting for approvals and is no longer autonomous). That means agents run
 shell/file tools and **`vg generate` (costs money)** without asking.
 
 - **Deploys are gated by default** — nothing publishes to production until you
-  run `vg-studio approve <slug>`. Only `--auto-deploy` lets the loop publish on
+  run `pnpm approve <slug>`. Only `--auto-deploy` lets the loop publish on
   its own (it writes to production R2 and serves a live game).
 - Use `--max-cycles` while you're trying it out; `--skip-ship` if you never want
   it to even prepare a release.
-- Watch the streamed output; stop anytime with `Ctrl-C` or `vg-studio stop <slug>`.
+- Watch the streamed output; stop anytime with `Ctrl-C` or `pnpm stop <slug>`.
 - `status --json` is machine-readable for monitoring.
 - Approximate spend is tracked in `state.json` (`totalCostUsd`).

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -86,6 +86,7 @@ node apps/agents/dist/index.js start <slug> --idea "<one-line idea>"
 | `--max-cycles`  | `0` (forever)                    | Stop after N specialist runs.                                       |
 | `--max-turns`   | `40`                             | Per-specialist agentic turn ceiling.                                |
 | `--idle-timeout`| `45`                             | Kill a specialist that emits no output for this many minutes (0 disables). |
+| `--session-timeout`| `120`                         | Absolute cap on a single specialist session, in minutes (0 disables). |
 | `--interval`    | `0`                              | ms to pause between specialist runs.                                |
 | `--skip-ship`     | off                              | Skip deploys — no production R2 writes (use while testing).         |
 | `--workspace`   | `apps/agents/.workspaces/<slug>` | Override the game workspace dir.                                     |

--- a/apps/agents/README.md
+++ b/apps/agents/README.md
@@ -1,8 +1,9 @@
 # @repo/agents — autonomous game studio
 
 A long-running, multi-agent orchestrator that builds **one** browser game
-end-to-end and then **polishes it forever** — with no human in the loop. You
-start it with a one-line idea; it keeps running until you stop it.
+end-to-end and then **runs it like a studio** — shipping bug fixes, new
+features, gameplay & balance iteration, content, and polish — with no human in
+the loop. You start it with a one-line idea; it keeps running until you stop it.
 
 It does not reimplement any game knowledge. It drives the **vibedgames skills**
 and the **`vg` CLI** by spawning headless Claude Code sessions (`claude -p`),
@@ -30,10 +31,14 @@ prompt, the dogfooded skills, and the `vg` CLI available:
 | `playtest` | 🔎 QA             | Drives the build, files findings + bugs                 |
 | `ship`     | 🚀 Shipper        | `vg deploy ./dist` → `{slug}.vibedgames.com`            |
 
-After the first ship it enters the **forever loop**:
+After the first ship it enters the **forever loop**, where the Director runs the
+game like a product owner — triaging a typed backlog (bug / feature / gameplay /
+balance / content / polish / art), fixing ship-stoppers first, then picking the
+highest-impact work for the game's current maturity so it keeps *growing*, not
+just glistening:
 
 ```
-plan (🎬 Director picks the highest-leverage task) → work (the assigned specialist) → playtest → ship → plan → …
+plan (🎬 Director triages the backlog & assigns the next item) → work (designer | engineer | artist | QA) → playtest → ship → plan → …
 ```
 
 ### Coordination: the blackboard

--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@repo/agents",
+  "version": "0.0.0",
+  "private": true,
+  "bin": {
+    "vg-studio": "./dist/index.js"
+  },
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "clean": "rm -rf .turbo dist node_modules .workspaces",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "citty": "^0.2.2",
+    "consola": "^3.4.2"
+  },
+  "devDependencies": {
+    "@kyh/tsconfig": "catalog:",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -4,13 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "start": "node dist/index.js start",
-    "stop": "node dist/index.js stop",
-    "status": "node dist/index.js status",
-    "approve": "node dist/index.js approve",
-    "clean": "rm -rf .turbo dist node_modules .workspaces",
+    "start": "node src/index.ts start",
+    "stop": "node src/index.ts stop",
+    "status": "node src/index.ts status",
+    "approve": "node src/index.ts approve",
+    "clean": "rm -rf .turbo .cache node_modules .workspaces",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -2,14 +2,14 @@
   "name": "@repo/agents",
   "version": "0.0.0",
   "private": true,
-  "bin": {
-    "vg-studio": "./dist/index.js"
-  },
   "type": "module",
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "start": "node dist/index.js",
+    "start": "node dist/index.js start",
+    "stop": "node dist/index.js stop",
+    "status": "node dist/index.js status",
+    "approve": "node dist/index.js approve",
     "clean": "rm -rf .turbo dist node_modules .workspaces",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/agents/src/claude.ts
+++ b/apps/agents/src/claude.ts
@@ -18,6 +18,10 @@ import consola from "consola";
  */
 const RESULT_EXIT_GRACE_MS = 10_000;
 
+/** Human-friendly duration for watchdog messages ("45m", "3s"). */
+const fmtMs = (ms: number): string =>
+  ms >= 60_000 ? `${Math.round(ms / 60_000)}m` : `${Math.round(ms / 1000)}s`;
+
 export type RunOptions = {
   /** The task prompt (the "user" turn). */
   prompt: string;
@@ -42,6 +46,13 @@ export type RunOptions = {
    * Reset on every event, so it never fires during active work. 0 disables it.
    */
   idleTimeoutMs: number;
+  /**
+   * Absolute ceiling on a single session, regardless of activity (ms; 0
+   * disables). Catches a session that keeps streaming events but never emits a
+   * terminal `result` — which the idle watchdog can't, since output keeps
+   * resetting it.
+   */
+  maxSessionMs: number;
 };
 
 export type RunResult = {
@@ -85,6 +96,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
     let settled = false;
     let graceTimer: ReturnType<typeof setTimeout> | undefined;
     let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let sessionTimer: ReturnType<typeof setTimeout> | undefined;
 
     // Watchdog: if the session produces no output at all for idleTimeoutMs, the
     // process is wedged (or a tool is stuck) — kill it and fail so the phase
@@ -99,14 +111,10 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
         } catch {
           /* already gone */
         }
-        const idle =
-          opts.idleTimeoutMs >= 60_000
-            ? `${Math.round(opts.idleTimeoutMs / 60_000)}m`
-            : `${Math.round(opts.idleTimeoutMs / 1000)}s`;
         settle({
           ok: false,
           result: "",
-          error: `no output for ${idle} — treating claude as hung`,
+          error: `no output for ${fmtMs(opts.idleTimeoutMs)} — treating claude as hung`,
         });
       }, opts.idleTimeoutMs);
       idleTimer.unref?.();
@@ -121,6 +129,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       settled = true;
       if (graceTimer) clearTimeout(graceTimer);
       if (idleTimer) clearTimeout(idleTimer);
+      if (sessionTimer) clearTimeout(sessionTimer);
       try {
         rl?.close();
       } catch {
@@ -152,7 +161,25 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       return;
     }
 
-    pokeIdle(); // arm the watchdog before the first byte arrives
+    pokeIdle(); // arm the inactivity watchdog before the first byte arrives
+
+    // Absolute ceiling: fires even while the session is actively streaming, so a
+    // run that never emits a terminal `result` can't hang the loop forever.
+    if (opts.maxSessionMs > 0) {
+      sessionTimer = setTimeout(() => {
+        try {
+          child?.kill("SIGKILL");
+        } catch {
+          /* already gone */
+        }
+        settle({
+          ok: false,
+          result: "",
+          error: `exceeded the ${fmtMs(opts.maxSessionMs)} session limit — killed`,
+        });
+      }, opts.maxSessionMs);
+      sessionTimer.unref?.();
+    }
 
     rl = createInterface({ input: child.stdout! });
     rl.on("line", (line) => {
@@ -168,7 +195,10 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       printEvent(opts.label, evt);
       if (evt.type === "result") {
         gotResult = true;
-        if (idleTimer) clearTimeout(idleTimer); // grace timer governs from here
+        // The grace timer governs from here; stand down the watchdogs so a late
+        // idle/session deadline can't clobber a result we already have.
+        if (idleTimer) clearTimeout(idleTimer);
+        if (sessionTimer) clearTimeout(sessionTimer);
         final = {
           ok: evt.subtype === "success" && !evt.is_error,
           result: typeof evt.result === "string" ? evt.result : "",

--- a/apps/agents/src/claude.ts
+++ b/apps/agents/src/claude.ts
@@ -74,6 +74,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
     }
 
     let final: RunResult = { ok: false, result: "" };
+    let gotResult = false;
     let stderr = "";
 
     const rl = createInterface({ input: child.stdout! });
@@ -88,6 +89,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       }
       printEvent(opts.label, evt);
       if (evt.type === "result") {
+        gotResult = true;
         final = {
           ok: evt.subtype === "success" && !evt.is_error,
           result: typeof evt.result === "string" ? evt.result : "",
@@ -108,14 +110,17 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
     });
 
     child.on("close", (code) => {
-      if (final.result || final.ok || code === 0) {
-        resolvePromise(final.result || final.ok ? final : { ...final, ok: true });
+      // Success is defined solely by a parsed stream-json `result` event — a
+      // bare exit 0 with no result means we have no confirmed outcome, so we
+      // treat it as a failure rather than silently advancing the phase.
+      if (gotResult) {
+        resolvePromise(final);
         return;
       }
       resolvePromise({
         ok: false,
-        result: final.result,
-        error: stderr.trim() || `claude exited with code ${code}`,
+        result: "",
+        error: stderr.trim() || `claude exited with code ${code} without a result event`,
       });
     });
   });

--- a/apps/agents/src/claude.ts
+++ b/apps/agents/src/claude.ts
@@ -148,10 +148,23 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       resolvePromise(res);
     };
 
+    // `claude --dangerously-skip-permissions` refuses to run as root/sudo
+    // unless IS_SANDBOX=1 marks the environment as already-isolated. The studio
+    // is built for exactly this — unattended runs in containers/CI, often as
+    // root — and the operator has already opted into skip-permissions, so set
+    // the flag for the child when we're root and asking for it. claude only
+    // accepts the literal "1" (a stray IS_SANDBOX=yes in the env still gets
+    // rejected), so force that value rather than preserving whatever's there.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+    if (opts.skipPermissions && isRoot && env.IS_SANDBOX !== "1") {
+      env.IS_SANDBOX = "1";
+    }
+
     try {
       child = spawn(opts.claudeBin, args, {
         cwd: opts.cwd,
-        env: process.env,
+        env,
         stdio: ["ignore", "pipe", "pipe"],
         signal: opts.signal,
       });

--- a/apps/agents/src/claude.ts
+++ b/apps/agents/src/claude.ts
@@ -3,6 +3,12 @@ import { createInterface } from "node:readline";
 
 import consola from "consola";
 
+// Every resolution path funnels through the `settle()` helper below, which is
+// guarded by a `settled` flag so it resolves exactly once. oxlint's static
+// check can't see that guard and flags each settle() caller, so disable the
+// rule for this file.
+/* oxlint-disable promise/no-multiple-resolved */
+
 /**
  * After the stream-json `result` event arrives we already have the outcome.
  * Normally the CLI exits right after, but stream-json has a known failure mode
@@ -30,6 +36,12 @@ export type RunOptions = {
   signal?: AbortSignal;
   /** Label shown in streamed output, e.g. "engineer". */
   label: string;
+  /**
+   * Kill the session and fail if it produces NO output (no stream-json events,
+   * no stderr) for this long — a watchdog for a wedged `claude`/stuck tool.
+   * Reset on every event, so it never fires during active work. 0 disables it.
+   */
+  idleTimeoutMs: number;
 };
 
 export type RunResult = {
@@ -72,6 +84,33 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
     let stderr = "";
     let settled = false;
     let graceTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+    // Watchdog: if the session produces no output at all for idleTimeoutMs, the
+    // process is wedged (or a tool is stuck) — kill it and fail so the phase
+    // loop and workspace lock can never block forever. Reset on every event, so
+    // it never trips during active work (long-but-busy runs keep emitting).
+    const pokeIdle = (): void => {
+      if (opts.idleTimeoutMs <= 0 || settled || gotResult) return;
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        try {
+          child?.kill("SIGKILL");
+        } catch {
+          /* already gone */
+        }
+        const idle =
+          opts.idleTimeoutMs >= 60_000
+            ? `${Math.round(opts.idleTimeoutMs / 60_000)}m`
+            : `${Math.round(opts.idleTimeoutMs / 1000)}s`;
+        settle({
+          ok: false,
+          result: "",
+          error: `no output for ${idle} — treating claude as hung`,
+        });
+      }, opts.idleTimeoutMs);
+      idleTimer.unref?.();
+    };
 
     // Resolve exactly once and release every handle we hold. Tearing down the
     // pipes/child matters because a killed child's orphaned grandchild can keep
@@ -81,6 +120,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       if (settled) return;
       settled = true;
       if (graceTimer) clearTimeout(graceTimer);
+      if (idleTimer) clearTimeout(idleTimer);
       try {
         rl?.close();
       } catch {
@@ -93,8 +133,6 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       } catch {
         /* ignore */
       }
-      // `settled` guarantees this runs once; oxlint can't see the guard.
-      // oxlint-disable-next-line promise/no-multiple-resolved
       resolvePromise(res);
     };
 
@@ -114,8 +152,11 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       return;
     }
 
+    pokeIdle(); // arm the watchdog before the first byte arrives
+
     rl = createInterface({ input: child.stdout! });
     rl.on("line", (line) => {
+      pokeIdle(); // any output is a sign of life
       const trimmed = line.trim();
       if (!trimmed) return;
       let evt: StreamEvent;
@@ -127,6 +168,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       printEvent(opts.label, evt);
       if (evt.type === "result") {
         gotResult = true;
+        if (idleTimer) clearTimeout(idleTimer); // grace timer governs from here
         final = {
           ok: evt.subtype === "success" && !evt.is_error,
           result: typeof evt.result === "string" ? evt.result : "",
@@ -151,6 +193,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
     });
 
     child.stderr!.on("data", (d: Buffer) => {
+      pokeIdle(); // stderr output is also a sign of life
       stderr += d.toString();
     });
 

--- a/apps/agents/src/claude.ts
+++ b/apps/agents/src/claude.ts
@@ -1,0 +1,168 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+import consola from "consola";
+
+export type RunOptions = {
+  /** The task prompt (the "user" turn). */
+  prompt: string;
+  /** Role definition, appended to Claude Code's system prompt. */
+  systemPrompt: string;
+  /** Working directory — the game workspace. */
+  cwd: string;
+  model: string;
+  maxTurns: number;
+  claudeBin: string;
+  /** Extra dirs the agent may read (e.g. the repo root for skills). */
+  addDirs?: string[];
+  /** Run tools without per-call approval. Required for unattended autonomy. */
+  skipPermissions: boolean;
+  /** Aborts the underlying process (second Ctrl-C). */
+  signal?: AbortSignal;
+  /** Label shown in streamed output, e.g. "engineer". */
+  label: string;
+};
+
+export type RunResult = {
+  ok: boolean;
+  result: string;
+  sessionId?: string;
+  costUsd?: number;
+  numTurns?: number;
+  error?: string;
+};
+
+/**
+ * Invoke a headless Claude Code session and stream a compact view of what it
+ * does. Uses `--output-format stream-json` so the operator can watch the agent
+ * work in real time; the terminal `result` event carries the final summary,
+ * cost and session id.
+ */
+export function runClaude(opts: RunOptions): Promise<RunResult> {
+  const args = [
+    "-p",
+    opts.prompt,
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--model",
+    opts.model,
+    "--append-system-prompt",
+    opts.systemPrompt,
+    "--max-turns",
+    String(opts.maxTurns),
+  ];
+  if (opts.skipPermissions) args.push("--dangerously-skip-permissions");
+  for (const dir of opts.addDirs ?? []) args.push("--add-dir", dir);
+
+  return new Promise((resolvePromise) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(opts.claudeBin, args, {
+        cwd: opts.cwd,
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+        signal: opts.signal,
+      });
+    } catch (err) {
+      resolvePromise({
+        ok: false,
+        result: "",
+        error: `failed to spawn ${opts.claudeBin}: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+
+    let final: RunResult = { ok: false, result: "" };
+    let stderr = "";
+
+    const rl = createInterface({ input: child.stdout! });
+    rl.on("line", (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      let evt: StreamEvent;
+      try {
+        evt = JSON.parse(trimmed) as StreamEvent;
+      } catch {
+        return; // ignore non-JSON noise
+      }
+      printEvent(opts.label, evt);
+      if (evt.type === "result") {
+        final = {
+          ok: evt.subtype === "success" && !evt.is_error,
+          result: typeof evt.result === "string" ? evt.result : "",
+          sessionId: evt.session_id,
+          costUsd: evt.total_cost_usd,
+          numTurns: evt.num_turns,
+          error: evt.is_error ? (evt.result ?? "agent reported an error") : undefined,
+        };
+      }
+    });
+
+    child.stderr!.on("data", (d: Buffer) => {
+      stderr += d.toString();
+    });
+
+    child.on("error", (err: Error) => {
+      resolvePromise({ ok: false, result: "", error: `${opts.claudeBin}: ${err.message}` });
+    });
+
+    child.on("close", (code) => {
+      if (final.result || final.ok || code === 0) {
+        resolvePromise(final.result || final.ok ? final : { ...final, ok: true });
+        return;
+      }
+      resolvePromise({
+        ok: false,
+        result: final.result,
+        error: stderr.trim() || `claude exited with code ${code}`,
+      });
+    });
+  });
+}
+
+type StreamEvent =
+  | { type: "system"; subtype?: string; model?: string; tools?: string[] }
+  | { type: "assistant"; message?: { content?: ContentBlock[] } }
+  | { type: "user"; message?: { content?: ContentBlock[] } }
+  | {
+      type: "result";
+      subtype?: string;
+      is_error?: boolean;
+      result?: string;
+      session_id?: string;
+      total_cost_usd?: number;
+      num_turns?: number;
+    };
+
+type ContentBlock =
+  | { type: "text"; text?: string }
+  | { type: "tool_use"; name?: string; input?: Record<string, unknown> }
+  | { type: "tool_result"; [k: string]: unknown };
+
+function printEvent(label: string, evt: StreamEvent): void {
+  const tag = `  ${label} ·`;
+  if (evt.type === "system" && evt.subtype === "init") {
+    consola.log(
+      `${tag} session started (${evt.model ?? "model"}, ${evt.tools?.length ?? 0} tools)`,
+    );
+    return;
+  }
+  if (evt.type === "assistant") {
+    for (const block of evt.message?.content ?? []) {
+      if (block.type === "text" && block.text?.trim()) {
+        for (const ln of block.text.trim().split("\n")) consola.log(`${tag} ${ln}`);
+      } else if (block.type === "tool_use") {
+        consola.log(`${tag} ⚙ ${block.name ?? "tool"}${summarizeTool(block.input)}`);
+      }
+    }
+  }
+}
+
+function summarizeTool(input?: Record<string, unknown>): string {
+  if (!input) return "";
+  const cmd = input.command ?? input.file_path ?? input.path ?? input.pattern ?? input.prompt;
+  if (typeof cmd !== "string") return "";
+  const oneLine = cmd.replace(/\s+/g, " ").trim();
+  return oneLine ? `  (${oneLine.slice(0, 80)}${oneLine.length > 80 ? "…" : ""})` : "";
+}

--- a/apps/agents/src/claude.ts
+++ b/apps/agents/src/claude.ts
@@ -18,6 +18,9 @@ import consola from "consola";
  */
 const RESULT_EXIT_GRACE_MS = 10_000;
 
+/** Keep only the tail of stderr — it's used solely for final error reporting. */
+const STDERR_TAIL_MAX = 16_000;
+
 /** Human-friendly duration for watchdog messages ("45m", "3s"). */
 const fmtMs = (ms: number): string =>
   ms >= 60_000 ? `${Math.round(ms / 60_000)}m` : `${Math.round(ms / 1000)}s`;
@@ -224,7 +227,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
 
     child.stderr!.on("data", (d: Buffer) => {
       pokeIdle(); // stderr output is also a sign of life
-      stderr += d.toString();
+      stderr = (stderr + d.toString()).slice(-STDERR_TAIL_MAX); // bounded tail
     });
 
     child.on("error", (err: Error) => {

--- a/apps/agents/src/claude.ts
+++ b/apps/agents/src/claude.ts
@@ -3,6 +3,15 @@ import { createInterface } from "node:readline";
 
 import consola from "consola";
 
+/**
+ * After the stream-json `result` event arrives we already have the outcome.
+ * Normally the CLI exits right after, but stream-json has a known failure mode
+ * where it keeps the process alive — so if `close` doesn't fire within this
+ * grace window we kill the child and resolve with the result we have, rather
+ * than blocking the loop (and holding the workspace lock) forever.
+ */
+const RESULT_EXIT_GRACE_MS = 10_000;
+
 export type RunOptions = {
   /** The task prompt (the "user" turn). */
   prompt: string;
@@ -56,7 +65,39 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
   for (const dir of opts.addDirs ?? []) args.push("--add-dir", dir);
 
   return new Promise((resolvePromise) => {
-    let child: ReturnType<typeof spawn>;
+    let child: ReturnType<typeof spawn> | undefined;
+    let rl: ReturnType<typeof createInterface> | undefined;
+    let final: RunResult = { ok: false, result: "" };
+    let gotResult = false;
+    let stderr = "";
+    let settled = false;
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    // Resolve exactly once and release every handle we hold. Tearing down the
+    // pipes/child matters because a killed child's orphaned grandchild can keep
+    // the stdout pipe (and thus the event loop) alive after we already have our
+    // answer — without this, the loop could never exit cleanly.
+    const settle = (res: RunResult): void => {
+      if (settled) return;
+      settled = true;
+      if (graceTimer) clearTimeout(graceTimer);
+      try {
+        rl?.close();
+      } catch {
+        /* ignore */
+      }
+      try {
+        child?.stdout?.destroy();
+        child?.stderr?.destroy();
+        child?.unref();
+      } catch {
+        /* ignore */
+      }
+      // `settled` guarantees this runs once; oxlint can't see the guard.
+      // oxlint-disable-next-line promise/no-multiple-resolved
+      resolvePromise(res);
+    };
+
     try {
       child = spawn(opts.claudeBin, args, {
         cwd: opts.cwd,
@@ -65,7 +106,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
         signal: opts.signal,
       });
     } catch (err) {
-      resolvePromise({
+      settle({
         ok: false,
         result: "",
         error: `failed to spawn ${opts.claudeBin}: ${err instanceof Error ? err.message : String(err)}`,
@@ -73,11 +114,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       return;
     }
 
-    let final: RunResult = { ok: false, result: "" };
-    let gotResult = false;
-    let stderr = "";
-
-    const rl = createInterface({ input: child.stdout! });
+    rl = createInterface({ input: child.stdout! });
     rl.on("line", (line) => {
       const trimmed = line.trim();
       if (!trimmed) return;
@@ -98,6 +135,18 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
           numTurns: evt.num_turns,
           error: evt.is_error ? (evt.result ?? "agent reported an error") : undefined,
         };
+        // Prefer a clean exit (the `close` handler), but don't wait forever.
+        if (!graceTimer) {
+          graceTimer = setTimeout(() => {
+            try {
+              child?.kill("SIGKILL");
+            } catch {
+              /* already gone */
+            }
+            settle(final);
+          }, RESULT_EXIT_GRACE_MS);
+          graceTimer.unref?.();
+        }
       }
     });
 
@@ -106,7 +155,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
     });
 
     child.on("error", (err: Error) => {
-      resolvePromise({ ok: false, result: "", error: `${opts.claudeBin}: ${err.message}` });
+      settle({ ok: false, result: "", error: `${opts.claudeBin}: ${err.message}` });
     });
 
     child.on("close", (code) => {
@@ -114,10 +163,10 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       // bare exit 0 with no result means we have no confirmed outcome, so we
       // treat it as a failure rather than silently advancing the phase.
       if (gotResult) {
-        resolvePromise(final);
+        settle(final);
         return;
       }
-      resolvePromise({
+      settle({
         ok: false,
         result: "",
         error: stderr.trim() || `claude exited with code ${code} without a result event`,

--- a/apps/agents/src/config.ts
+++ b/apps/agents/src/config.ts
@@ -45,3 +45,10 @@ export const DEFAULT_MAX_TURNS = 40;
  * min — so it only ever catches a genuinely wedged session.
  */
 export const DEFAULT_IDLE_MINUTES = 45;
+
+/**
+ * Default absolute ceiling on a single specialist session. A backstop for a
+ * session that streams forever without finishing; generous enough not to cut
+ * off legitimate long art/build work.
+ */
+export const DEFAULT_SESSION_MINUTES = 120;

--- a/apps/agents/src/config.ts
+++ b/apps/agents/src/config.ts
@@ -16,7 +16,7 @@ export function findRepoRoot(start: string = process.cwd()): string {
     if (parent === dir) break;
     dir = parent;
   }
-  // Fallback: this file compiles to apps/agents/dist/config.js → ../../.. is repo root.
+  // Fallback: this file lives at apps/agents/src/config.ts → ../../.. is repo root.
   return resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 }
 

--- a/apps/agents/src/config.ts
+++ b/apps/agents/src/config.ts
@@ -38,3 +38,10 @@ export const DEFAULT_MODEL = "sonnet";
 
 /** Default per-role agentic turn ceiling. Keeps any single step bounded. */
 export const DEFAULT_MAX_TURNS = 40;
+
+/**
+ * Default idle watchdog: kill a specialist that emits no output for this long.
+ * Generous on purpose — a single `vg generate` poll can stay silent for ~30
+ * min — so it only ever catches a genuinely wedged session.
+ */
+export const DEFAULT_IDLE_MINUTES = 45;

--- a/apps/agents/src/config.ts
+++ b/apps/agents/src/config.ts
@@ -1,0 +1,40 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Walk up from `start` until we find the monorepo root (the dir holding
+ * pnpm-workspace.yaml). The orchestrator runs the `claude` CLI with its cwd
+ * set to a game workspace *inside* this repo, so Claude Code resolves the
+ * dogfooded skills from `<repoRoot>/.claude/skills` and the linked `vg` CLI.
+ */
+export function findRepoRoot(start: string = process.cwd()): string {
+  let dir = start;
+  for (let i = 0; i < 25; i++) {
+    if (existsSync(resolve(dir, "pnpm-workspace.yaml"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Fallback: this file compiles to apps/agents/dist/config.js → ../../.. is repo root.
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+}
+
+/** Default workspace location for a given game slug (gitignored). */
+export function defaultWorkspace(repoRoot: string, slug: string): string {
+  return resolve(repoRoot, "apps/agents/.workspaces", slug);
+}
+
+/** Path to the `claude` CLI. Override with CLAUDE_BIN for non-PATH installs. */
+export function claudeBin(): string {
+  return process.env.CLAUDE_BIN ?? "claude";
+}
+
+/**
+ * Default model alias passed to `claude --model`. Sonnet keeps a forever-loop
+ * affordable and within plan limits; pass `--model opus` for higher-craft runs.
+ */
+export const DEFAULT_MODEL = "sonnet";
+
+/** Default per-role agentic turn ceiling. Keeps any single step bounded. */
+export const DEFAULT_MAX_TURNS = 40;

--- a/apps/agents/src/config.ts
+++ b/apps/agents/src/config.ts
@@ -31,10 +31,11 @@ export function claudeBin(): string {
 }
 
 /**
- * Default model alias passed to `claude --model`. Sonnet keeps a forever-loop
- * affordable and within plan limits; pass `--model opus` for higher-craft runs.
+ * Default model passed to `claude --model`. Opus 4.8 — the latest, most capable
+ * model — for the highest-craft games; override with `--model sonnet` for a
+ * cheaper forever-loop.
  */
-export const DEFAULT_MODEL = "sonnet";
+export const DEFAULT_MODEL = "claude-opus-4-8";
 
 /** Default per-role agentic turn ceiling. Keeps any single step bounded. */
 export const DEFAULT_MAX_TURNS = 40;

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { defineCommand, runMain } from "citty";
@@ -14,7 +14,43 @@ import {
   findRepoRoot,
 } from "./config.js";
 import { runStudio } from "./orchestrator.js";
-import { approvalRequested, blackboard, loadState, requestApproval } from "./state.js";
+import {
+  approvalPending,
+  blackboard,
+  hasExistingProject,
+  loadState,
+  requestApproval,
+} from "./state.js";
+
+/** Cap how much of a context file we inline into the brief. */
+const MAX_CONTEXT_CHARS = 20_000;
+
+/**
+ * Resolve the optional --context value into a brief (and maybe a reference dir
+ * the agents get read access to). A path to a file is read inline; a path to a
+ * directory becomes a reference the agents explore; anything else is literal
+ * text.
+ */
+function resolveContext(raw: string | undefined): { context?: string; contextDir?: string } {
+  const value = (raw ?? "").trim();
+  if (!value) return {};
+  const p = resolve(process.cwd(), value);
+  try {
+    const st = existsSync(p) ? statSync(p) : null;
+    if (st?.isDirectory()) {
+      return {
+        contextDir: p,
+        context: `Reference material is provided in this directory (you have read access): ${p}\nExplore it and take direction from / build upon what's there.`,
+      };
+    }
+    if (st?.isFile()) {
+      return { context: readFileSync(p, "utf8").slice(0, MAX_CONTEXT_CHARS) };
+    }
+  } catch {
+    /* fall through to literal text */
+  }
+  return { context: value };
+}
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
 
@@ -53,8 +89,14 @@ const startCommand = defineCommand({
     },
     idea: {
       type: "string",
-      description: 'Seed idea, e.g. --idea "a neon roguelike where you fight with sound".',
+      description:
+        'Seed idea, e.g. --idea "a neon roguelike where you fight with sound". Optional when --dir points at an existing project or you pass --context.',
       default: "",
+    },
+    context: {
+      type: "string",
+      description:
+        "Extra context for the build: literal text, a path to a file (read inline), or a path to a directory (the agents get read access and build upon it).",
     },
     model: {
       type: "string",
@@ -110,9 +152,12 @@ const startCommand = defineCommand({
     const workspace = resolveWorkspace(slug, args.dir);
     const bb = blackboard(workspace);
     const fresh = !existsSync(bb.state);
-    if (fresh && !args.idea.trim()) {
+    const { context, contextDir } = resolveContext(args.context);
+    // A new game needs *something* to go on: a seed idea, an operator brief, or
+    // an existing project in the game dir to build upon.
+    if (fresh && !args.idea.trim() && !context && !hasExistingProject(workspace)) {
       consola.error(
-        'A seed idea is required for a new game. Pass --idea "your one-line game idea".',
+        'Nothing to build from. Pass --idea "your one-line idea", add --context, or point --dir at an existing project.',
       );
       process.exit(1);
     }
@@ -124,7 +169,7 @@ const startCommand = defineCommand({
       idea: args.idea.trim(),
       workspace,
       model: args.model,
-      maxTurns: toInt(args["max-turns"], DEFAULT_MAX_TURNS),
+      maxTurns: toInt(args["max-turns"], DEFAULT_MAX_TURNS, 1),
       idleTimeoutMs: toInt(args["idle-timeout"], DEFAULT_IDLE_MINUTES) * 60_000,
       maxSessionMs: toInt(args["session-timeout"], DEFAULT_SESSION_MINUTES) * 60_000,
       maxCycles: toInt(args["max-cycles"], 0),
@@ -132,6 +177,8 @@ const startCommand = defineCommand({
       noShip: Boolean(args["skip-ship"]),
       autoDeploy: Boolean(args["auto-deploy"]),
       skipPermissions: !args.guarded,
+      context,
+      contextDir,
     });
     if (!started) process.exit(1);
   },
@@ -191,7 +238,7 @@ const statusCommand = defineCommand({
         `Iterations: ${state.iteration}`,
         `Shipped:    ${state.shipped ? "yes" : "no"}`,
         state.deployUrl ? `Live:       ${state.deployUrl}` : `Live:       —`,
-        `Approval:   ${approvalRequested(bb) ? "pending — deploys the current build shortly" : "none (run `vg-studio approve` to publish)"}`,
+        `Approval:   ${approvalPending(bb, state.lastApproval) ? "pending — deploys the current build shortly" : "none (run `vg-studio approve` to publish)"}`,
         `Spend:      ~$${state.totalCostUsd.toFixed(2)}`,
         `Updated:    ${state.updatedAt}`,
         `Game dir:   ${bb.root}`,
@@ -238,10 +285,17 @@ const main = defineCommand({
   },
 });
 
-function toInt(v: string | undefined, fallback: number): number {
+/**
+ * Parse a CLI integer strictly: only a plain non-negative integer (>= min) is
+ * accepted; anything malformed or out of range falls back, so a typo can't
+ * silently disable a timeout or set a nonsensical budget.
+ */
+function toInt(v: string | undefined, fallback: number, min = 0): number {
   if (v == null) return fallback;
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n : fallback;
+  const t = v.trim();
+  if (!/^\d+$/.test(t)) return fallback;
+  const n = Number(t);
+  return Number.isSafeInteger(n) && n >= min ? n : fallback;
 }
 
 runMain(main);

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { defineCommand, runMain } from "citty";
@@ -23,31 +23,56 @@ import {
 } from "./state.js";
 
 /** Cap how much of a context file we inline into the brief. */
-const MAX_CONTEXT_CHARS = 20_000;
+const MAX_CONTEXT_BYTES = 20_000;
+
+/** Read at most maxBytes from a file without loading the whole thing. */
+function readBounded(path: string, maxBytes: number): string {
+  const fd = openSync(path, "r");
+  try {
+    const buf = Buffer.alloc(maxBytes);
+    const n = readSync(fd, buf, 0, maxBytes, 0);
+    return buf.subarray(0, n).toString("utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
 
 /**
  * Resolve the optional --context value into a brief (and maybe a reference dir
- * the agents get read access to). A path to a file is read inline; a path to a
- * directory becomes a reference the agents explore; anything else is literal
- * text.
+ * the agents get read access to). A path to a file is read inline (bounded); a
+ * path to a directory becomes a reference the agents explore; anything that
+ * isn't an existing path is treated as literal brief text. A path that exists
+ * but can't be read is a hard error (don't silently treat it as text).
  */
 function resolveContext(raw: string | undefined): { context?: string; contextDir?: string } {
   const value = (raw ?? "").trim();
   if (!value) return {};
   const p = resolve(process.cwd(), value);
+
+  let stat;
   try {
-    const st = existsSync(p) ? statSync(p) : null;
-    if (st?.isDirectory()) {
-      return {
-        contextDir: p,
-        context: `Reference material is provided in this directory (you have read access): ${p}\nExplore it and take direction from / build upon what's there.`,
-      };
+    stat = statSync(p);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { context: value }; // not a path — a literal brief
     }
-    if (st?.isFile()) {
-      return { context: readFileSync(p, "utf8").slice(0, MAX_CONTEXT_CHARS) };
+    consola.error(`Could not access --context path ${p}: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  if (stat.isDirectory()) {
+    return {
+      contextDir: p,
+      context: `Reference material is provided in this directory (you have read access): ${p}\nExplore it and take direction from / build upon what's there.`,
+    };
+  }
+  if (stat.isFile()) {
+    try {
+      return { context: readBounded(p, MAX_CONTEXT_BYTES) };
+    } catch (err) {
+      consola.error(`Could not read --context file ${p}: ${(err as Error).message}`);
+      process.exit(1);
     }
-  } catch {
-    /* fall through to literal text */
   }
   return { context: value };
 }

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -12,15 +12,15 @@ import {
   DEFAULT_SESSION_MINUTES,
   defaultWorkspace,
   findRepoRoot,
-} from "./config.js";
-import { runStudio } from "./orchestrator.js";
+} from "./config.ts";
+import { runStudio } from "./orchestrator.ts";
 import {
   approvalPending,
   blackboard,
   hasExistingProject,
   loadState,
   requestApproval,
-} from "./state.js";
+} from "./state.ts";
 
 /** Cap how much of a context file we inline into the brief. */
 const MAX_CONTEXT_BYTES = 20_000;

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -104,7 +104,7 @@ const startCommand = defineCommand({
   meta: {
     name: "start",
     description:
-      "Start (or resume) the autonomous studio for a game. Builds the game end-to-end and evolves it like a studio until you stop it. Deploys are gated on `vg-studio approve` unless --auto-deploy is set.",
+      "Start (or resume) the autonomous studio for a game. Builds the game end-to-end and evolves it like a studio until you stop it. Deploys are gated on `pnpm approve <slug>` unless --auto-deploy is set.",
   },
   args: {
     slug: {
@@ -161,7 +161,7 @@ const startCommand = defineCommand({
     "auto-deploy": {
       type: "boolean",
       description:
-        "Deploy automatically without per-release approval. Default is OFF: nothing goes live until you run `vg-studio approve <slug>`.",
+        "Deploy automatically without per-release approval. Default is OFF: nothing goes live until you run `pnpm approve <slug>`.",
       default: false,
     },
     guarded: {
@@ -263,7 +263,7 @@ const statusCommand = defineCommand({
         `Iterations: ${state.iteration}`,
         `Shipped:    ${state.shipped ? "yes" : "no"}`,
         state.deployUrl ? `Live:       ${state.deployUrl}` : `Live:       —`,
-        `Approval:   ${approvalPending(bb, state.lastApproval) ? "pending — deploys the current build shortly" : "none (run `vg-studio approve` to publish)"}`,
+        `Approval:   ${approvalPending(bb, state.lastApproval) ? "pending — deploys the current build shortly" : "none (run `pnpm approve <slug>` to publish)"}`,
         `Spend:      ~$${state.totalCostUsd.toFixed(2)}`,
         `Updated:    ${state.updatedAt}`,
         `Game dir:   ${bb.root}`,
@@ -298,9 +298,9 @@ const approveCommand = defineCommand({
 
 const main = defineCommand({
   meta: {
-    name: "vg-studio",
+    name: "studio",
     description:
-      "vibedgames autonomous studio — a multi-agent loop that builds one browser game and evolves it like a studio. Deploys require approval (`vg-studio approve`).",
+      "vibedgames autonomous studio — a multi-agent loop that builds one browser game and evolves it like a studio. Run via pnpm scripts (start/stop/status/approve). Deploys require approval (`pnpm approve <slug>`).",
   },
   subCommands: {
     start: startCommand,

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -125,7 +125,7 @@ const startCommand = defineCommand({
     },
     model: {
       type: "string",
-      description: `Model alias passed to claude --model (default ${DEFAULT_MODEL}; try "opus" for higher craft).`,
+      description: `Model passed to claude --model (default ${DEFAULT_MODEL}, the latest model; pass "sonnet" for a cheaper run).`,
       default: DEFAULT_MODEL,
     },
     dir: {

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+import { existsSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { defineCommand, runMain } from "citty";
+import consola from "consola";
+
+import { DEFAULT_MAX_TURNS, DEFAULT_MODEL, defaultWorkspace, findRepoRoot } from "./config.js";
+import { runStudio } from "./orchestrator.js";
+import { blackboard, loadState } from "./state.js";
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+function resolveWorkspace(slug: string, override?: string): string {
+  if (override) return resolve(process.cwd(), override);
+  return defaultWorkspace(findRepoRoot(), slug);
+}
+
+const startCommand = defineCommand({
+  meta: {
+    name: "start",
+    description:
+      "Start (or resume) the autonomous studio for a game. Runs a multi-agent loop that builds the game end-to-end and polishes it forever until you stop it.",
+  },
+  args: {
+    slug: {
+      type: "positional",
+      description: "Lowercase, hyphenated game slug — also the deploy subdomain.",
+      required: true,
+    },
+    idea: {
+      type: "string",
+      description: 'Seed idea, e.g. --idea "a neon roguelike where you fight with sound".',
+      default: "",
+    },
+    model: {
+      type: "string",
+      description: `Model alias passed to claude --model (default ${DEFAULT_MODEL}; try "opus" for higher craft).`,
+      default: DEFAULT_MODEL,
+    },
+    workspace: {
+      type: "string",
+      description: "Override the game workspace dir (default apps/agents/.workspaces/<slug>).",
+    },
+    "max-turns": {
+      type: "string",
+      description: `Per-specialist agentic turn ceiling (default ${DEFAULT_MAX_TURNS}).`,
+    },
+    "max-cycles": {
+      type: "string",
+      description: "Stop after N specialist runs (default 0 = run forever).",
+    },
+    interval: {
+      type: "string",
+      description: "Milliseconds to pause between specialist runs (default 0).",
+    },
+    "no-ship": {
+      type: "boolean",
+      description: "Skip the deploy phase — no production deploys (useful while testing the loop).",
+      default: false,
+    },
+    guarded: {
+      type: "boolean",
+      description:
+        "Do NOT pass --dangerously-skip-permissions. Agents will block waiting for approval — breaks unattended autonomy. For debugging only.",
+      default: false,
+    },
+  },
+  run: async ({ args }) => {
+    const slug = args.slug.trim().toLowerCase();
+    if (!SLUG_RE.test(slug)) {
+      consola.error(`Invalid slug: ${args.slug}\n  Use lowercase letters, digits, and hyphens.`);
+      process.exit(1);
+    }
+
+    const workspace = resolveWorkspace(slug, args.workspace);
+    const bb = blackboard(workspace);
+    const fresh = !existsSync(bb.state);
+    if (fresh && !args.idea.trim()) {
+      consola.error(
+        'A seed idea is required for a new game. Pass --idea "your one-line game idea".',
+      );
+      process.exit(1);
+    }
+    // Clear a stale STOP sentinel from a previous run.
+    if (existsSync(bb.stop)) {
+      try {
+        const { rmSync } = await import("node:fs");
+        rmSync(bb.stop);
+      } catch {
+        /* ignore */
+      }
+    }
+
+    await runStudio({
+      slug,
+      idea: args.idea.trim(),
+      workspace,
+      model: args.model,
+      maxTurns: toInt(args["max-turns"], DEFAULT_MAX_TURNS),
+      maxCycles: toInt(args["max-cycles"], 0),
+      interval: toInt(args.interval, 0),
+      noShip: Boolean(args["no-ship"]),
+      skipPermissions: !args.guarded,
+    });
+  },
+});
+
+const stopCommand = defineCommand({
+  meta: {
+    name: "stop",
+    description: "Signal a running studio to stop after its current step (writes a STOP sentinel).",
+  },
+  args: {
+    slug: { type: "positional", description: "Game slug.", required: true },
+    workspace: { type: "string", description: "Override workspace dir." },
+  },
+  run: ({ args }) => {
+    const slug = args.slug.trim().toLowerCase();
+    const bb = blackboard(resolveWorkspace(slug, args.workspace));
+    if (!existsSync(bb.dir)) {
+      consola.error(`No studio workspace found for "${slug}".`);
+      process.exit(1);
+    }
+    writeFileSync(bb.stop, `stop requested ${new Date().toISOString()}\n`);
+    consola.success(
+      `Stop signalled for "${slug}". It will halt after the current specialist finishes.`,
+    );
+  },
+});
+
+const statusCommand = defineCommand({
+  meta: {
+    name: "status",
+    description: "Show the current state of a game's studio.",
+  },
+  args: {
+    slug: { type: "positional", description: "Game slug.", required: true },
+    workspace: { type: "string", description: "Override workspace dir." },
+    json: { type: "boolean", description: "Machine-readable output.", default: false },
+  },
+  run: ({ args }) => {
+    const slug = args.slug.trim().toLowerCase();
+    const bb = blackboard(resolveWorkspace(slug, args.workspace));
+    if (!existsSync(bb.state)) {
+      consola.error(`No studio state found for "${slug}".`);
+      process.exit(1);
+    }
+    const state = loadState(bb);
+    if (args.json) {
+      consola.log(JSON.stringify(state, null, 2));
+      return;
+    }
+    consola.box(
+      [
+        `Game:       ${state.slug}`,
+        `Idea:       ${state.idea}`,
+        `Phase:      ${state.phase}`,
+        `Cycles:     ${state.cycle}`,
+        `Iterations: ${state.iteration}`,
+        `Shipped:    ${state.shipped ? "yes" : "no"}`,
+        state.deployUrl ? `Live:       ${state.deployUrl}` : `Live:       —`,
+        `Spend:      ~$${state.totalCostUsd.toFixed(2)}`,
+        `Updated:    ${state.updatedAt}`,
+        `Workspace:  ${bb.root}`,
+      ].join("\n"),
+    );
+  },
+});
+
+const main = defineCommand({
+  meta: {
+    name: "vg-studio",
+    description:
+      "vibedgames autonomous studio — a multi-agent loop that builds one browser game end-to-end and polishes it forever.",
+  },
+  subCommands: {
+    start: startCommand,
+    stop: stopCommand,
+    status: statusCommand,
+  },
+});
+
+function toInt(v: string | undefined, fallback: number): number {
+  if (v == null) return fallback;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+runMain(main);

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -14,7 +14,7 @@ import {
   findRepoRoot,
 } from "./config.js";
 import { runStudio } from "./orchestrator.js";
-import { blackboard, loadState } from "./state.js";
+import { approvalRequested, blackboard, loadState, requestApproval } from "./state.js";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
 
@@ -43,7 +43,7 @@ const startCommand = defineCommand({
   meta: {
     name: "start",
     description:
-      "Start (or resume) the autonomous studio for a game. Runs a multi-agent loop that builds the game end-to-end and polishes it forever until you stop it.",
+      "Start (or resume) the autonomous studio for a game. Builds the game end-to-end and evolves it like a studio until you stop it. Deploys are gated on `vg-studio approve` unless --auto-deploy is set.",
   },
   args: {
     slug: {
@@ -61,9 +61,10 @@ const startCommand = defineCommand({
       description: `Model alias passed to claude --model (default ${DEFAULT_MODEL}; try "opus" for higher craft).`,
       default: DEFAULT_MODEL,
     },
-    workspace: {
+    dir: {
       type: "string",
-      description: "Override the game workspace dir (default apps/agents/.workspaces/<slug>).",
+      description:
+        "Where the game lives — its project directory (default apps/agents/.workspaces/<slug>). Outside this repo, run `vg init` first so the skills resolve.",
     },
     "max-turns": {
       type: "string",
@@ -87,7 +88,13 @@ const startCommand = defineCommand({
     },
     "skip-ship": {
       type: "boolean",
-      description: "Skip the deploy phase — no production deploys (useful while testing the loop).",
+      description: "Skip the deploy phase entirely — never even prepare a release.",
+      default: false,
+    },
+    "auto-deploy": {
+      type: "boolean",
+      description:
+        "Deploy automatically without per-release approval. Default is OFF: nothing goes live until you run `vg-studio approve <slug>`.",
       default: false,
     },
     guarded: {
@@ -100,7 +107,7 @@ const startCommand = defineCommand({
   run: async ({ args }) => {
     const slug = requireSlug(args.slug);
 
-    const workspace = resolveWorkspace(slug, args.workspace);
+    const workspace = resolveWorkspace(slug, args.dir);
     const bb = blackboard(workspace);
     const fresh = !existsSync(bb.state);
     if (fresh && !args.idea.trim()) {
@@ -123,6 +130,7 @@ const startCommand = defineCommand({
       maxCycles: toInt(args["max-cycles"], 0),
       interval: toInt(args.interval, 0),
       noShip: Boolean(args["skip-ship"]),
+      autoDeploy: Boolean(args["auto-deploy"]),
       skipPermissions: !args.guarded,
     });
     if (!started) process.exit(1);
@@ -136,11 +144,11 @@ const stopCommand = defineCommand({
   },
   args: {
     slug: { type: "positional", description: "Game slug.", required: true },
-    workspace: { type: "string", description: "Override workspace dir." },
+    dir: { type: "string", description: "Game directory (if you set --dir on start)." },
   },
   run: ({ args }) => {
     const slug = requireSlug(args.slug);
-    const bb = blackboard(resolveWorkspace(slug, args.workspace));
+    const bb = blackboard(resolveWorkspace(slug, args.dir));
     if (!existsSync(bb.dir)) {
       consola.error(`No studio workspace found for "${slug}".`);
       process.exit(1);
@@ -159,12 +167,12 @@ const statusCommand = defineCommand({
   },
   args: {
     slug: { type: "positional", description: "Game slug.", required: true },
-    workspace: { type: "string", description: "Override workspace dir." },
+    dir: { type: "string", description: "Game directory (if you set --dir on start)." },
     json: { type: "boolean", description: "Machine-readable output.", default: false },
   },
   run: ({ args }) => {
     const slug = requireSlug(args.slug);
-    const bb = blackboard(resolveWorkspace(slug, args.workspace));
+    const bb = blackboard(resolveWorkspace(slug, args.dir));
     if (!existsSync(bb.state)) {
       consola.error(`No studio state found for "${slug}".`);
       process.exit(1);
@@ -183,10 +191,35 @@ const statusCommand = defineCommand({
         `Iterations: ${state.iteration}`,
         `Shipped:    ${state.shipped ? "yes" : "no"}`,
         state.deployUrl ? `Live:       ${state.deployUrl}` : `Live:       —`,
+        `Approval:   ${approvalRequested(bb) ? "pending — will deploy at next ship" : "none (run `vg-studio approve` to publish)"}`,
         `Spend:      ~$${state.totalCostUsd.toFixed(2)}`,
         `Updated:    ${state.updatedAt}`,
-        `Workspace:  ${bb.root}`,
+        `Game dir:   ${bb.root}`,
       ].join("\n"),
+    );
+  },
+});
+
+const approveCommand = defineCommand({
+  meta: {
+    name: "approve",
+    description:
+      "Approve the current build for ONE deployment. A running studio publishes it at its next ship step (or immediately if it's waiting); the next release needs fresh approval.",
+  },
+  args: {
+    slug: { type: "positional", description: "Game slug.", required: true },
+    dir: { type: "string", description: "Game directory (if you set --dir on start)." },
+  },
+  run: ({ args }) => {
+    const slug = requireSlug(args.slug);
+    const bb = blackboard(resolveWorkspace(slug, args.dir));
+    if (!existsSync(bb.dir)) {
+      consola.error(`No studio workspace found for "${slug}".`);
+      process.exit(1);
+    }
+    requestApproval(bb);
+    consola.success(
+      `Approved "${slug}" for one deployment. It will publish at the next ship step (or now, if the studio is waiting).`,
     );
   },
 });
@@ -195,12 +228,13 @@ const main = defineCommand({
   meta: {
     name: "vg-studio",
     description:
-      "vibedgames autonomous studio — a multi-agent loop that builds one browser game end-to-end and polishes it forever.",
+      "vibedgames autonomous studio — a multi-agent loop that builds one browser game and evolves it like a studio. Deploys require approval (`vg-studio approve`).",
   },
   subCommands: {
     start: startCommand,
     stop: stopCommand,
     status: statusCommand,
+    approve: approveCommand,
   },
 });
 

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -97,7 +97,7 @@ const startCommand = defineCommand({
     // A stale STOP sentinel is cleared inside runStudio once the workspace lock
     // is held, so a restart can never wipe a still-running process's stop.
 
-    await runStudio({
+    const started = await runStudio({
       slug,
       idea: args.idea.trim(),
       workspace,
@@ -108,6 +108,7 @@ const startCommand = defineCommand({
       noShip: Boolean(args["skip-ship"]),
       skipPermissions: !args.guarded,
     });
+    if (!started) process.exit(1);
   },
 });
 

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -54,7 +54,7 @@ const startCommand = defineCommand({
       type: "string",
       description: "Milliseconds to pause between specialist runs (default 0).",
     },
-    "no-ship": {
+    "skip-ship": {
       type: "boolean",
       description: "Skip the deploy phase — no production deploys (useful while testing the loop).",
       default: false,
@@ -100,7 +100,7 @@ const startCommand = defineCommand({
       maxTurns: toInt(args["max-turns"], DEFAULT_MAX_TURNS),
       maxCycles: toInt(args["max-cycles"], 0),
       interval: toInt(args.interval, 0),
-      noShip: Boolean(args["no-ship"]),
+      noShip: Boolean(args["skip-ship"]),
       skipPermissions: !args.guarded,
     });
   },

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_IDLE_MINUTES,
   DEFAULT_MAX_TURNS,
   DEFAULT_MODEL,
+  DEFAULT_SESSION_MINUTES,
   defaultWorkspace,
   findRepoRoot,
 } from "./config.js";
@@ -72,6 +73,10 @@ const startCommand = defineCommand({
       type: "string",
       description: `Kill a specialist that emits no output for this many minutes (default ${DEFAULT_IDLE_MINUTES}; 0 disables).`,
     },
+    "session-timeout": {
+      type: "string",
+      description: `Absolute cap on a single specialist session in minutes (default ${DEFAULT_SESSION_MINUTES}; 0 disables).`,
+    },
     "max-cycles": {
       type: "string",
       description: "Stop after N specialist runs (default 0 = run forever).",
@@ -114,6 +119,7 @@ const startCommand = defineCommand({
       model: args.model,
       maxTurns: toInt(args["max-turns"], DEFAULT_MAX_TURNS),
       idleTimeoutMs: toInt(args["idle-timeout"], DEFAULT_IDLE_MINUTES) * 60_000,
+      maxSessionMs: toInt(args["session-timeout"], DEFAULT_SESSION_MINUTES) * 60_000,
       maxCycles: toInt(args["max-cycles"], 0),
       interval: toInt(args.interval, 0),
       noShip: Boolean(args["skip-ship"]),

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -191,7 +191,7 @@ const statusCommand = defineCommand({
         `Iterations: ${state.iteration}`,
         `Shipped:    ${state.shipped ? "yes" : "no"}`,
         state.deployUrl ? `Live:       ${state.deployUrl}` : `Live:       —`,
-        `Approval:   ${approvalRequested(bb) ? "pending — will deploy at next ship" : "none (run `vg-studio approve` to publish)"}`,
+        `Approval:   ${approvalRequested(bb) ? "pending — deploys the current build shortly" : "none (run `vg-studio approve` to publish)"}`,
         `Spend:      ~$${state.totalCostUsd.toFixed(2)}`,
         `Updated:    ${state.updatedAt}`,
         `Game dir:   ${bb.root}`,
@@ -219,7 +219,7 @@ const approveCommand = defineCommand({
     }
     requestApproval(bb);
     consola.success(
-      `Approved "${slug}" for one deployment. It will publish at the next ship step (or now, if the studio is waiting).`,
+      `Approved "${slug}" for one deployment. A running studio publishes the current build shortly (after the in-flight step finishes); the next release needs fresh approval.`,
     );
   },
 });

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -11,6 +11,22 @@ import { blackboard, loadState } from "./state.js";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
 
+/**
+ * Validate + normalize a slug before it's ever used to build a filesystem
+ * path. Rejecting anything outside [a-z0-9-] keeps `..`/path segments from
+ * resolving `.studio` outside the workspaces dir.
+ */
+function requireSlug(raw: string): string {
+  const slug = raw.trim().toLowerCase();
+  if (!SLUG_RE.test(slug)) {
+    consola.error(
+      `Invalid slug: ${raw}\n  Use lowercase letters, digits, and hyphens (e.g. "asteroid-belt").`,
+    );
+    process.exit(1);
+  }
+  return slug;
+}
+
 function resolveWorkspace(slug: string, override?: string): string {
   if (override) return resolve(process.cwd(), override);
   return defaultWorkspace(findRepoRoot(), slug);
@@ -67,11 +83,7 @@ const startCommand = defineCommand({
     },
   },
   run: async ({ args }) => {
-    const slug = args.slug.trim().toLowerCase();
-    if (!SLUG_RE.test(slug)) {
-      consola.error(`Invalid slug: ${args.slug}\n  Use lowercase letters, digits, and hyphens.`);
-      process.exit(1);
-    }
+    const slug = requireSlug(args.slug);
 
     const workspace = resolveWorkspace(slug, args.workspace);
     const bb = blackboard(workspace);
@@ -82,15 +94,8 @@ const startCommand = defineCommand({
       );
       process.exit(1);
     }
-    // Clear a stale STOP sentinel from a previous run.
-    if (existsSync(bb.stop)) {
-      try {
-        const { rmSync } = await import("node:fs");
-        rmSync(bb.stop);
-      } catch {
-        /* ignore */
-      }
-    }
+    // A stale STOP sentinel is cleared inside runStudio once the workspace lock
+    // is held, so a restart can never wipe a still-running process's stop.
 
     await runStudio({
       slug,
@@ -116,7 +121,7 @@ const stopCommand = defineCommand({
     workspace: { type: "string", description: "Override workspace dir." },
   },
   run: ({ args }) => {
-    const slug = args.slug.trim().toLowerCase();
+    const slug = requireSlug(args.slug);
     const bb = blackboard(resolveWorkspace(slug, args.workspace));
     if (!existsSync(bb.dir)) {
       consola.error(`No studio workspace found for "${slug}".`);
@@ -140,7 +145,7 @@ const statusCommand = defineCommand({
     json: { type: "boolean", description: "Machine-readable output.", default: false },
   },
   run: ({ args }) => {
-    const slug = args.slug.trim().toLowerCase();
+    const slug = requireSlug(args.slug);
     const bb = blackboard(resolveWorkspace(slug, args.workspace));
     if (!existsSync(bb.state)) {
       consola.error(`No studio state found for "${slug}".`);

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -5,7 +5,13 @@ import { resolve } from "node:path";
 import { defineCommand, runMain } from "citty";
 import consola from "consola";
 
-import { DEFAULT_MAX_TURNS, DEFAULT_MODEL, defaultWorkspace, findRepoRoot } from "./config.js";
+import {
+  DEFAULT_IDLE_MINUTES,
+  DEFAULT_MAX_TURNS,
+  DEFAULT_MODEL,
+  defaultWorkspace,
+  findRepoRoot,
+} from "./config.js";
 import { runStudio } from "./orchestrator.js";
 import { blackboard, loadState } from "./state.js";
 
@@ -62,6 +68,10 @@ const startCommand = defineCommand({
       type: "string",
       description: `Per-specialist agentic turn ceiling (default ${DEFAULT_MAX_TURNS}).`,
     },
+    "idle-timeout": {
+      type: "string",
+      description: `Kill a specialist that emits no output for this many minutes (default ${DEFAULT_IDLE_MINUTES}; 0 disables).`,
+    },
     "max-cycles": {
       type: "string",
       description: "Stop after N specialist runs (default 0 = run forever).",
@@ -103,6 +113,7 @@ const startCommand = defineCommand({
       workspace,
       model: args.model,
       maxTurns: toInt(args["max-turns"], DEFAULT_MAX_TURNS),
+      idleTimeoutMs: toInt(args["idle-timeout"], DEFAULT_IDLE_MINUTES) * 60_000,
       maxCycles: toInt(args["max-cycles"], 0),
       interval: toInt(args.interval, 0),
       noShip: Boolean(args["skip-ship"]),

--- a/apps/agents/src/index.ts
+++ b/apps/agents/src/index.ts
@@ -181,8 +181,13 @@ const startCommand = defineCommand({
     // A new game needs *something* to go on: a seed idea, an operator brief, or
     // an existing project in the game dir to build upon.
     if (fresh && !args.idea.trim() && !context && !hasExistingProject(workspace)) {
+      // Distinguish "no --context given" from "--context given but empty", so an
+      // operator who pointed at an empty file isn't told to "add --context".
+      const contextAttempted = Boolean((args.context ?? "").trim());
       consola.error(
-        'Nothing to build from. Pass --idea "your one-line idea", add --context, or point --dir at an existing project.',
+        contextAttempted
+          ? "The --context you provided is empty (blank text or an empty file). Provide non-empty context, pass --idea, or point --dir at an existing project."
+          : 'Nothing to build from. Pass --idea "your one-line idea", add --context, or point --dir at an existing project.',
       );
       process.exit(1);
     }

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -412,6 +412,18 @@ function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void
     consola.warn(
       `Running with --dangerously-skip-permissions: agents run shell/file tools and \`vg generate\` (which costs money) WITHOUT asking. ${deployNote} Stop with Ctrl-C.`,
     );
+    // claude rejects --dangerously-skip-permissions under root unless the
+    // environment is marked as a sandbox; we set IS_SANDBOX=1 for the children
+    // so unattended container/CI runs (which are typically root) actually work.
+    if (
+      typeof process.getuid === "function" &&
+      process.getuid() === 0 &&
+      process.env.IS_SANDBOX !== "1"
+    ) {
+      consola.info(
+        "Detected root: setting IS_SANDBOX=1 for agents so skip-permissions is allowed.",
+      );
+    }
   }
 }
 

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -117,11 +117,15 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   // `built:false, shipped:true` can't make the ship guard and preemption spin.
   state.built = (state.built ?? false) || state.shipped;
   state.lastApproval = state.lastApproval ?? null;
-  // A new --context overrides; otherwise keep the persisted reference dir so it
-  // survives a resume that doesn't repeat --context.
-  state.contextDir = opts.contextDir ?? state.contextDir ?? null;
-  // Record the operator's brief/reference so the specialists can read it.
-  if (opts.context) writeFileSync(bb.context, `${opts.context.trim()}\n`);
+  // A new --context this run fully replaces the prior brief AND reference dir
+  // (so switching to a file/text brief clears a stale reference folder);
+  // otherwise keep what's persisted so a plain resume retains them.
+  if (opts.context !== undefined) {
+    writeFileSync(bb.context, `${opts.context.trim()}\n`);
+    state.contextDir = opts.contextDir ?? null;
+  } else {
+    state.contextDir = state.contextDir ?? null;
+  }
   saveState(bb, state);
 
   banner(opts, state, repoRoot);

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -24,6 +24,8 @@ export type StudioOptions = {
   maxTurns: number;
   /** Kill a specialist that emits no output for this long (ms; 0 disables). */
   idleTimeoutMs: number;
+  /** Absolute ceiling on a single specialist session (ms; 0 disables). */
+  maxSessionMs: number;
   /** 0 = run forever (until stopped). */
   maxCycles: number;
   /** ms to pause between specialist runs. */
@@ -157,6 +159,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       model: state.model,
       maxTurns: opts.maxTurns,
       idleTimeoutMs: opts.idleTimeoutMs,
+      maxSessionMs: opts.maxSessionMs,
       claudeBin: claudeBin(),
       addDirs: [repoRoot],
       skipPermissions: opts.skipPermissions,

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -1,0 +1,235 @@
+import consola from "consola";
+
+import { claudeBin, findRepoRoot } from "./config.js";
+import { runClaude } from "./claude.js";
+import { buildTask, roleForPhase, ROLES } from "./roles.js";
+import {
+  appendJournal,
+  blackboard,
+  initWorkspace,
+  saveState,
+  stopRequested,
+  type Phase,
+  type StudioState,
+} from "./state.js";
+
+export type StudioOptions = {
+  slug: string;
+  idea: string;
+  workspace: string;
+  model: string;
+  maxTurns: number;
+  /** 0 = run forever (until stopped). */
+  maxCycles: number;
+  /** ms to pause between specialist runs. */
+  interval: number;
+  /** Skip the ship phase (no prod deploys — useful while testing the loop). */
+  noShip: boolean;
+  /** Pass --dangerously-skip-permissions so tools run unattended. */
+  skipPermissions: boolean;
+};
+
+const MAX_RETRIES = 5;
+
+export async function runStudio(opts: StudioOptions): Promise<void> {
+  const repoRoot = findRepoRoot();
+  const bb = blackboard(opts.workspace);
+  const now = new Date().toISOString();
+
+  const seed: StudioState = {
+    slug: opts.slug,
+    idea: opts.idea,
+    model: opts.model,
+    phase: "spec",
+    cycle: 0,
+    iteration: 0,
+    shipped: false,
+    deployUrl: null,
+    totalCostUsd: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+  let state = initWorkspace(bb, seed);
+  // Re-seed mutable knobs on restart so flags take effect.
+  state.idea = opts.idea || state.idea;
+  state.model = opts.model;
+  saveState(bb, state);
+
+  banner(opts, state, repoRoot);
+
+  let stopping = false;
+  const abort = new AbortController();
+  const onSignal = () => {
+    if (!stopping) {
+      stopping = true;
+      consola.warn(
+        "\nStop requested — finishing the current step. Press Ctrl-C again to force quit.",
+      );
+    } else {
+      consola.warn("Force quitting.");
+      abort.abort();
+      process.exit(130);
+    }
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  let failures = 0;
+
+  // `stopping` is flipped by the SIGINT/SIGTERM handler above (and we also
+  // honor the STOP sentinel inside the loop) — oxlint can't see the async
+  // mutation, so silence its unmodified-condition heuristic.
+  // oxlint-disable-next-line no-unmodified-loop-condition
+  while (!stopping) {
+    if (stopRequested(bb)) {
+      consola.warn("STOP sentinel found in .studio/ — halting.");
+      break;
+    }
+    if (opts.maxCycles > 0 && state.cycle >= opts.maxCycles) {
+      consola.info(`Reached --max-cycles=${opts.maxCycles}. Stopping.`);
+      break;
+    }
+
+    // Optionally skip shipping (no prod deploy) while testing.
+    if (state.phase === "ship" && opts.noShip) {
+      consola.info("--no-ship set; skipping the ship phase.");
+      advance(state);
+      saveState(bb, state);
+      continue;
+    }
+
+    const phase = state.phase;
+    const role = ROLES[roleForPhase(phase, bb)];
+    const task = buildTask(phase, state, bb);
+
+    consola.log("");
+    consola.start(
+      `${role.emoji} ${role.name} — phase "${phase}" · cycle ${state.cycle + 1}${
+        state.shipped ? ` · iteration ${state.iteration + 1}` : ""
+      }`,
+    );
+
+    const res = await runClaude({
+      prompt: task,
+      systemPrompt: role.system,
+      cwd: opts.workspace,
+      model: state.model,
+      maxTurns: opts.maxTurns,
+      claudeBin: claudeBin(),
+      addDirs: [repoRoot],
+      skipPermissions: opts.skipPermissions,
+      signal: abort.signal,
+      label: role.name,
+    });
+
+    state.cycle += 1;
+    if (typeof res.costUsd === "number") state.totalCostUsd += res.costUsd;
+    saveState(bb, state);
+
+    if (!res.ok) {
+      failures += 1;
+      appendJournal(
+        bb,
+        `${role.name} (${phase}) FAILED: ${truncate(res.error ?? "unknown error")}`,
+      );
+      consola.error(`${role.name} failed: ${res.error ?? "unknown error"}`);
+      if (failures >= MAX_RETRIES) {
+        consola.warn(
+          `${MAX_RETRIES} consecutive failures on "${phase}" — skipping ahead to avoid a stuck loop.`,
+        );
+        advance(state);
+        saveState(bb, state);
+        failures = 0;
+      } else {
+        const backoff = Math.min(2 ** failures, 60);
+        consola.info(
+          `Retrying "${phase}" in ${backoff}s (attempt ${failures + 1}/${MAX_RETRIES}).`,
+        );
+        await sleep(backoff * 1000);
+      }
+      continue;
+    }
+
+    failures = 0;
+    appendJournal(
+      bb,
+      `${role.name} (${phase}) done${costNote(res.costUsd)}: ${truncate(res.result)}`,
+    );
+    consola.success(`${role.name} done${costNote(res.costUsd)} · ${res.numTurns ?? "?"} turns`);
+
+    advance(state);
+    saveState(bb, state);
+
+    if (opts.interval > 0 && !stopping) await sleep(opts.interval);
+  }
+
+  saveState(bb, state);
+  consola.box(
+    [
+      `Studio stopped for "${state.slug}".`,
+      `Cycles run: ${state.cycle} · iterations: ${state.iteration}`,
+      state.deployUrl ? `Live: ${state.deployUrl}` : "Not yet shipped.",
+      `Approx spend: $${state.totalCostUsd.toFixed(2)}`,
+      `Resume anytime: vg-studio start ${state.slug}`,
+    ].join("\n"),
+  );
+}
+
+/** Phase machine: bootstrap once, then loop the polish cycle forever. */
+function advance(state: StudioState): void {
+  const transitions: Record<Phase, Phase> = {
+    spec: "scaffold",
+    scaffold: "assets",
+    assets: "build",
+    build: "playtest",
+    playtest: "ship",
+    ship: "plan",
+    plan: "work",
+    work: "playtest",
+  };
+
+  if (state.phase === "ship") {
+    if (!state.shipped) {
+      state.shipped = true;
+      state.deployUrl = `https://${state.slug}.vibedgames.com`;
+    } else {
+      state.iteration += 1;
+    }
+  }
+  state.phase = transitions[state.phase];
+}
+
+function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void {
+  consola.box(
+    [
+      `🎮 vibedgames autonomous studio`,
+      ``,
+      `Game:      ${state.slug}`,
+      `Idea:      ${state.idea}`,
+      `Model:     ${state.model}`,
+      `Workspace: ${opts.workspace}`,
+      `Repo:      ${repoRoot}`,
+      `Mode:      ${opts.skipPermissions ? "unattended (tools auto-approved)" : "guarded (will block on approvals!)"}`,
+      opts.noShip
+        ? `Shipping:  disabled (--no-ship)`
+        : `Shipping:  vg deploy → ${state.slug}.vibedgames.com`,
+      opts.maxCycles > 0
+        ? `Stops at:  ${opts.maxCycles} cycles`
+        : `Runs:      until you stop it (Ctrl-C or \`vg-studio stop ${state.slug}\`)`,
+    ].join("\n"),
+  );
+  if (opts.skipPermissions) {
+    consola.warn(
+      "Running with --dangerously-skip-permissions: agents run shell/file tools, `vg generate`, and `vg deploy` WITHOUT asking. These cost money and deploy to production. Stop with Ctrl-C.",
+    );
+  }
+}
+
+const truncate = (s: string, n = 240): string => {
+  const flat = (s ?? "").replace(/\s+/g, " ").trim();
+  return flat.length > n ? `${flat.slice(0, n)}…` : flat;
+};
+
+const costNote = (c?: number): string => (typeof c === "number" ? ` ($${c.toFixed(2)})` : "");
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -116,9 +116,12 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   // claiming adoption. A fresh game never flips to "adopt" just because
   // scaffolding created files (false stays false).
   state.existingProject = (state.existingProject ?? false) && hasExistingProject(opts.workspace);
-  // shipped implies built — force the invariant so an inconsistent persisted
-  // `built:false, shipped:true` can't make the ship guard and preemption spin.
-  state.built = (state.built ?? false) || state.shipped;
+  // Backfill `built` for pre-field workspaces, but do NOT resurrect a persisted
+  // `built:false`: once a work phase invalidates it (see the loop), false must
+  // survive a restart so ship stays gated until a fresh playtest re-verifies the
+  // current tree. The preemption and ship-built guards are themselves gated on
+  // `built`, so a `built:false, shipped:true` state can't spin.
+  state.built = state.built ?? false;
   state.lastApproval = state.lastApproval ?? null;
   // A new --context this run fully replaces the prior brief AND reference dir
   // (so switching to a file/text brief clears a stale reference folder);
@@ -172,7 +175,11 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
 
     // In the forever loop (after the first release), an operator approval ships
     // the CURRENT build promptly instead of iterating further, so what goes live
-    // is the build they approved rather than a newer, unreviewed one. We do NOT
+    // is the build they approved rather than a newer, unreviewed one. Only
+    // preempt when a VERIFIED build exists (`built`): mid-iteration — right after
+    // a work phase cleared it — there's nothing safe to ship, so let playtest
+    // re-verify first. Gating on `built` also stops a built:false/shipped:true
+    // state from spinning between here and the ship-built guard. We do NOT
     // preempt during the initial bootstrap (before the first ship): an early
     // approval simply waits and is honored at the natural ship phase, once
     // assets/build/playtest have run — so it can't deploy an incomplete game.
@@ -181,6 +188,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     if (
       state.phase !== "ship" &&
       state.shipped &&
+      state.built &&
       !opts.autoDeploy &&
       !opts.noShip &&
       approvalPending(bb, state.lastApproval)
@@ -192,9 +200,11 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     }
 
     // An operator-approved deploy is a deliberate command — let that single ship
-    // run even if the autonomous cycle budget is used up.
+    // run even if the autonomous cycle budget is used up. Only when a verified
+    // build exists; otherwise ship would just be skipped, so don't burn budget.
     const approvedShipPending =
       state.phase === "ship" &&
+      state.built &&
       !opts.autoDeploy &&
       !opts.noShip &&
       approvalPending(bb, state.lastApproval);

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -6,8 +6,10 @@ import { buildTask, roleForPhase, ROLES } from "./roles.js";
 import {
   acquireLock,
   appendJournal,
+  approvalRequested,
   blackboard,
   clearStop,
+  consumeApproval,
   initWorkspace,
   releaseLock,
   saveState,
@@ -32,6 +34,8 @@ export type StudioOptions = {
   interval: number;
   /** Skip the ship phase (no prod deploys — useful while testing the loop). */
   noShip: boolean;
+  /** Deploy automatically without per-release human approval. */
+  autoDeploy: boolean;
   /** Pass --dangerously-skip-permissions so tools run unattended. */
   skipPermissions: boolean;
 };
@@ -141,6 +145,20 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       continue;
     }
 
+    // Deploys require explicit human approval unless --auto-deploy is set. When
+    // there's no standing approval we don't even run the shipper: the build is
+    // ready, we just don't publish it — the loop keeps improving the game
+    // locally until a human runs `vg-studio approve <slug>`.
+    if (state.phase === "ship" && !opts.autoDeploy && !approvalRequested(bb)) {
+      consola.warn(
+        `Build ready but NOT deployed — approval required. Run \`vg-studio approve ${state.slug}\` to publish it (or start with --auto-deploy).`,
+      );
+      appendJournal(bb, "ship: build ready, awaiting human approval (not deployed).");
+      advance(state);
+      saveState(bb, state);
+      continue;
+    }
+
     const phase = state.phase;
     const role = ROLES[roleForPhase(phase, bb)];
     const task = buildTask(phase, state, bb);
@@ -202,8 +220,12 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     );
     consola.success(`${role.name} done${costNote(res.costUsd)} · ${res.numTurns ?? "?"} turns`);
 
-    // Only a real, successful ship marks the game deployed.
-    if (phase === "ship") recordShip(state);
+    // Only a real, successful ship marks the game deployed; a one-shot approval
+    // is spent on this deploy, so the next release needs fresh approval.
+    if (phase === "ship") {
+      recordShip(state);
+      consumeApproval(bb);
+    }
     advance(state);
     saveState(bb, state);
 
@@ -267,20 +289,27 @@ function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void
       `Game:      ${state.slug}`,
       `Idea:      ${state.idea}`,
       `Model:     ${state.model}`,
-      `Workspace: ${opts.workspace}`,
+      `Game dir:  ${opts.workspace}`,
       `Repo:      ${repoRoot}`,
       `Mode:      ${opts.skipPermissions ? "unattended (tools auto-approved)" : "guarded (will block on approvals!)"}`,
       opts.noShip
-        ? `Shipping:  disabled (--skip-ship)`
-        : `Shipping:  vg deploy → ${state.slug}.vibedgames.com`,
+        ? `Deploy:    disabled (--skip-ship)`
+        : opts.autoDeploy
+          ? `Deploy:    AUTOMATIC → ${state.slug}.vibedgames.com`
+          : `Deploy:    on approval only — \`vg-studio approve ${state.slug}\` → ${state.slug}.vibedgames.com`,
       opts.maxCycles > 0
         ? `Stops at:  ${opts.maxCycles} cycles`
         : `Runs:      until you stop it (Ctrl-C or \`vg-studio stop ${state.slug}\`)`,
     ].join("\n"),
   );
   if (opts.skipPermissions) {
+    const deployNote = opts.noShip
+      ? "Deploys are disabled."
+      : opts.autoDeploy
+        ? "Deploys to production run AUTOMATICALLY."
+        : "Deploys are gated on `vg-studio approve` — nothing goes live without you.";
     consola.warn(
-      "Running with --dangerously-skip-permissions: agents run shell/file tools, `vg generate`, and `vg deploy` WITHOUT asking. These cost money and deploy to production. Stop with Ctrl-C.",
+      `Running with --dangerously-skip-permissions: agents run shell/file tools and \`vg generate\` (which costs money) WITHOUT asking. ${deployNote} Stop with Ctrl-C.`,
     );
   }
 }

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -1,3 +1,5 @@
+import { existsSync, writeFileSync } from "node:fs";
+
 import consola from "consola";
 
 import { claudeBin, findRepoRoot } from "./config.js";
@@ -6,10 +8,12 @@ import { buildTask, roleForPhase, ROLES } from "./roles.js";
 import {
   acquireLock,
   appendJournal,
-  approvalRequested,
+  approvalPending,
+  approvalToken,
   blackboard,
   clearStop,
   consumeApproval,
+  hasExistingProject,
   initWorkspace,
   releaseLock,
   saveState,
@@ -38,6 +42,10 @@ export type StudioOptions = {
   autoDeploy: boolean;
   /** Pass --dangerously-skip-permissions so tools run unattended. */
   skipPermissions: boolean;
+  /** Optional operator brief written to .studio/context.md for the specialists. */
+  context?: string;
+  /** Optional reference directory the specialists are granted read access to. */
+  contextDir?: string;
 };
 
 const MAX_RETRIES = 5;
@@ -48,6 +56,11 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   const bb = blackboard(opts.workspace);
   const now = new Date().toISOString();
 
+  // Detect an existing project to build upon (only meaningful on a fresh start;
+  // on resume the flag is already persisted).
+  const isFresh = !existsSync(bb.state);
+  const existingProject = isFresh && hasExistingProject(opts.workspace);
+
   const seed: StudioState = {
     slug: opts.slug,
     idea: opts.idea,
@@ -56,6 +69,9 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     cycle: 0,
     iteration: 0,
     phaseFailures: 0,
+    existingProject,
+    built: false,
+    lastApproval: null,
     shipped: false,
     deployUrl: null,
     totalCostUsd: 0,
@@ -73,7 +89,8 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     );
     return false;
   }
-  process.on("exit", () => releaseLock(bb));
+  const onExit = () => releaseLock(bb);
+  process.on("exit", onExit);
 
   // We now hold the lock, so any STOP sentinel is necessarily stale (left by a
   // previous run that has since exited) — safe to clear before we loop.
@@ -92,6 +109,11 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   state.idea = opts.idea || state.idea;
   state.model = opts.model;
   state.phaseFailures = state.phaseFailures ?? 0; // backfill pre-field workspaces
+  state.existingProject = state.existingProject ?? false;
+  state.built = state.built ?? state.shipped; // a shipped game has necessarily built
+  state.lastApproval = state.lastApproval ?? null;
+  // Record the operator's brief/reference so the specialists can read it.
+  if (opts.context) writeFileSync(bb.context, `${opts.context.trim()}\n`);
   saveState(bb, state);
 
   banner(opts, state, repoRoot);
@@ -135,13 +157,17 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
 
     // The operator approved a deploy — ship the CURRENT build promptly instead
     // of iterating further, so what goes live is the build they approved rather
-    // than a newer, unreviewed one. Checked before the cycle-budget stop so an
-    // explicit approval is honored even when --max-cycles is already spent.
+    // than a newer, unreviewed one. Only preempt once a build actually exists,
+    // so an early approval doesn't skip bootstrap and deploy nothing; before
+    // that, the approval simply waits and is honored at the natural ship phase.
+    // Checked before the cycle-budget stop so an explicit approval is honored
+    // even when --max-cycles is already spent.
     if (
       state.phase !== "ship" &&
+      state.built &&
       !opts.autoDeploy &&
       !opts.noShip &&
-      approvalRequested(bb)
+      approvalPending(bb, state.lastApproval)
     ) {
       consola.info("Approval received — shipping the current build before continuing.");
       state.phase = "ship";
@@ -152,7 +178,10 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     // An operator-approved deploy is a deliberate command — let that single ship
     // run even if the autonomous cycle budget is used up.
     const approvedShipPending =
-      state.phase === "ship" && !opts.autoDeploy && !opts.noShip && approvalRequested(bb);
+      state.phase === "ship" &&
+      !opts.autoDeploy &&
+      !opts.noShip &&
+      approvalPending(bb, state.lastApproval);
     if (opts.maxCycles > 0 && state.cycle >= opts.maxCycles && !approvedShipPending) {
       consola.info(`Reached --max-cycles=${opts.maxCycles}. Stopping.`);
       break;
@@ -170,7 +199,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     // there's no standing approval we don't even run the shipper: the build is
     // ready, we just don't publish it — the loop keeps improving the game
     // locally until a human runs `vg-studio approve <slug>`.
-    if (state.phase === "ship" && !opts.autoDeploy && !approvalRequested(bb)) {
+    if (state.phase === "ship" && !opts.autoDeploy && !approvalPending(bb, state.lastApproval)) {
       consola.warn(
         `Build ready but NOT deployed — approval required. Run \`vg-studio approve ${state.slug}\` to publish it (or start with --auto-deploy).`,
       );
@@ -200,7 +229,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       idleTimeoutMs: opts.idleTimeoutMs,
       maxSessionMs: opts.maxSessionMs,
       claudeBin: claudeBin(),
-      addDirs: [repoRoot],
+      addDirs: opts.contextDir ? [repoRoot, opts.contextDir] : [repoRoot],
       skipPermissions: opts.skipPermissions,
       signal: abort.signal,
       label: role.name,
@@ -224,7 +253,10 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
         );
         // A spent attempt consumes the deploy approval too, so a broken ship
         // can't re-trigger itself forever; the operator can re-approve.
-        if (phase === "ship") consumeApproval(bb);
+        if (phase === "ship") {
+          state.lastApproval = approvalToken(bb) ?? state.lastApproval;
+          consumeApproval(bb);
+        }
         state.phaseFailures = 0;
         advance(state);
         saveState(bb, state);
@@ -245,10 +277,15 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     );
     consola.success(`${role.name} done${costNote(res.costUsd)} · ${res.numTurns ?? "?"} turns`);
 
-    // Only a real, successful ship marks the game deployed; a one-shot approval
-    // is spent on this deploy, so the next release needs fresh approval.
+    // A completed build means a deployable game now exists.
+    if (phase === "build") state.built = true;
+
+    // Only a real, successful ship marks the game deployed; the one-shot
+    // approval is recorded as consumed in state (authoritative even if the
+    // sentinel file fails to delete), so the next release needs fresh approval.
     if (phase === "ship") {
       recordShip(state);
+      state.lastApproval = approvalToken(bb) ?? state.lastApproval;
       consumeApproval(bb);
     }
     advance(state);
@@ -256,6 +293,11 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
 
     if (opts.interval > 0 && !stopping) await sleepUnlessStopping(opts.interval);
   }
+
+  // Don't leak handlers if runStudio is called more than once in a process.
+  process.off("SIGINT", onSignal);
+  process.off("SIGTERM", onSignal);
+  process.off("exit", onExit);
 
   saveState(bb, state);
   releaseLock(bb);
@@ -312,9 +354,13 @@ function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void
       `🎮 vibedgames autonomous studio`,
       ``,
       `Game:      ${state.slug}`,
-      `Idea:      ${state.idea}`,
+      `Idea:      ${state.idea || "(from existing project / context)"}`,
       `Model:     ${state.model}`,
       `Game dir:  ${opts.workspace}`,
+      state.existingProject ? `Source:    building on existing files in the game dir` : null,
+      opts.context
+        ? `Context:   provided${opts.contextDir ? ` (+ reference dir: ${opts.contextDir})` : ""}`
+        : null,
       `Repo:      ${repoRoot}`,
       `Mode:      ${opts.skipPermissions ? "unattended (tools auto-approved)" : "guarded (will block on approvals!)"}`,
       opts.noShip
@@ -325,7 +371,9 @@ function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void
       opts.maxCycles > 0
         ? `Stops at:  ${opts.maxCycles} cycles`
         : `Runs:      until you stop it (Ctrl-C or \`vg-studio stop ${state.slug}\`)`,
-    ].join("\n"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
   );
   if (opts.skipPermissions) {
     const deployNote = opts.noShip

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -110,9 +110,12 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   state.idea = opts.idea || state.idea;
   state.model = opts.model;
   state.phaseFailures = state.phaseFailures ?? 0; // backfill pre-field workspaces
-  // Reconcile against the dir each start (monotonic) so files added between
-  // runs are adopted, not overwritten by a fresh scaffold.
-  state.existingProject = (state.existingProject ?? false) || hasExistingProject(opts.workspace);
+  // Keep the adopt flag reflecting whether a project is actually present to
+  // build upon: it starts true only when the workspace was created on existing
+  // files, and clears if those files later go away — so a wiped workspace stops
+  // claiming adoption. A fresh game never flips to "adopt" just because
+  // scaffolding created files (false stays false).
+  state.existingProject = (state.existingProject ?? false) && hasExistingProject(opts.workspace);
   // shipped implies built — force the invariant so an inconsistent persisted
   // `built:false, shipped:true` can't make the ship guard and preemption spin.
   state.built = (state.built ?? false) || state.shipped;

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -109,7 +109,9 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   state.idea = opts.idea || state.idea;
   state.model = opts.model;
   state.phaseFailures = state.phaseFailures ?? 0; // backfill pre-field workspaces
-  state.existingProject = state.existingProject ?? false;
+  // Reconcile against the dir each start (monotonic) so files added between
+  // runs are adopted, not overwritten by a fresh scaffold.
+  state.existingProject = (state.existingProject ?? false) || hasExistingProject(opts.workspace);
   state.built = state.built ?? state.shipped; // a shipped game has necessarily built
   state.lastApproval = state.lastApproval ?? null;
   // Record the operator's brief/reference so the specialists can read it.
@@ -190,6 +192,16 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     // Optionally skip shipping (no prod deploy) while testing.
     if (state.phase === "ship" && opts.noShip) {
       consola.info("--skip-ship set; skipping the ship phase.");
+      advance(state);
+      saveState(bb, state);
+      continue;
+    }
+
+    // Never deploy without a recorded successful build — e.g. if the build
+    // phase was skipped after repeated failures. Wait until a build lands.
+    if (state.phase === "ship" && !state.built) {
+      consola.warn("Reached ship with no successful build recorded — not deploying yet.");
+      appendJournal(bb, "ship: skipped — no successful build recorded.");
       advance(state);
       saveState(bb, state);
       continue;
@@ -277,8 +289,10 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     );
     consola.success(`${role.name} done${costNote(res.costUsd)} · ${res.numTurns ?? "?"} turns`);
 
-    // A completed build means a deployable game now exists.
-    if (phase === "build") state.built = true;
+    // A deployable build exists once the scaffold confirms the project builds
+    // (or a gameplay build lands). This gates ship and approval preemption and,
+    // set at scaffold, can't deadlock if a later build phase keeps failing.
+    if (phase === "scaffold" || phase === "build") state.built = true;
 
     // Only a real, successful ship marks the game deployed; the one-shot
     // approval is recorded as consumed in state (authoritative even if the

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -137,6 +137,20 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       break;
     }
 
+    // The operator approved a deploy — ship the CURRENT build promptly instead
+    // of iterating further, so what goes live is the build they approved rather
+    // than a newer, unreviewed one.
+    if (
+      state.phase !== "ship" &&
+      !opts.autoDeploy &&
+      !opts.noShip &&
+      approvalRequested(bb)
+    ) {
+      consola.info("Approval received — shipping the current build before continuing.");
+      state.phase = "ship";
+      saveState(bb, state);
+    }
+
     // Optionally skip shipping (no prod deploy) while testing.
     if (state.phase === "ship" && opts.noShip) {
       consola.info("--skip-ship set; skipping the ship phase.");
@@ -200,6 +214,9 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
         consola.warn(
           `${MAX_RETRIES} consecutive failures on "${phase}" — skipping ahead to avoid a stuck loop.`,
         );
+        // A spent attempt consumes the deploy approval too, so a broken ship
+        // can't re-trigger itself forever; the operator can re-approve.
+        if (phase === "ship") consumeApproval(bb);
         advance(state);
         saveState(bb, state);
         failures = 0;

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -105,6 +105,16 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
 
+  // A sleep that wakes early if a stop is requested (Ctrl-C or STOP sentinel),
+  // so backoff/interval waits never delay shutdown.
+  const sleepUnlessStopping = async (ms: number): Promise<void> => {
+    const step = 250;
+    for (let waited = 0; waited < ms; waited += step) {
+      if (stopping || stopRequested(bb)) return;
+      await sleep(Math.min(step, ms - waited));
+    }
+  };
+
   let failures = 0;
 
   // `stopping` is flipped by the SIGINT/SIGTERM handler above (and we also
@@ -177,7 +187,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
         consola.info(
           `Retrying "${phase}" in ${backoff}s (attempt ${failures + 1}/${MAX_RETRIES}).`,
         );
-        await sleep(backoff * 1000);
+        await sleepUnlessStopping(backoff * 1000);
       }
       continue;
     }
@@ -194,7 +204,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     advance(state);
     saveState(bb, state);
 
-    if (opts.interval > 0 && !stopping) await sleep(opts.interval);
+    if (opts.interval > 0 && !stopping) await sleepUnlessStopping(opts.interval);
   }
 
   saveState(bb, state);

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -116,12 +116,9 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   // claiming adoption. A fresh game never flips to "adopt" just because
   // scaffolding created files (false stays false).
   state.existingProject = (state.existingProject ?? false) && hasExistingProject(opts.workspace);
-  // Backfill `built` for pre-field workspaces, but do NOT resurrect a persisted
-  // `built:false`: once a work phase invalidates it (see the loop), false must
-  // survive a restart so ship stays gated until a fresh playtest re-verifies the
-  // current tree. The preemption and ship-built guards are themselves gated on
-  // `built`, so a `built:false, shipped:true` state can't spin.
-  state.built = state.built ?? false;
+  // shipped implies built — force the invariant so an inconsistent persisted
+  // `built:false, shipped:true` can't make the ship guard and preemption spin.
+  state.built = (state.built ?? false) || state.shipped;
   state.lastApproval = state.lastApproval ?? null;
   // A new --context this run fully replaces the prior brief AND reference dir
   // (so switching to a file/text brief clears a stale reference folder);
@@ -175,11 +172,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
 
     // In the forever loop (after the first release), an operator approval ships
     // the CURRENT build promptly instead of iterating further, so what goes live
-    // is the build they approved rather than a newer, unreviewed one. Only
-    // preempt when a VERIFIED build exists (`built`): mid-iteration — right after
-    // a work phase cleared it — there's nothing safe to ship, so let playtest
-    // re-verify first. Gating on `built` also stops a built:false/shipped:true
-    // state from spinning between here and the ship-built guard. We do NOT
+    // is the build they approved rather than a newer, unreviewed one. We do NOT
     // preempt during the initial bootstrap (before the first ship): an early
     // approval simply waits and is honored at the natural ship phase, once
     // assets/build/playtest have run — so it can't deploy an incomplete game.
@@ -188,7 +181,6 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     if (
       state.phase !== "ship" &&
       state.shipped &&
-      state.built &&
       !opts.autoDeploy &&
       !opts.noShip &&
       approvalPending(bb, state.lastApproval)
@@ -200,11 +192,9 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     }
 
     // An operator-approved deploy is a deliberate command — let that single ship
-    // run even if the autonomous cycle budget is used up. Only when a verified
-    // build exists; otherwise ship would just be skipped, so don't burn budget.
+    // run even if the autonomous cycle budget is used up.
     const approvedShipPending =
       state.phase === "ship" &&
-      state.built &&
       !opts.autoDeploy &&
       !opts.noShip &&
       approvalPending(bb, state.lastApproval);
@@ -248,16 +238,6 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     const phase = state.phase;
     const role = ROLES[roleForPhase(phase, bb)];
     const task = buildTask(phase, state, bb);
-
-    // A work phase mutates the game, so the prior scaffold/build/playtest no
-    // longer verifies the current tree. Drop `built` here; the next playtest
-    // (or build) re-establishes it. Without this, a playtest that exhausts its
-    // retries and skips ahead would let ship deploy — or burn an approval on —
-    // a tree QA never passed.
-    if (phase === "work" && state.built) {
-      state.built = false;
-      saveState(bb, state);
-    }
 
     consola.log("");
     consola.start(

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -222,7 +222,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
 }
 
 /**
- * Pure phase transition: bootstrap once, then loop the polish cycle forever.
+ * Pure phase transition: bootstrap once, then loop the studio cycle forever.
  * Deliberately has NO side effects on shipped/deployUrl/iteration — those only
  * happen on a *successful* ship (see recordShip), never when the ship phase is
  * skipped (--no-ship) or abandoned after repeated failures.
@@ -245,7 +245,7 @@ function advance(state: StudioState): void {
  * Record a confirmed deploy. Called only after the shipper actually succeeds,
  * so state.json / status never claim a shipped game or live URL that wasn't
  * deployed. The first success flips `shipped`; each later success counts a
- * completed polish iteration.
+ * completed studio iteration (a shipped feature/fix/iteration pass).
  */
 function recordShip(state: StudioState): void {
   if (state.shipped) {

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -92,7 +92,7 @@ export async function runStudio(opts: StudioOptions): Promise<void> {
 
     // Optionally skip shipping (no prod deploy) while testing.
     if (state.phase === "ship" && opts.noShip) {
-      consola.info("--no-ship set; skipping the ship phase.");
+      consola.info("--skip-ship set; skipping the ship phase.");
       advance(state);
       saveState(bb, state);
       continue;
@@ -157,6 +157,8 @@ export async function runStudio(opts: StudioOptions): Promise<void> {
     );
     consola.success(`${role.name} done${costNote(res.costUsd)} · ${res.numTurns ?? "?"} turns`);
 
+    // Only a real, successful ship marks the game deployed.
+    if (phase === "ship") recordShip(state);
     advance(state);
     saveState(bb, state);
 
@@ -175,7 +177,12 @@ export async function runStudio(opts: StudioOptions): Promise<void> {
   );
 }
 
-/** Phase machine: bootstrap once, then loop the polish cycle forever. */
+/**
+ * Pure phase transition: bootstrap once, then loop the polish cycle forever.
+ * Deliberately has NO side effects on shipped/deployUrl/iteration — those only
+ * happen on a *successful* ship (see recordShip), never when the ship phase is
+ * skipped (--no-ship) or abandoned after repeated failures.
+ */
 function advance(state: StudioState): void {
   const transitions: Record<Phase, Phase> = {
     spec: "scaffold",
@@ -187,16 +194,22 @@ function advance(state: StudioState): void {
     plan: "work",
     work: "playtest",
   };
-
-  if (state.phase === "ship") {
-    if (!state.shipped) {
-      state.shipped = true;
-      state.deployUrl = `https://${state.slug}.vibedgames.com`;
-    } else {
-      state.iteration += 1;
-    }
-  }
   state.phase = transitions[state.phase];
+}
+
+/**
+ * Record a confirmed deploy. Called only after the shipper actually succeeds,
+ * so state.json / status never claim a shipped game or live URL that wasn't
+ * deployed. The first success flips `shipped`; each later success counts a
+ * completed polish iteration.
+ */
+function recordShip(state: StudioState): void {
+  if (state.shipped) {
+    state.iteration += 1;
+  } else {
+    state.shipped = true;
+    state.deployUrl = `https://${state.slug}.vibedgames.com`;
+  }
 }
 
 function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void {
@@ -211,7 +224,7 @@ function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void
       `Repo:      ${repoRoot}`,
       `Mode:      ${opts.skipPermissions ? "unattended (tools auto-approved)" : "guarded (will block on approvals!)"}`,
       opts.noShip
-        ? `Shipping:  disabled (--no-ship)`
+        ? `Shipping:  disabled (--skip-ship)`
         : `Shipping:  vg deploy → ${state.slug}.vibedgames.com`,
       opts.maxCycles > 0
         ? `Stops at:  ${opts.maxCycles} cycles`

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -157,16 +157,17 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       break;
     }
 
-    // The operator approved a deploy — ship the CURRENT build promptly instead
-    // of iterating further, so what goes live is the build they approved rather
-    // than a newer, unreviewed one. Only preempt once a build actually exists,
-    // so an early approval doesn't skip bootstrap and deploy nothing; before
-    // that, the approval simply waits and is honored at the natural ship phase.
+    // In the forever loop (after the first release), an operator approval ships
+    // the CURRENT build promptly instead of iterating further, so what goes live
+    // is the build they approved rather than a newer, unreviewed one. We do NOT
+    // preempt during the initial bootstrap (before the first ship): an early
+    // approval simply waits and is honored at the natural ship phase, once
+    // assets/build/playtest have run — so it can't deploy an incomplete game.
     // Checked before the cycle-budget stop so an explicit approval is honored
     // even when --max-cycles is already spent.
     if (
       state.phase !== "ship" &&
-      state.built &&
+      state.shipped &&
       !opts.autoDeploy &&
       !opts.noShip &&
       approvalPending(bb, state.lastApproval)

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -86,7 +86,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   if (owner !== null) {
     const who = owner > 0 ? `pid ${owner}` : "another process";
     consola.error(
-      `A studio is already running for "${opts.slug}" (${who}). Stop it first with \`vg-studio stop ${opts.slug}\`, or wait for it to finish.`,
+      `A studio is already running for "${opts.slug}" (${who}). Stop it first with \`pnpm stop ${opts.slug}\`, or wait for it to finish.`,
     );
     return false;
   }
@@ -221,10 +221,10 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     // Deploys require explicit human approval unless --auto-deploy is set. When
     // there's no standing approval we don't even run the shipper: the build is
     // ready, we just don't publish it — the loop keeps improving the game
-    // locally until a human runs `vg-studio approve <slug>`.
+    // locally until a human runs `pnpm approve <slug>`.
     if (state.phase === "ship" && !opts.autoDeploy && !approvalPending(bb, state.lastApproval)) {
       consola.warn(
-        `Build ready but NOT deployed — approval required. Run \`vg-studio approve ${state.slug}\` to publish it (or start with --auto-deploy).`,
+        `Build ready but NOT deployed — approval required. Run \`pnpm approve ${state.slug}\` to publish it (or start with --auto-deploy).`,
       );
       appendJournal(bb, "ship: build ready, awaiting human approval (not deployed).");
       advance(state);
@@ -334,7 +334,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       `Cycles run: ${state.cycle} · iterations: ${state.iteration}`,
       state.deployUrl ? `Live: ${state.deployUrl}` : "Not yet shipped.",
       `Approx spend: $${state.totalCostUsd.toFixed(2)}`,
-      `Resume anytime: vg-studio start ${state.slug}`,
+      `Resume anytime: pnpm start ${state.slug}`,
     ].join("\n"),
   );
   return true;
@@ -395,10 +395,10 @@ function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void
         ? `Deploy:    disabled (--skip-ship)`
         : opts.autoDeploy
           ? `Deploy:    AUTOMATIC → ${state.slug}.vibedgames.com`
-          : `Deploy:    on approval only — \`vg-studio approve ${state.slug}\` → ${state.slug}.vibedgames.com`,
+          : `Deploy:    on approval only — \`pnpm approve ${state.slug}\` → ${state.slug}.vibedgames.com`,
       opts.maxCycles > 0
         ? `Stops at:  ${opts.maxCycles} cycles`
-        : `Runs:      until you stop it (Ctrl-C or \`vg-studio stop ${state.slug}\`)`,
+        : `Runs:      until you stop it (Ctrl-C or \`pnpm stop ${state.slug}\`)`,
     ]
       .filter(Boolean)
       .join("\n"),
@@ -408,7 +408,7 @@ function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void
       ? "Deploys are disabled."
       : opts.autoDeploy
         ? "Deploys to production run AUTOMATICALLY."
-        : "Deploys are gated on `vg-studio approve` — nothing goes live without you.";
+        : "Deploys are gated on `pnpm approve <slug>` — nothing goes live without you.";
     consola.warn(
       `Running with --dangerously-skip-permissions: agents run shell/file tools and \`vg generate\` (which costs money) WITHOUT asking. ${deployNote} Stop with Ctrl-C.`,
     );

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -132,14 +132,11 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       consola.warn("STOP sentinel found in .studio/ — halting.");
       break;
     }
-    if (opts.maxCycles > 0 && state.cycle >= opts.maxCycles) {
-      consola.info(`Reached --max-cycles=${opts.maxCycles}. Stopping.`);
-      break;
-    }
 
     // The operator approved a deploy — ship the CURRENT build promptly instead
     // of iterating further, so what goes live is the build they approved rather
-    // than a newer, unreviewed one.
+    // than a newer, unreviewed one. Checked before the cycle-budget stop so an
+    // explicit approval is honored even when --max-cycles is already spent.
     if (
       state.phase !== "ship" &&
       !opts.autoDeploy &&
@@ -150,6 +147,15 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       state.phase = "ship";
       state.phaseFailures = 0; // entering a new phase: fresh retry budget
       saveState(bb, state);
+    }
+
+    // An operator-approved deploy is a deliberate command — let that single ship
+    // run even if the autonomous cycle budget is used up.
+    const approvedShipPending =
+      state.phase === "ship" && !opts.autoDeploy && !opts.noShip && approvalRequested(bb);
+    if (opts.maxCycles > 0 && state.cycle >= opts.maxCycles && !approvedShipPending) {
+      consola.info(`Reached --max-cycles=${opts.maxCycles}. Stopping.`);
+      break;
     }
 
     // Optionally skip shipping (no prod deploy) while testing.

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -22,6 +22,8 @@ export type StudioOptions = {
   workspace: string;
   model: string;
   maxTurns: number;
+  /** Kill a specialist that emits no output for this long (ms; 0 disables). */
+  idleTimeoutMs: number;
   /** 0 = run forever (until stopped). */
   maxCycles: number;
   /** ms to pause between specialist runs. */
@@ -144,6 +146,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       cwd: opts.workspace,
       model: state.model,
       maxTurns: opts.maxTurns,
+      idleTimeoutMs: opts.idleTimeoutMs,
       claudeBin: claudeBin(),
       addDirs: [repoRoot],
       skipPermissions: opts.skipPermissions,

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -4,9 +4,12 @@ import { claudeBin, findRepoRoot } from "./config.js";
 import { runClaude } from "./claude.js";
 import { buildTask, roleForPhase, ROLES } from "./roles.js";
 import {
+  acquireLock,
   appendJournal,
   blackboard,
+  clearStop,
   initWorkspace,
+  releaseLock,
   saveState,
   stopRequested,
   type Phase,
@@ -49,6 +52,22 @@ export async function runStudio(opts: StudioOptions): Promise<void> {
     createdAt: now,
     updatedAt: now,
   };
+  // One studio per workspace: refuse to start a second process on the same
+  // game, which would let two loops fight over the same files (and let an
+  // impatient `start` wipe a still-running process's pending STOP).
+  const owner = acquireLock(bb);
+  if (owner !== null) {
+    consola.error(
+      `A studio is already running for "${opts.slug}" (pid ${owner}). Stop it first with \`vg-studio stop ${opts.slug}\`, or wait for it to finish.`,
+    );
+    return;
+  }
+  process.on("exit", () => releaseLock(bb));
+
+  // We now hold the lock, so any STOP sentinel is necessarily stale (left by a
+  // previous run that has since exited) — safe to clear before we loop.
+  clearStop(bb);
+
   let state = initWorkspace(bb, seed);
   // Re-seed mutable knobs on restart so flags take effect.
   state.idea = opts.idea || state.idea;
@@ -166,6 +185,7 @@ export async function runStudio(opts: StudioOptions): Promise<void> {
   }
 
   saveState(bb, state);
+  releaseLock(bb);
   consola.box(
     [
       `Studio stopped for "${state.slug}".`,

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -300,10 +300,12 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     );
     consola.success(`${role.name} done${costNote(res.costUsd)} · ${res.numTurns ?? "?"} turns`);
 
-    // A deployable build exists once the scaffold confirms the project builds
-    // (or a gameplay build lands). This gates ship and approval preemption and,
-    // set at scaffold, can't deadlock if a later build phase keeps failing.
-    if (phase === "scaffold" || phase === "build") state.built = true;
+    // A deployable build exists once a phase that builds the game succeeds:
+    // scaffold (confirms the template/adopted project builds), build, or
+    // playtest (QA builds to run it). Including playtest — which recurs in the
+    // forever loop — means a game made buildable by later work can still ship;
+    // built never gets permanently stuck false after a skipped bootstrap build.
+    if (phase === "scaffold" || phase === "build" || phase === "playtest") state.built = true;
 
     // Only a real, successful ship marks the game deployed; the one-shot
     // approval is recorded as consumed in state (authoritative even if the

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -112,7 +112,9 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   // Reconcile against the dir each start (monotonic) so files added between
   // runs are adopted, not overwritten by a fresh scaffold.
   state.existingProject = (state.existingProject ?? false) || hasExistingProject(opts.workspace);
-  state.built = state.built ?? state.shipped; // a shipped game has necessarily built
+  // shipped implies built — force the invariant so an inconsistent persisted
+  // `built:false, shipped:true` can't make the ship guard and preemption spin.
+  state.built = (state.built ?? false) || state.shipped;
   state.lastApproval = state.lastApproval ?? null;
   // Record the operator's brief/reference so the specialists can read it.
   if (opts.context) writeFileSync(bb.context, `${opts.context.trim()}\n`);

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -2,9 +2,9 @@ import { existsSync, writeFileSync } from "node:fs";
 
 import consola from "consola";
 
-import { claudeBin, findRepoRoot } from "./config.js";
-import { runClaude } from "./claude.js";
-import { buildTask, roleForPhase, ROLES } from "./roles.js";
+import { claudeBin, findRepoRoot } from "./config.ts";
+import { runClaude } from "./claude.ts";
+import { buildTask, roleForPhase, ROLES } from "./roles.ts";
 import {
   acquireLock,
   appendJournal,
@@ -20,7 +20,7 @@ import {
   stopRequested,
   type Phase,
   type StudioState,
-} from "./state.js";
+} from "./state.ts";
 
 export type StudioOptions = {
   slug: string;

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -239,6 +239,16 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     const role = ROLES[roleForPhase(phase, bb)];
     const task = buildTask(phase, state, bb);
 
+    // A work phase mutates the game, so the prior scaffold/build/playtest no
+    // longer verifies the current tree. Drop `built` here; the next playtest
+    // (or build) re-establishes it. Without this, a playtest that exhausts its
+    // retries and skips ahead would let ship deploy — or burn an approval on —
+    // a tree QA never passed.
+    if (phase === "work" && state.built) {
+      state.built = false;
+      saveState(bb, state);
+    }
+
     consola.log("");
     consola.start(
       `${role.emoji} ${role.name} — phase "${phase}" · cycle ${state.cycle + 1}${

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -70,6 +70,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     iteration: 0,
     phaseFailures: 0,
     existingProject,
+    contextDir: opts.contextDir ?? null,
     built: false,
     lastApproval: null,
     shipped: false,
@@ -116,6 +117,9 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   // `built:false, shipped:true` can't make the ship guard and preemption spin.
   state.built = (state.built ?? false) || state.shipped;
   state.lastApproval = state.lastApproval ?? null;
+  // A new --context overrides; otherwise keep the persisted reference dir so it
+  // survives a resume that doesn't repeat --context.
+  state.contextDir = opts.contextDir ?? state.contextDir ?? null;
   // Record the operator's brief/reference so the specialists can read it.
   if (opts.context) writeFileSync(bb.context, `${opts.context.trim()}\n`);
   saveState(bb, state);
@@ -244,7 +248,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
       idleTimeoutMs: opts.idleTimeoutMs,
       maxSessionMs: opts.maxSessionMs,
       claudeBin: claudeBin(),
-      addDirs: opts.contextDir ? [repoRoot, opts.contextDir] : [repoRoot],
+      addDirs: state.contextDir ? [repoRoot, state.contextDir] : [repoRoot],
       skipPermissions: opts.skipPermissions,
       signal: abort.signal,
       label: role.name,
@@ -366,6 +370,7 @@ function recordShip(state: StudioState): void {
 }
 
 function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void {
+  const bb = blackboard(opts.workspace);
   consola.box(
     [
       `🎮 vibedgames autonomous studio`,
@@ -375,8 +380,8 @@ function banner(opts: StudioOptions, state: StudioState, repoRoot: string): void
       `Model:     ${state.model}`,
       `Game dir:  ${opts.workspace}`,
       state.existingProject ? `Source:    building on existing files in the game dir` : null,
-      opts.context
-        ? `Context:   provided${opts.contextDir ? ` (+ reference dir: ${opts.contextDir})` : ""}`
+      existsSync(bb.context)
+        ? `Context:   provided${state.contextDir ? ` (+ reference dir: ${state.contextDir})` : ""}`
         : null,
       `Repo:      ${repoRoot}`,
       `Mode:      ${opts.skipPermissions ? "unattended (tools auto-approved)" : "guarded (will block on approvals!)"}`,

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -55,6 +55,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     phase: "spec",
     cycle: 0,
     iteration: 0,
+    phaseFailures: 0,
     shipped: false,
     deployUrl: null,
     totalCostUsd: 0,
@@ -90,6 +91,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
   // Re-seed mutable knobs on restart so flags take effect.
   state.idea = opts.idea || state.idea;
   state.model = opts.model;
+  state.phaseFailures = state.phaseFailures ?? 0; // backfill pre-field workspaces
   saveState(bb, state);
 
   banner(opts, state, repoRoot);
@@ -121,8 +123,6 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     }
   };
 
-  let failures = 0;
-
   // `stopping` is flipped by the SIGINT/SIGTERM handler above (and we also
   // honor the STOP sentinel inside the loop) — oxlint can't see the async
   // mutation, so silence its unmodified-condition heuristic.
@@ -148,6 +148,7 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     ) {
       consola.info("Approval received — shipping the current build before continuing.");
       state.phase = "ship";
+      state.phaseFailures = 0; // entering a new phase: fresh retry budget
       saveState(bb, state);
     }
 
@@ -204,33 +205,34 @@ export async function runStudio(opts: StudioOptions): Promise<boolean> {
     saveState(bb, state);
 
     if (!res.ok) {
-      failures += 1;
+      state.phaseFailures += 1;
+      saveState(bb, state); // persist so a restart can't reset the retry budget
       appendJournal(
         bb,
         `${role.name} (${phase}) FAILED: ${truncate(res.error ?? "unknown error")}`,
       );
       consola.error(`${role.name} failed: ${res.error ?? "unknown error"}`);
-      if (failures >= MAX_RETRIES) {
+      if (state.phaseFailures >= MAX_RETRIES) {
         consola.warn(
           `${MAX_RETRIES} consecutive failures on "${phase}" — skipping ahead to avoid a stuck loop.`,
         );
         // A spent attempt consumes the deploy approval too, so a broken ship
         // can't re-trigger itself forever; the operator can re-approve.
         if (phase === "ship") consumeApproval(bb);
+        state.phaseFailures = 0;
         advance(state);
         saveState(bb, state);
-        failures = 0;
       } else {
-        const backoff = Math.min(2 ** failures, 60);
+        const backoff = Math.min(2 ** state.phaseFailures, 60);
         consola.info(
-          `Retrying "${phase}" in ${backoff}s (attempt ${failures + 1}/${MAX_RETRIES}).`,
+          `Retrying "${phase}" in ${backoff}s (attempt ${state.phaseFailures + 1}/${MAX_RETRIES}).`,
         );
         await sleepUnlessStopping(backoff * 1000);
       }
       continue;
     }
 
-    failures = 0;
+    state.phaseFailures = 0;
     appendJournal(
       bb,
       `${role.name} (${phase}) done${costNote(res.costUsd)}: ${truncate(res.result)}`,

--- a/apps/agents/src/orchestrator.ts
+++ b/apps/agents/src/orchestrator.ts
@@ -34,7 +34,8 @@ export type StudioOptions = {
 
 const MAX_RETRIES = 5;
 
-export async function runStudio(opts: StudioOptions): Promise<void> {
+/** Resolves true if the studio ran, false if it couldn't start (lock held). */
+export async function runStudio(opts: StudioOptions): Promise<boolean> {
   const repoRoot = findRepoRoot();
   const bb = blackboard(opts.workspace);
   const now = new Date().toISOString();
@@ -57,10 +58,11 @@ export async function runStudio(opts: StudioOptions): Promise<void> {
   // impatient `start` wipe a still-running process's pending STOP).
   const owner = acquireLock(bb);
   if (owner !== null) {
+    const who = owner > 0 ? `pid ${owner}` : "another process";
     consola.error(
-      `A studio is already running for "${opts.slug}" (pid ${owner}). Stop it first with \`vg-studio stop ${opts.slug}\`, or wait for it to finish.`,
+      `A studio is already running for "${opts.slug}" (${who}). Stop it first with \`vg-studio stop ${opts.slug}\`, or wait for it to finish.`,
     );
-    return;
+    return false;
   }
   process.on("exit", () => releaseLock(bb));
 
@@ -69,6 +71,14 @@ export async function runStudio(opts: StudioOptions): Promise<void> {
   clearStop(bb);
 
   let state = initWorkspace(bb, seed);
+  // The persisted slug is authoritative for an existing workspace (R2 keys and
+  // the deploy URL are tied to it). Warn rather than silently honor a different
+  // CLI slug aimed at the same blackboard (only possible via --workspace).
+  if (state.slug !== opts.slug) {
+    consola.warn(
+      `Workspace already belongs to "${state.slug}"; ignoring the "${opts.slug}" slug for this run.`,
+    );
+  }
   // Re-seed mutable knobs on restart so flags take effect.
   state.idea = opts.idea || state.idea;
   state.model = opts.model;
@@ -195,6 +205,7 @@ export async function runStudio(opts: StudioOptions): Promise<void> {
       `Resume anytime: vg-studio start ${state.slug}`,
     ].join("\n"),
   );
+  return true;
 }
 
 /**

--- a/apps/agents/src/roles.ts
+++ b/apps/agents/src/roles.ts
@@ -170,7 +170,17 @@ export function buildTask(phase: Phase, state: StudioState, bb: Blackboard): str
     case "work": {
       const next = readNext(bb);
       const kind = next.type ? ` [${next.type}]` : "";
-      return `Current assignment from the director (./.studio/next.json)${kind}:\n\n${next.task}\n\nDo exactly this for "${slug}". If it's a bug, reproduce it and fix the root cause. When done, set the item's status to "done" in backlog.json and append a 2–3 line note to journal.md.`;
+      // The closing instruction must match the assigned specialist — engineer-only
+      // guidance (fix the bug, mark the item done) would contradict QA/artist/designer.
+      const close: Record<RoleName, string> = {
+        engineer: `If it's a bug, reproduce it and fix the root cause; verify with typecheck + build. When done, set the item's status to "done" in backlog.json and append a 2–3 line note to journal.md.`,
+        artist: `Generate/update the assets, place them where the game loads them, and record file paths + exact frame sizes. When done, set the item's status to "done" in backlog.json and append a note to journal.md naming the files.`,
+        designer: `Append the design to the "Features & iterations" section of spec.md with crisp acceptance criteria. When done, set the item's status to "done" in backlog.json and append a note to journal.md.`,
+        qa: `Playtest as described, record findings in ./.studio/playtest.md, and file/triage concrete items in backlog.json. Do NOT change game code — your output is findings; leave status updates to the director.`,
+        director: "",
+        shipper: "",
+      };
+      return `Current assignment from the director (./.studio/next.json)${kind}:\n\n${next.task}\n\nDo exactly this for "${slug}". ${close[next.role]}`;
     }
   }
 }

--- a/apps/agents/src/roles.ts
+++ b/apps/agents/src/roles.ts
@@ -15,12 +15,12 @@ export type Role = {
  * Shared charter injected into every specialist. It establishes the blackboard
  * protocol and the hard rule that nobody ever waits on a human.
  */
-const CHARTER = `You are one specialist in an AUTONOMOUS browser-game studio. A single game is being built and polished forever with ZERO human supervision — there is no one to ask, approve, or unblock you. Decide with strong, opinionated defaults and act.
+const CHARTER = `You are one specialist in an AUTONOMOUS browser-game studio. A single game is being built, shipped, and then evolved like a real studio — bug fixes, new features, gameplay and balance iteration, new content, and polish — with ZERO human supervision. There is no one to ask, approve, or unblock you. Decide with strong, opinionated defaults and act.
 
 The game lives in your current working directory. Coordinate with the other specialists ONLY through the shared blackboard in ./.studio/:
-- spec.md        — the game design (owned by the designer)
-- backlog.json   — prioritized work, array of {id, title, detail, role, priority, status}
-- next.json      — the current assignment {role, task} (written by the director)
+- spec.md        — the game design + a running "Features & iterations" log (owned by the designer)
+- backlog.json   — prioritized work, array of {id, title, detail, type, role, priority, status}; type ∈ "bug"|"feature"|"gameplay"|"balance"|"content"|"polish"|"art"
+- next.json      — the current assignment {role, type, task} (written by the director)
 - playtest.md    — QA findings, newest at the bottom
 - journal.md     — append-only log; add a 2–3 line entry every time you run
 
@@ -36,12 +36,25 @@ export const ROLES: Record<RoleName, Role> = {
     emoji: "🎬",
     system: `${CHARTER}
 
-ROLE: Creative Director. You own the loop's direction. Read spec.md, backlog.json, playtest.md, and inspect the current game (skim src/ and run \`npm run build\`/playtest output if useful). Apply the design-lenses and game-playbook craft lens to judge what most holds the game back from being GREAT right now.
+ROLE: Creative Director / Product Owner. You run this game like a studio. It has already shipped — your job is to decide what ships NEXT to make it a better, deeper, more-played game over time. You are NOT here to polish one corner forever.
+
+First, read playtest.md (newest findings), spec.md (the vision + feature log), backlog.json, and inspect the current game (skim src/, build it, read recent journal.md entries) to gauge its MATURITY and what it most needs right now.
+
+Prioritize like a studio:
+1. Ship-stoppers & bugs FIRST — anything broken, crashing, soft-locking, or blatantly unfair (usually surfaced in playtest.md).
+2. Otherwise pick the single highest-impact thing for where the game is NOW. Across the game's life this MUST be a healthy mix — do not default to polish:
+   - feature   — a new mechanic/mode/system (dash, weapon, boss, shop, power-ups, local co-op…)
+   - gameplay  — retune/rework an existing mechanic that isn't fun yet
+   - balance   — difficulty curve, costs, drop rates, pacing, economy
+   - content   — new levels, waves, enemies, biomes, items
+   - polish    — juice, onboarding, readability, game feel
+   - art       — new or upgraded assets (route to the artist)
+Judge by maturity: a thin game needs DEPTH (features/content) before more shine; a deep-but-rough game needs bug fixes and balance; a solid game can take a polish/onboarding pass. Rotate focus so the game keeps GROWING, not just glistening.
 
 Then:
-1. Update ./.studio/backlog.json — keep it a clean, deduped, priority-ordered array of concrete tasks ({id, title, detail, role, priority, status}). role ∈ "engineer" | "artist" | "qa". Mark done items status:"done".
-2. Choose the single highest-leverage task to do next and write ./.studio/next.json EXACTLY as {"role": "engineer|artist|qa", "task": "<one crisp paragraph telling that specialist precisely what to build/change and why it matters>"}.
-Bias toward game feel, content variety, and the first-30-seconds experience. One game, polished forever — never start a different game.`,
+1. Update ./.studio/backlog.json — a clean, deduped, priority-ordered array of {id, title, detail, type, role, priority, status}. type ∈ "bug"|"feature"|"gameplay"|"balance"|"content"|"polish"|"art". role ∈ "designer"|"engineer"|"artist"|"qa". Mark shipped items status:"done". Keep it a forward-looking roadmap, not just the next item.
+2. Write ./.studio/next.json EXACTLY as {"role":"designer|engineer|artist|qa","type":"<one of the types above>","task":"<one crisp paragraph telling that specialist exactly what to do and the player-facing reason it matters>"}.
+Commission the designer (role:"designer") when a sizable new feature/mode should be designed before it's built. Never start a different game — evolve THIS one.`,
   },
 
   designer: {
@@ -49,9 +62,11 @@ Bias toward game feel, content variety, and the first-30-seconds experience. One
     emoji: "🧭",
     system: `${CHARTER}
 
-ROLE: Game Designer. Turn the seed idea into a concrete, build-ready spec. Use the ask-me question tree, but ANSWER every question yourself with bold, coherent defaults — there is no human to interview. Use game-playbook to keep scope shippable.
+ROLE: Game Designer. You handle two kinds of work depending on the assignment:
 
-Write ./.studio/spec.md with: title; one-line pitch; genre; the 10-second core loop; controls (keyboard + touch); win/lose & failure loop; the single "juice moment" that must feel amazing; art direction (palette, vibe, references); minimum content to feel complete; and the ENGINE choice — write a line exactly like \`engine: phaser\` or \`engine: threejs\` (phaser for 2D/pixel/top-down/platformer, threejs for 3D/first-person/camera-driven). Keep the first playable scope deliberately small.`,
+(a) INITIAL SPEC (the very first run, before any code): turn the seed idea into a concrete, build-ready spec. Use the ask-me question tree, but ANSWER every question yourself with bold, coherent defaults — there is no human to interview. Use game-playbook to keep scope shippable. Write ./.studio/spec.md with: title; one-line pitch; genre; the 10-second core loop; controls (keyboard + touch); win/lose & failure loop; the single "juice moment" that must feel amazing; art direction (palette, vibe, references); minimum content to feel complete; and the ENGINE choice — a line exactly like \`engine: phaser\` or \`engine: threejs\` (phaser for 2D/pixel/top-down/platformer, threejs for 3D/first-person/camera-driven). Keep the first playable scope deliberately small.
+
+(b) FEATURE/MODE DESIGN (when the director commissions one — see next.json): do NOT rewrite the whole spec. APPEND a dated, tightly-scoped entry to a "## Features & iterations" section of spec.md covering: the mechanic, player inputs (keyboard + touch), the content/art it needs, how it changes the core loop, and crisp acceptance criteria the engineer can build to and QA can verify. Keep it small enough to ship in one iteration.`,
   },
 
   engineer: {
@@ -59,7 +74,11 @@ Write ./.studio/spec.md with: title; one-line pitch; genre; the 10-second core l
     emoji: "🛠️",
     system: `${CHARTER}
 
-ROLE: Game Engineer. Build and improve the actual game code with the phaser/threejs engine skill plus game-feel, vfx, animation and level-design. The CRAFT PASS is mandatory, not optional: every hit, kill, pickup, jump, land and damage event must have screen shake, hit-stop, knockback where relevant, particles, a hit flash, squash & stretch, and eased (never linear) tweens. Full-screen resizable canvas, tight follow camera, exact spritesheet frame dims. Wire real generated assets (never the template logo/placeholder). Always finish by running \`npm run typecheck\` and \`npm run build\` and fixing what breaks.`,
+ROLE: Game Engineer (gameplay generalist). You build features, fix bugs, and iterate on gameplay, balance and feel with the phaser/threejs engine skill plus game-feel, vfx, animation, level-design and game-balance.
+- Bug: reproduce it from the playtest.md/backlog description, fix the ROOT CAUSE (not the symptom), and confirm it's gone.
+- Feature/content: implement what spec.md's feature log or next.json describes, wiring real generated assets (never the template logo/placeholder).
+- Gameplay/balance: change the specific numbers/systems called for and sanity-check they feel/curve better.
+The CRAFT PASS is mandatory for any NEW or changed interactive moment (hit, kill, pickup, jump, land, damage): screen shake, hit-stop, knockback where relevant, particles, a hit flash, squash & stretch, and eased (never linear) tweens. A pure bug fix or number tweak does NOT need fresh juice — don't gold-plate it. Keep a full-screen resizable canvas, a tight follow camera, and exact spritesheet frame dims. Always finish by running \`npm run typecheck\` and \`npm run build\` and fixing what breaks.`,
   },
 
   artist: {
@@ -108,14 +127,14 @@ export function roleForPhase(phase: Phase, bb: Blackboard): RoleName {
   }
 }
 
-type NextAssignment = { role: RoleName; task: string };
+type NextAssignment = { role: RoleName; type?: string; task: string };
 
 function readNext(bb: Blackboard): NextAssignment {
   try {
     const parsed = JSON.parse(readFileSync(bb.next, "utf8")) as Partial<NextAssignment>;
     const role = parsed.role;
-    if (role === "engineer" || role === "artist" || role === "qa") {
-      return { role, task: parsed.task ?? "" };
+    if (role === "designer" || role === "engineer" || role === "artist" || role === "qa") {
+      return { role, type: parsed.type, task: parsed.task ?? "" };
     }
   } catch {
     // fall through to default
@@ -143,10 +162,11 @@ export function buildTask(phase: Phase, state: StudioState, bb: Blackboard): str
     case "ship":
       return `Ship "${slug}". Build and \`vg deploy ./dist\`, then record the live URL in journal.md.`;
     case "plan":
-      return `Direct the next polish iteration for "${slug}" (iteration ${state.iteration + 1}). Inspect the game and the blackboard, update backlog.json, and write ./.studio/next.json with the single most valuable next task.`;
+      return `Direct iteration ${state.iteration + 1} for "${slug}" like a studio. Read playtest.md and inspect the current game to gauge what it most needs now, triage ./.studio/backlog.json (ship-stoppers/bugs first, then the highest-impact feature / gameplay / balance / content / polish work for the game's current maturity — don't default to polish), and write ./.studio/next.json with the single most valuable next assignment.`;
     case "work": {
       const next = readNext(bb);
-      return `Current assignment from the director (./.studio/next.json):\n\n${next.task}\n\nDo exactly this for "${slug}", then mark the item done in backlog.json and append a note to journal.md.`;
+      const kind = next.type ? ` [${next.type}]` : "";
+      return `Current assignment from the director (./.studio/next.json)${kind}:\n\n${next.task}\n\nDo exactly this for "${slug}". If it's a bug, reproduce it and fix the root cause. When done, set the item's status to "done" in backlog.json and append a 2–3 line note to journal.md.`;
     }
   }
 }

--- a/apps/agents/src/roles.ts
+++ b/apps/agents/src/roles.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 import type { Blackboard, Phase, StudioState } from "./state.js";
 
@@ -13,11 +13,13 @@ export type Role = {
 
 /**
  * Shared charter injected into every specialist. It establishes the blackboard
- * protocol and the hard rule that nobody ever waits on a human.
+ * protocol and that each specialist works autonomously on its own task (while
+ * the operator still gates production deploys, which the orchestrator handles).
  */
-const CHARTER = `You are one specialist in an AUTONOMOUS browser-game studio. A single game is being built, shipped, and then evolved like a real studio — bug fixes, new features, gameplay and balance iteration, new content, and polish — with ZERO human supervision. There is no one to ask, approve, or unblock you. Decide with strong, opinionated defaults and act.
+const CHARTER = `You are one specialist in an autonomous browser-game studio that builds a single game and then evolves it like a real studio — bug fixes, new features, gameplay and balance iteration, new content, and polish. Operate autonomously: don't pause to ask the operator questions, request permission, or wait to be unblocked mid-task — decide with strong, opinionated defaults and act. (Publishing to production is gated by a separate human approval the orchestrator manages outside your turn — that's not something you arrange, approve, or wait on; just do your specialist job well.)
 
 The game lives in your current working directory. Coordinate with the other specialists ONLY through the shared blackboard in ./.studio/:
+- context.md     — optional operator brief / reference notes (present only if provided); read it FIRST if it exists
 - spec.md        — the game design + a running "Features & iterations" log (owned by the designer)
 - backlog.json   — prioritized work, array of {id, title, detail, type, role, priority, status}; type ∈ "bug"|"feature"|"gameplay"|"balance"|"content"|"polish"|"art"
 - next.json      — the current assignment {role, type, task} (written by the director)
@@ -148,15 +150,33 @@ function readNext(bb: Blackboard): NextAssignment {
 /** The task ("user" turn) for a phase, grounded in current state. */
 export function buildTask(phase: Phase, state: StudioState, bb: Blackboard): string {
   const slug = state.slug;
+  // Tell specialists to read the operator's brief/reference when one was given.
+  const ctx = existsSync(bb.context)
+    ? "First read ./.studio/context.md for the operator's brief / reference, and honor it. "
+    : "";
   switch (phase) {
     case "spec":
-      return `Design the game from this seed idea: "${state.idea}".\nThe game slug is "${slug}". Produce ./.studio/spec.md per your role instructions, then append a one-line summary to journal.md.`;
+      if (state.existingProject) {
+        return `${ctx}The game directory ALREADY contains a project — build UPON it, don't start over. Read the existing source (package.json, src/, index.html, any README) to understand what it is and which engine/stack it uses. Then write ./.studio/spec.md describing the current game honestly and a concrete plan to finish/evolve it, and record the detected engine as a line exactly like \`engine: phaser\`, \`engine: threejs\`, or \`engine: other\`. Slug is "${slug}". Append a one-line summary to journal.md.`;
+      }
+      return `${ctx}Design the game from this seed idea: "${state.idea}".\nThe game slug is "${slug}". Produce ./.studio/spec.md per your role instructions, then append a one-line summary to journal.md.`;
     case "scaffold":
-      return `Read ./.studio/spec.md for the engine choice. The current directory IS the game project root (it already contains the ./.studio folder). Scaffold the engine here by running \`vg new ${slug} --engine <phaser|threejs from spec> --here --force\`, then \`npm install\`. Confirm \`npm run build\` works on the fresh template. Append what you did to journal.md.`;
-    case "assets":
-      return `Read ./.studio/spec.md and generate the initial art set for "${slug}" per your role instructions. This is the FIRST art pass — produce at least a hero, one enemy, one pickup, an impact VFX, and a background/tileset. Record frame sizes and file paths in journal.md.`;
-    case "build":
-      return `Read ./.studio/spec.md. Build the core gameplay loop for "${slug}" using the assets the artist generated (check journal.md for paths and frame sizes). Implement movement, the central mechanic, win/lose, and the mandatory craft pass. This is the first playable — make the first 10 seconds feel good. Verify with typecheck + build.`;
+      if (state.existingProject) {
+        return `${ctx}A project already exists in the current directory — do NOT run \`vg new\` (it would overwrite the existing code). Instead make it deployable: \`npm install\`, ensure \`npm run build\` and \`npm run typecheck\` succeed (add a typecheck script if missing), make sure a \`vibedgames.json\` with {"slug":"${slug}"} exists (\`vg deploy\` needs it), and add \`.studio/\` to .gitignore. Fix any build breakage. Append what you did to journal.md.`;
+      }
+      return `${ctx}Read ./.studio/spec.md for the engine choice. The current directory IS the game project root (it already contains the ./.studio folder). Scaffold the engine here by running \`vg new ${slug} --engine <phaser|threejs from spec> --here --force\`, then \`npm install\`. Confirm \`npm run build\` works on the fresh template. Append what you did to journal.md.`;
+    case "assets": {
+      const note = state.existingProject
+        ? "The project may already ship art — only generate what's MISSING or what the spec calls for; never delete existing assets."
+        : "This is the FIRST art pass — produce at least a hero, one enemy, one pickup, an impact VFX, and a background/tileset.";
+      return `${ctx}Read ./.studio/spec.md and produce the art for "${slug}" per your role instructions. ${note} Record frame sizes and file paths in journal.md.`;
+    }
+    case "build": {
+      const note = state.existingProject
+        ? "Build upon the EXISTING code (don't rewrite it from scratch); wire in the generated assets and bring the core loop up to the spec."
+        : "Implement movement, the central mechanic, win/lose, and the mandatory craft pass. This is the first playable — make the first 10 seconds feel good.";
+      return `${ctx}Read ./.studio/spec.md. Get the core gameplay loop for "${slug}" working using the assets the artist generated (check journal.md for paths and frame sizes). ${note} Verify with typecheck + build.`;
+    }
     case "playtest":
       return `Playtest the current build of "${slug}" per your role instructions and record findings in ./.studio/playtest.md and backlog.json.`;
     case "ship":

--- a/apps/agents/src/roles.ts
+++ b/apps/agents/src/roles.ts
@@ -36,7 +36,7 @@ export const ROLES: Record<RoleName, Role> = {
     emoji: "🎬",
     system: `${CHARTER}
 
-ROLE: Creative Director / Product Owner. You run this game like a studio. It has already shipped — your job is to decide what ships NEXT to make it a better, deeper, more-played game over time. You are NOT here to polish one corner forever.
+ROLE: Creative Director / Product Owner. You run this game like a studio — decide what the team builds, fixes, and ships NEXT to make it a better, deeper, more-played game over time. You are NOT here to polish one corner forever. (Your assignment will tell you whether the game is currently live or not yet deployed — plan accordingly; don't assume a release exists.)
 
 First, read playtest.md (newest findings), spec.md (the vision + feature log), backlog.json, and inspect the current game (skim src/, build it, read recent journal.md entries) to gauge its MATURITY and what it most needs right now.
 
@@ -161,8 +161,12 @@ export function buildTask(phase: Phase, state: StudioState, bb: Blackboard): str
       return `Playtest the current build of "${slug}" per your role instructions and record findings in ./.studio/playtest.md and backlog.json.`;
     case "ship":
       return `Ship "${slug}". Build and \`vg deploy ./dist\`, then record the live URL in journal.md.`;
-    case "plan":
-      return `Direct iteration ${state.iteration + 1} for "${slug}" like a studio. Read playtest.md and inspect the current game to gauge what it most needs now, triage ./.studio/backlog.json (ship-stoppers/bugs first, then the highest-impact feature / gameplay / balance / content / polish work for the game's current maturity — don't default to polish), and write ./.studio/next.json with the single most valuable next assignment.`;
+    case "plan": {
+      const release = state.shipped
+        ? `The game is live at ${state.deployUrl}.`
+        : "The game has NOT been deployed yet (no live release) — favor getting it to a shippable first release.";
+      return `Direct iteration ${state.iteration + 1} for "${slug}" like a studio. ${release} Read playtest.md and inspect the current game to gauge what it most needs now, triage ./.studio/backlog.json (ship-stoppers/bugs first, then the highest-impact feature / gameplay / balance / content / polish work for the game's current maturity — don't default to polish), and write ./.studio/next.json with the single most valuable next assignment.`;
+    }
     case "work": {
       const next = readNext(bb);
       const kind = next.type ? ` [${next.type}]` : "";

--- a/apps/agents/src/roles.ts
+++ b/apps/agents/src/roles.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+
+import type { Blackboard, Phase, StudioState } from "./state.js";
+
+export type RoleName = "director" | "designer" | "engineer" | "artist" | "qa" | "shipper";
+
+export type Role = {
+  name: RoleName;
+  emoji: string;
+  /** Appended to Claude Code's system prompt for every invocation in this role. */
+  system: string;
+};
+
+/**
+ * Shared charter injected into every specialist. It establishes the blackboard
+ * protocol and the hard rule that nobody ever waits on a human.
+ */
+const CHARTER = `You are one specialist in an AUTONOMOUS browser-game studio. A single game is being built and polished forever with ZERO human supervision — there is no one to ask, approve, or unblock you. Decide with strong, opinionated defaults and act.
+
+The game lives in your current working directory. Coordinate with the other specialists ONLY through the shared blackboard in ./.studio/:
+- spec.md        — the game design (owned by the designer)
+- backlog.json   — prioritized work, array of {id, title, detail, role, priority, status}
+- next.json      — the current assignment {role, task} (written by the director)
+- playtest.md    — QA findings, newest at the bottom
+- journal.md     — append-only log; add a 2–3 line entry every time you run
+
+Always start by reading the blackboard files that are relevant to your job, then do the work, then update the files you own and append to journal.md.
+
+Tooling: use the vibedgames Claude Code skills (game-playbook, phaser, threejs, game-feel, vfx, animation, pixel-art, generate, multiplayer, gamepad, playwright, deploy, design-lenses, level-design, onboarding, game-balance, ask-me) and the \`vg\` CLI. Prefer skill-documented commands.
+
+Quality bar: this is a real, shippable game, not a tech demo. Never leave placeholder/template art or logos. Verify code with \`npm run typecheck\` (and \`npm run build\` when relevant) before declaring a step done. Keep each step tightly scoped to your role — do not redesign the whole game in one turn.`;
+
+export const ROLES: Record<RoleName, Role> = {
+  director: {
+    name: "director",
+    emoji: "🎬",
+    system: `${CHARTER}
+
+ROLE: Creative Director. You own the loop's direction. Read spec.md, backlog.json, playtest.md, and inspect the current game (skim src/ and run \`npm run build\`/playtest output if useful). Apply the design-lenses and game-playbook craft lens to judge what most holds the game back from being GREAT right now.
+
+Then:
+1. Update ./.studio/backlog.json — keep it a clean, deduped, priority-ordered array of concrete tasks ({id, title, detail, role, priority, status}). role ∈ "engineer" | "artist" | "qa". Mark done items status:"done".
+2. Choose the single highest-leverage task to do next and write ./.studio/next.json EXACTLY as {"role": "engineer|artist|qa", "task": "<one crisp paragraph telling that specialist precisely what to build/change and why it matters>"}.
+Bias toward game feel, content variety, and the first-30-seconds experience. One game, polished forever — never start a different game.`,
+  },
+
+  designer: {
+    name: "designer",
+    emoji: "🧭",
+    system: `${CHARTER}
+
+ROLE: Game Designer. Turn the seed idea into a concrete, build-ready spec. Use the ask-me question tree, but ANSWER every question yourself with bold, coherent defaults — there is no human to interview. Use game-playbook to keep scope shippable.
+
+Write ./.studio/spec.md with: title; one-line pitch; genre; the 10-second core loop; controls (keyboard + touch); win/lose & failure loop; the single "juice moment" that must feel amazing; art direction (palette, vibe, references); minimum content to feel complete; and the ENGINE choice — write a line exactly like \`engine: phaser\` or \`engine: threejs\` (phaser for 2D/pixel/top-down/platformer, threejs for 3D/first-person/camera-driven). Keep the first playable scope deliberately small.`,
+  },
+
+  engineer: {
+    name: "engineer",
+    emoji: "🛠️",
+    system: `${CHARTER}
+
+ROLE: Game Engineer. Build and improve the actual game code with the phaser/threejs engine skill plus game-feel, vfx, animation and level-design. The CRAFT PASS is mandatory, not optional: every hit, kill, pickup, jump, land and damage event must have screen shake, hit-stop, knockback where relevant, particles, a hit flash, squash & stretch, and eased (never linear) tweens. Full-screen resizable canvas, tight follow camera, exact spritesheet frame dims. Wire real generated assets (never the template logo/placeholder). Always finish by running \`npm run typecheck\` and \`npm run build\` and fixing what breaks.`,
+  },
+
+  artist: {
+    name: "artist",
+    emoji: "🎨",
+    system: `${CHARTER}
+
+ROLE: Technical Artist. Generate game-ready assets with the \`vg generate\` CLI and the pixel-art / character-design / animated-spritesheets / cinematography skills, following the art direction in spec.md. Produce hero/enemy/pickup sprites and directional walk sheets, impact + ability VFX on pure black (for additive blend), and a ground/tileset or parallax backdrop. Remove backgrounds and NORMALIZE frames to consistent power-of-two cells, and record exact frame dimensions where code will load them. Place assets where the game expects them and update any asset manifest. Note in journal.md which files you produced and their frame sizes so the engineer can wire them.`,
+  },
+
+  qa: {
+    name: "qa",
+    emoji: "🔎",
+    system: `${CHARTER}
+
+ROLE: QA / Playtester. Be a harsh, specific critic. Build the game (\`npm run build\`) and drive it with the playwright skill (headless): move, attack, take damage, die, and restart. Judge it against the first-30-seconds bar from the onboarding skill and the feel bar from game-feel. Append a timestamped entry to ./.studio/playtest.md describing what is broken and what feels bad (floaty, laggy, unreadable, empty, confusing). File concrete, actionable items into ./.studio/backlog.json with the right target role. Do not change game code yourself — your output is findings.`,
+  },
+
+  shipper: {
+    name: "shipper",
+    emoji: "🚀",
+    system: `${CHARTER}
+
+ROLE: Release Engineer. Ship the current build live using the deploy skill. Run \`npm run build\`; if it fails, make the MINIMAL fix needed to build, then build again. Deploy with \`vg deploy ./dist\`. Confirm the deploy succeeds and capture the live \`{slug}.vibedgames.com\` URL. Append the URL and a one-line "what changed this release" note to journal.md. Do not add features — your job is to get the current state shipped cleanly.`,
+  },
+};
+
+/** Which specialist runs a given phase. `work` is routed dynamically. */
+export function roleForPhase(phase: Phase, bb: Blackboard): RoleName {
+  switch (phase) {
+    case "spec":
+      return "designer";
+    case "scaffold":
+    case "build":
+      return "engineer";
+    case "assets":
+      return "artist";
+    case "playtest":
+      return "qa";
+    case "ship":
+      return "shipper";
+    case "plan":
+      return "director";
+    case "work":
+      return readNext(bb).role;
+  }
+}
+
+type NextAssignment = { role: RoleName; task: string };
+
+function readNext(bb: Blackboard): NextAssignment {
+  try {
+    const parsed = JSON.parse(readFileSync(bb.next, "utf8")) as Partial<NextAssignment>;
+    const role = parsed.role;
+    if (role === "engineer" || role === "artist" || role === "qa") {
+      return { role, task: parsed.task ?? "" };
+    }
+  } catch {
+    // fall through to default
+  }
+  return {
+    role: "engineer",
+    task: "next.json was missing or invalid — pick the highest-priority unfinished item from .studio/backlog.json and implement it.",
+  };
+}
+
+/** The task ("user" turn) for a phase, grounded in current state. */
+export function buildTask(phase: Phase, state: StudioState, bb: Blackboard): string {
+  const slug = state.slug;
+  switch (phase) {
+    case "spec":
+      return `Design the game from this seed idea: "${state.idea}".\nThe game slug is "${slug}". Produce ./.studio/spec.md per your role instructions, then append a one-line summary to journal.md.`;
+    case "scaffold":
+      return `Read ./.studio/spec.md for the engine choice. The current directory IS the game project root (it already contains the ./.studio folder). Scaffold the engine here by running \`vg new ${slug} --engine <phaser|threejs from spec> --here --force\`, then \`npm install\`. Confirm \`npm run build\` works on the fresh template. Append what you did to journal.md.`;
+    case "assets":
+      return `Read ./.studio/spec.md and generate the initial art set for "${slug}" per your role instructions. This is the FIRST art pass — produce at least a hero, one enemy, one pickup, an impact VFX, and a background/tileset. Record frame sizes and file paths in journal.md.`;
+    case "build":
+      return `Read ./.studio/spec.md. Build the core gameplay loop for "${slug}" using the assets the artist generated (check journal.md for paths and frame sizes). Implement movement, the central mechanic, win/lose, and the mandatory craft pass. This is the first playable — make the first 10 seconds feel good. Verify with typecheck + build.`;
+    case "playtest":
+      return `Playtest the current build of "${slug}" per your role instructions and record findings in ./.studio/playtest.md and backlog.json.`;
+    case "ship":
+      return `Ship "${slug}". Build and \`vg deploy ./dist\`, then record the live URL in journal.md.`;
+    case "plan":
+      return `Direct the next polish iteration for "${slug}" (iteration ${state.iteration + 1}). Inspect the game and the blackboard, update backlog.json, and write ./.studio/next.json with the single most valuable next task.`;
+    case "work": {
+      const next = readNext(bb);
+      return `Current assignment from the director (./.studio/next.json):\n\n${next.task}\n\nDo exactly this for "${slug}", then mark the item done in backlog.json and append a note to journal.md.`;
+    }
+  }
+}

--- a/apps/agents/src/roles.ts
+++ b/apps/agents/src/roles.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 
-import type { Blackboard, Phase, StudioState } from "./state.js";
+import type { Blackboard, Phase, StudioState } from "./state.ts";
 
 export type RoleName = "director" | "designer" | "engineer" | "artist" | "qa" | "shipper";
 

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -28,6 +28,12 @@ export type StudioState = {
   cycle: number;
   /** Completed studio iterations shipped (post first ship). */
   iteration: number;
+  /**
+   * Consecutive failures on the CURRENT phase. Persisted so a stop/restart
+   * doesn't reset the retry budget — a phase that keeps failing still reaches
+   * the skip-ahead threshold and advances instead of getting stuck forever.
+   */
+  phaseFailures: number;
   shipped: boolean;
   deployUrl: string | null;
   totalCostUsd: number;

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -167,7 +167,7 @@ export function approvalPending(bb: Blackboard, lastApproval: string | null): bo
   return token !== null && token !== lastApproval;
 }
 
-/** Grant a one-shot deploy approval (written by `vg-studio approve`). */
+/** Grant a one-shot deploy approval (written by `pnpm approve <slug>`). */
 export function requestApproval(bb: Blackboard): void {
   mkdirSync(bb.dir, { recursive: true });
   // The nonce makes every approval a distinct token, so the orchestrator can

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -37,6 +37,8 @@ export type StudioState = {
   phaseFailures: number;
   /** True when the studio is building ON an existing project in the game dir. */
   existingProject: boolean;
+  /** Absolute path of a --context reference directory, persisted across resumes. */
+  contextDir: string | null;
   /** True once the first playable build exists — gates deploy preemption. */
   built: boolean;
   /**

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 /**
@@ -34,6 +35,17 @@ export type StudioState = {
    * the skip-ahead threshold and advances instead of getting stuck forever.
    */
   phaseFailures: number;
+  /** True when the studio is building ON an existing project in the game dir. */
+  existingProject: boolean;
+  /** True once the first playable build exists — gates deploy preemption. */
+  built: boolean;
+  /**
+   * Token of the last deploy approval that was acted on. Approval is "pending"
+   * only when the APPROVE sentinel's token differs from this — so consumption
+   * is authoritative in persisted state and a failed file delete can't let one
+   * approval trigger a second deploy.
+   */
+  lastApproval: string | null;
   shipped: boolean;
   deployUrl: string | null;
   totalCostUsd: number;
@@ -51,6 +63,7 @@ export type Blackboard = {
   next: string;
   playtest: string;
   journal: string;
+  context: string;
   stop: string;
   approve: string;
   lock: string;
@@ -67,10 +80,26 @@ export function blackboard(workspace: string): Blackboard {
     next: resolve(dir, "next.json"),
     playtest: resolve(dir, "playtest.md"),
     journal: resolve(dir, "journal.md"),
+    context: resolve(dir, "context.md"),
     stop: resolve(dir, "STOP"),
     approve: resolve(dir, "APPROVE"),
     lock: resolve(dir, "studio.lock"),
   };
+}
+
+/**
+ * Does the game directory already hold a project to build upon? True when it
+ * contains anything other than the studio's own bookkeeping — so pointing the
+ * studio at an existing app adopts it instead of scaffolding fresh.
+ */
+export function hasExistingProject(dir: string): boolean {
+  try {
+    if (!existsSync(dir)) return false;
+    const ignore = new Set([".studio", ".git", ".DS_Store"]);
+    return readdirSync(dir).some((entry) => !ignore.has(entry));
+  } catch {
+    return false;
+  }
 }
 
 export function initWorkspace(bb: Blackboard, seed: StudioState): StudioState {
@@ -116,40 +145,77 @@ export function clearStop(bb: Blackboard): void {
   }
 }
 
-/** A human has approved the current build for ONE deployment. */
-export function approvalRequested(bb: Blackboard): boolean {
-  return existsSync(bb.approve);
+/** The current approval token (APPROVE file contents), or null if none. */
+export function approvalToken(bb: Blackboard): string | null {
+  try {
+    const token = readFileSync(bb.approve, "utf8").trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is there an unacted-on deploy approval? Pending only when the sentinel's
+ * token differs from the last one we consumed (tracked in persisted state), so
+ * a one-shot approval can't be re-used even if the file fails to delete.
+ */
+export function approvalPending(bb: Blackboard, lastApproval: string | null): boolean {
+  const token = approvalToken(bb);
+  return token !== null && token !== lastApproval;
 }
 
 /** Grant a one-shot deploy approval (written by `vg-studio approve`). */
 export function requestApproval(bb: Blackboard): void {
   mkdirSync(bb.dir, { recursive: true });
-  writeFileSync(bb.approve, `approved ${new Date().toISOString()}\n`);
+  // The nonce makes every approval a distinct token, so the orchestrator can
+  // tell a fresh approval from one it already deployed.
+  writeFileSync(bb.approve, `approved ${new Date().toISOString()} ${randomUUID()}\n`);
 }
 
-/** Consume the one-shot approval after a successful deploy. */
+/** Best-effort removal of the approval sentinel after it's been acted on. */
 export function consumeApproval(bb: Blackboard): void {
   try {
     if (existsSync(bb.approve)) rmSync(bb.approve);
   } catch {
-    /* ignore */
+    /* ignore — consumption is authoritative via state.lastApproval */
   }
 }
 
-/** The pid currently owning the workspace lock, or null if free/stale. */
-function lockOwner(bb: Blackboard): number | null {
+type LockStatus =
+  | { state: "free" } // no lock file
+  | { state: "alive"; pid: number } // a live owner (possibly another user's process)
+  | { state: "stale" } // dead owner, our own prior pid, or junk contents — reclaimable
+  | { state: "unknown" }; // exists but couldn't be read (transient IO) — do NOT reclaim
+
+/** Inspect the lock file without mutating it. */
+function readLock(bb: Blackboard): LockStatus {
+  let raw: string;
   try {
-    const { pid } = JSON.parse(readFileSync(bb.lock, "utf8")) as { pid?: number };
-    if (typeof pid !== "number" || !Number.isFinite(pid)) return null;
-    try {
-      process.kill(pid, 0); // probe liveness without signalling
-      return pid;
-    } catch (err) {
-      // EPERM => process exists but isn't ours; ESRCH => gone (stale lock).
-      return (err as NodeJS.ErrnoException).code === "EPERM" ? pid : null;
-    }
+    raw = readFileSync(bb.lock, "utf8");
+  } catch (err) {
+    // Gone => free to take. Any other read error (e.g. transient EACCES) is
+    // ambiguous; treat as held so we never delete a possibly-live lock.
+    return (err as NodeJS.ErrnoException).code === "ENOENT"
+      ? { state: "free" }
+      : { state: "unknown" };
+  }
+  let pid: number | undefined;
+  try {
+    pid = (JSON.parse(raw) as { pid?: number }).pid;
   } catch {
-    return null;
+    return { state: "stale" }; // corrupt contents — safe to reclaim
+  }
+  if (typeof pid !== "number" || !Number.isFinite(pid)) return { state: "stale" };
+  if (pid === process.pid) return { state: "stale" }; // our own lock from a prior run
+  try {
+    process.kill(pid, 0); // probe liveness without signalling
+    return { state: "alive", pid };
+  } catch (err) {
+    // EPERM => the process exists but isn't ours (alive); ESRCH => gone (stale).
+    return (err as NodeJS.ErrnoException).code === "EPERM"
+      ? { state: "alive", pid }
+      : { state: "stale" };
   }
 }
 
@@ -160,8 +226,8 @@ export const LOCK_BUSY_UNKNOWN = -1;
  * Take the per-workspace lock so only one studio runs per game. Claims it via
  * an atomic exclusive create (O_EXCL) so two simultaneous `start`s can't both
  * see an empty slot and proceed. Returns null on success; otherwise the live
- * owner pid (or LOCK_BUSY_UNKNOWN). A stale lock left by a dead process is
- * reclaimed.
+ * owner pid (or LOCK_BUSY_UNKNOWN). Only a genuinely stale lock is reclaimed —
+ * an unreadable lock file is treated as held, never deleted.
  */
 export function acquireLock(bb: Blackboard): number | null {
   mkdirSync(bb.dir, { recursive: true });
@@ -173,9 +239,10 @@ export function acquireLock(bb: Blackboard): number | null {
       return null;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-      const owner = lockOwner(bb);
-      if (owner !== null && owner !== process.pid) return owner; // a live, different owner
-      // Stale (dead owner) or ours from a prior run — drop it and retry once.
+      const status = readLock(bb);
+      if (status.state === "alive") return status.pid;
+      if (status.state === "unknown") return LOCK_BUSY_UNKNOWN; // don't reclaim a lock we can't read
+      // free (vanished between create and read) or stale — drop and retry once.
       try {
         rmSync(bb.lock);
       } catch {
@@ -183,7 +250,8 @@ export function acquireLock(bb: Blackboard): number | null {
       }
     }
   }
-  return lockOwner(bb) ?? LOCK_BUSY_UNKNOWN;
+  const final = readLock(bb);
+  return final.state === "alive" ? final.pid : LOCK_BUSY_UNKNOWN;
 }
 
 /** Release the lock if (and only if) we own it. */

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 /**
@@ -45,6 +45,7 @@ export type Blackboard = {
   playtest: string;
   journal: string;
   stop: string;
+  lock: string;
 };
 
 export function blackboard(workspace: string): Blackboard {
@@ -59,6 +60,7 @@ export function blackboard(workspace: string): Blackboard {
     playtest: resolve(dir, "playtest.md"),
     journal: resolve(dir, "journal.md"),
     stop: resolve(dir, "STOP"),
+    lock: resolve(dir, "studio.lock"),
   };
 }
 
@@ -94,4 +96,53 @@ export function appendJournal(bb: Blackboard, line: string): void {
 
 export function stopRequested(bb: Blackboard): boolean {
   return existsSync(bb.stop);
+}
+
+/** Remove a stale STOP sentinel. Only safe to call while holding the lock. */
+export function clearStop(bb: Blackboard): void {
+  try {
+    if (existsSync(bb.stop)) rmSync(bb.stop);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** The pid currently owning the workspace lock, or null if free/stale. */
+function lockOwner(bb: Blackboard): number | null {
+  try {
+    const { pid } = JSON.parse(readFileSync(bb.lock, "utf8")) as { pid?: number };
+    if (typeof pid !== "number" || !Number.isFinite(pid)) return null;
+    try {
+      process.kill(pid, 0); // probe liveness without signalling
+      return pid;
+    } catch (err) {
+      // EPERM => process exists but isn't ours; ESRCH => gone (stale lock).
+      return (err as NodeJS.ErrnoException).code === "EPERM" ? pid : null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Take the per-workspace lock so only one studio runs per game. Returns the
+ * live owner pid if another process already holds it; otherwise claims the lock
+ * (taking over a stale one) and returns null.
+ */
+export function acquireLock(bb: Blackboard): number | null {
+  const owner = lockOwner(bb);
+  if (owner !== null && owner !== process.pid) return owner;
+  mkdirSync(bb.dir, { recursive: true });
+  writeFileSync(bb.lock, `${JSON.stringify({ pid: process.pid, at: new Date().toISOString() })}\n`);
+  return null;
+}
+
+/** Release the lock if (and only if) we own it. */
+export function releaseLock(bb: Blackboard): void {
+  try {
+    const { pid } = JSON.parse(readFileSync(bb.lock, "utf8")) as { pid?: number };
+    if (pid === process.pid) rmSync(bb.lock);
+  } catch {
+    /* ignore */
+  }
 }

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -124,17 +124,37 @@ function lockOwner(bb: Blackboard): number | null {
   }
 }
 
+/** Sentinel pid for "lock is held but we couldn't read whose it is". */
+export const LOCK_BUSY_UNKNOWN = -1;
+
 /**
- * Take the per-workspace lock so only one studio runs per game. Returns the
- * live owner pid if another process already holds it; otherwise claims the lock
- * (taking over a stale one) and returns null.
+ * Take the per-workspace lock so only one studio runs per game. Claims it via
+ * an atomic exclusive create (O_EXCL) so two simultaneous `start`s can't both
+ * see an empty slot and proceed. Returns null on success; otherwise the live
+ * owner pid (or LOCK_BUSY_UNKNOWN). A stale lock left by a dead process is
+ * reclaimed.
  */
 export function acquireLock(bb: Blackboard): number | null {
-  const owner = lockOwner(bb);
-  if (owner !== null && owner !== process.pid) return owner;
   mkdirSync(bb.dir, { recursive: true });
-  writeFileSync(bb.lock, `${JSON.stringify({ pid: process.pid, at: new Date().toISOString() })}\n`);
-  return null;
+  const payload = `${JSON.stringify({ pid: process.pid, at: new Date().toISOString() })}\n`;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      // "wx" => fail if the file already exists; the create is atomic.
+      writeFileSync(bb.lock, payload, { flag: "wx" });
+      return null;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      const owner = lockOwner(bb);
+      if (owner !== null && owner !== process.pid) return owner; // a live, different owner
+      // Stale (dead owner) or ours from a prior run — drop it and retry once.
+      try {
+        rmSync(bb.lock);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return lockOwner(bb) ?? LOCK_BUSY_UNKNOWN;
 }
 
 /** Release the lock if (and only if) we own it. */

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -5,7 +5,8 @@ import { resolve } from "node:path";
  * The studio advances a single game through a fixed phase machine. The first
  * pass (spec → scaffold → assets → build → playtest → ship) takes a one-line
  * idea to a deployed game. After the first ship it enters the forever loop
- * (plan → work → playtest → ship → plan …), polishing the same game until the
+ * (plan → work → playtest → ship → plan …), evolving the same game like a
+ * studio — bugs, features, gameplay/balance, content, polish — until the
  * operator stops it.
  */
 export type Phase =
@@ -25,7 +26,7 @@ export type StudioState = {
   phase: Phase;
   /** Total specialist invocations so far. */
   cycle: number;
-  /** Completed polish iterations (post first ship). */
+  /** Completed studio iterations shipped (post first ship). */
   iteration: number;
   shipped: boolean;
   deployUrl: string | null;

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * The studio advances a single game through a fixed phase machine. The first
+ * pass (spec → scaffold → assets → build → playtest → ship) takes a one-line
+ * idea to a deployed game. After the first ship it enters the forever loop
+ * (plan → work → playtest → ship → plan …), polishing the same game until the
+ * operator stops it.
+ */
+export type Phase =
+  | "spec"
+  | "scaffold"
+  | "assets"
+  | "build"
+  | "playtest"
+  | "ship"
+  | "plan"
+  | "work";
+
+export type StudioState = {
+  slug: string;
+  idea: string;
+  model: string;
+  phase: Phase;
+  /** Total specialist invocations so far. */
+  cycle: number;
+  /** Completed polish iterations (post first ship). */
+  iteration: number;
+  shipped: boolean;
+  deployUrl: string | null;
+  totalCostUsd: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** Resolved paths for the per-game blackboard the specialists coordinate through. */
+export type Blackboard = {
+  root: string;
+  dir: string;
+  state: string;
+  spec: string;
+  backlog: string;
+  next: string;
+  playtest: string;
+  journal: string;
+  stop: string;
+};
+
+export function blackboard(workspace: string): Blackboard {
+  const dir = resolve(workspace, ".studio");
+  return {
+    root: workspace,
+    dir,
+    state: resolve(dir, "state.json"),
+    spec: resolve(dir, "spec.md"),
+    backlog: resolve(dir, "backlog.json"),
+    next: resolve(dir, "next.json"),
+    playtest: resolve(dir, "playtest.md"),
+    journal: resolve(dir, "journal.md"),
+    stop: resolve(dir, "STOP"),
+  };
+}
+
+export function initWorkspace(bb: Blackboard, seed: StudioState): StudioState {
+  mkdirSync(bb.dir, { recursive: true });
+  if (existsSync(bb.state)) {
+    const existing = loadState(bb);
+    // Preserve progress across restarts; refresh the idea/model if re-seeded.
+    return existing;
+  }
+  if (!existsSync(bb.backlog)) writeFileSync(bb.backlog, "[]\n");
+  if (!existsSync(bb.journal)) {
+    writeFileSync(bb.journal, `# ${seed.slug} — studio journal\n\nSeed idea: ${seed.idea}\n`);
+  }
+  saveState(bb, seed);
+  return seed;
+}
+
+export function loadState(bb: Blackboard): StudioState {
+  return JSON.parse(readFileSync(bb.state, "utf8")) as StudioState;
+}
+
+export function saveState(bb: Blackboard, state: StudioState): void {
+  state.updatedAt = new Date().toISOString();
+  writeFileSync(bb.state, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+export function appendJournal(bb: Blackboard, line: string): void {
+  const stamp = new Date().toISOString();
+  const body = existsSync(bb.journal) ? readFileSync(bb.journal, "utf8") : "";
+  writeFileSync(bb.journal, `${body.replace(/\s*$/, "")}\n\n- [${stamp}] ${line}\n`);
+}
+
+export function stopRequested(bb: Blackboard): boolean {
+  return existsSync(bb.stop);
+}

--- a/apps/agents/src/state.ts
+++ b/apps/agents/src/state.ts
@@ -46,6 +46,7 @@ export type Blackboard = {
   playtest: string;
   journal: string;
   stop: string;
+  approve: string;
   lock: string;
 };
 
@@ -61,6 +62,7 @@ export function blackboard(workspace: string): Blackboard {
     playtest: resolve(dir, "playtest.md"),
     journal: resolve(dir, "journal.md"),
     stop: resolve(dir, "STOP"),
+    approve: resolve(dir, "APPROVE"),
     lock: resolve(dir, "studio.lock"),
   };
 }
@@ -103,6 +105,26 @@ export function stopRequested(bb: Blackboard): boolean {
 export function clearStop(bb: Blackboard): void {
   try {
     if (existsSync(bb.stop)) rmSync(bb.stop);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** A human has approved the current build for ONE deployment. */
+export function approvalRequested(bb: Blackboard): boolean {
+  return existsSync(bb.approve);
+}
+
+/** Grant a one-shot deploy approval (written by `vg-studio approve`). */
+export function requestApproval(bb: Blackboard): void {
+  mkdirSync(bb.dir, { recursive: true });
+  writeFileSync(bb.approve, `approved ${new Date().toISOString()}\n`);
+}
+
+/** Consume the one-shot approval after a successful deploy. */
+export function consumeApproval(bb: Blackboard): void {
+  try {
+    if (existsSync(bb.approve)) rmSync(bb.approve);
   } catch {
     /* ignore */
   }

--- a/apps/agents/tsconfig.json
+++ b/apps/agents/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@kyh/tsconfig/base.json",
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "noEmit": false,
+    "declaration": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/apps/agents/tsconfig.json
+++ b/apps/agents/tsconfig.json
@@ -3,11 +3,7 @@
   "compilerOptions": {
     "lib": ["ES2023"],
     "types": ["node"],
-    "noEmit": false,
-    "declaration": false,
-    "outDir": "dist",
-    "rootDir": "src",
-    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }

--- a/apps/party/src/server.ts
+++ b/apps/party/src/server.ts
@@ -78,7 +78,9 @@ export class VgServer extends Server {
     const now = Date.now();
     if (now - (this.room.lastSeen[host] ?? 0) <= HOST_LIVENESS_TIMEOUT_MS) return;
     const next = Object.keys(this.room.players)
-      .filter((id) => id !== host && now - (this.room.lastSeen[id] ?? 0) <= HOST_LIVENESS_TIMEOUT_MS)
+      .filter(
+        (id) => id !== host && now - (this.room.lastSeen[id] ?? 0) <= HOST_LIVENESS_TIMEOUT_MS,
+      )
       .sort()[0];
     if (!next) return; // nobody healthier to hand off to — keep the current host
     this.room.hostId = next;

--- a/games/moba/src/scenes/game-scene.ts
+++ b/games/moba/src/scenes/game-scene.ts
@@ -501,7 +501,9 @@ export class GameScene extends Phaser.Scene {
       );
       const target =
         hovered ??
-        (wantAlly ? (this.lowestAllyInRange(me, def.castRange) ?? me) : this.nearestEnemy(me, def.castRange));
+        (wantAlly
+          ? (this.lowestAllyInRange(me, def.castRange) ?? me)
+          : this.nearestEnemy(me, def.castRange));
       if (target) this.cmd({ kind: "cast", key, targetId: target.id });
     } else if (def.targeting === "point") {
       const r = def.castRange;
@@ -602,7 +604,10 @@ export class GameScene extends Phaser.Scene {
     }
     // auto-attack acquisition: while holding/idle/attack-moving the hero attacks the
     // nearest enemy in range — keep the reticle pinned to it the whole time.
-    if (!id && (me.order.type === "idle" || me.order.type === "hold" || me.order.type === "attackMove")) {
+    if (
+      !id &&
+      (me.order.type === "idle" || me.order.type === "hold" || me.order.type === "attackMove")
+    ) {
       const t = this.engageTarget(me);
       if (t) id = t.id;
     }

--- a/games/moba/src/sim/grid.ts
+++ b/games/moba/src/sim/grid.ts
@@ -30,13 +30,7 @@ export class NavGrid {
   private elevLvl: Int8Array;
   private rampFlag: Uint8Array;
 
-  constructor(
-    worldW: number,
-    worldH: number,
-    cell: number,
-    blockers: Blocker[],
-    meta?: ElevMeta,
-  ) {
+  constructor(worldW: number, worldH: number, cell: number, blockers: Blocker[], meta?: ElevMeta) {
     this.cell = cell;
     this.cols = Math.ceil(worldW / cell);
     this.rows = Math.ceil(worldH / cell);

--- a/games/starfall/src/scenes/game-scene.ts
+++ b/games/starfall/src/scenes/game-scene.ts
@@ -722,7 +722,12 @@ export class GameScene extends Phaser.Scene {
       [-MASK_PAD, -MASK_PAD, WORLD_W + MASK_PAD * 2, MASK_PAD - WORLD_BLEED_PX],
       [-MASK_PAD, WORLD_H + WORLD_BLEED_PX, WORLD_W + MASK_PAD * 2, MASK_PAD - WORLD_BLEED_PX],
       [-MASK_PAD, -WORLD_BLEED_PX, MASK_PAD - WORLD_BLEED_PX, WORLD_H + WORLD_BLEED_PX * 2],
-      [WORLD_W + WORLD_BLEED_PX, -WORLD_BLEED_PX, MASK_PAD - WORLD_BLEED_PX, WORLD_H + WORLD_BLEED_PX * 2],
+      [
+        WORLD_W + WORLD_BLEED_PX,
+        -WORLD_BLEED_PX,
+        MASK_PAD - WORLD_BLEED_PX,
+        WORLD_H + WORLD_BLEED_PX * 2,
+      ],
     ];
     for (const [x, y, w, h] of edges) {
       this.add.rectangle(x, y, w, h, 0x020617).setOrigin(0).setDepth(50);
@@ -1009,8 +1014,7 @@ export class GameScene extends Phaser.Scene {
   /** Rewrite the attract hint for the touch control scheme. Fired once, the
    *  first time the gamepad sees a finger. */
   private enterTouchMode(): void {
-    if (this.attractEl)
-      this.attractEl.innerHTML = "Drag to move. Tap to shoot";
+    if (this.attractEl) this.attractEl.innerHTML = "Drag to move. Tap to shoot";
   }
 
   /** Holding fire: any non-stick finger on touch, or the mouse button on desktop. */
@@ -1743,7 +1747,8 @@ export class GameScene extends Phaser.Scene {
         b.head.y += Math.sin(b.angle) * step;
         b.tail.x = b.head.x - Math.cos(b.angle) * b.weapon.length;
         b.tail.y = b.head.y - Math.sin(b.angle) * b.weapon.length;
-        if (!inWorld(b.head.x, b.head.y, BEAM_CULL_MARGIN, this.world.playW, this.world.playH)) b.vanished = true;
+        if (!inWorld(b.head.x, b.head.y, BEAM_CULL_MARGIN, this.world.playW, this.world.playH))
+          b.vanished = true;
         continue;
       }
       // HOMING: steer toward the live lock, capped turn rate.
@@ -1769,7 +1774,10 @@ export class GameScene extends Phaser.Scene {
         continue;
       }
       // RICOCHET: bounce off the world edge while bounces remain.
-      if (b.bouncesLeft > 0 && !inWorld(b.head.x, b.head.y, 0, this.world.playW, this.world.playH)) {
+      if (
+        b.bouncesLeft > 0 &&
+        !inWorld(b.head.x, b.head.y, 0, this.world.playW, this.world.playH)
+      ) {
         this.ricochetEdgeBounce(b);
       }
       if (!inWorld(b.head.x, b.head.y, BEAM_CULL_MARGIN, this.world.playW, this.world.playH)) {
@@ -3937,7 +3945,13 @@ export class GameScene extends Phaser.Scene {
           sim.fireAt = 0;
           sim.nextAttackAt = now + BOSS_P3_CYCLE_MS;
           for (let i = 0; i < BOSS_P3_NOVA_COUNT; i++) {
-            this.hostSpawnShot(e.x, e.y, (Math.PI * 2 * i) / BOSS_P3_NOVA_COUNT, BOSS_SHOT_SPEED, now);
+            this.hostSpawnShot(
+              e.x,
+              e.y,
+              (Math.PI * 2 * i) / BOSS_P3_NOVA_COUNT,
+              BOSS_SHOT_SPEED,
+              now,
+            );
           }
           // Cap the brood so a long phase-3 can't balloon enemies[] unbounded.
           if (sim.broodCount < BOSS_BROOD_CAP) this.hostBirthMites(e, BOSS_P3_MITES, now);
@@ -3994,7 +4008,8 @@ export class GameScene extends Phaser.Scene {
     let placed: { x: number; y: number; ang: number } | null = null;
     for (let i = 0; i < 8 && !placed; i++) {
       const c = edgeSpawn(30, this.world.playW, this.world.playH);
-      if (players.every((p) => Math.hypot(p.x - c.x, p.y - c.y) >= ENEMY_SPAWN_CLEARANCE)) placed = c;
+      if (players.every((p) => Math.hypot(p.x - c.x, p.y - c.y) >= ENEMY_SPAWN_CLEARANCE))
+        placed = c;
     }
     if (!placed) return;
     const e = spawnEnemyState("dreadnought", placed.x, placed.y);
@@ -4700,10 +4715,18 @@ export class GameScene extends Phaser.Scene {
       if (boss) {
         // Big multi-ring death blast for the marquee kill.
         this.fx.ring(x, y, 10, 140, 500, 0xffffff, 0.9);
-        this.fx.sparks(x, y, 40, spec.tint, { speedMin: 120, speedMax: 360, lifeMin: 300, lifeMax: 600 });
+        this.fx.sparks(x, y, 40, spec.tint, {
+          speedMin: 120,
+          speedMax: 360,
+          lifeMin: 300,
+          lifeMax: 600,
+        });
       }
       if (this.onScreen(x, y)) {
-        sfx.play("enemy_death", boss ? { gain: 1.5, rate: 0.6 } : big ? { gain: 1.3, rate: 0.8 } : {});
+        sfx.play(
+          "enemy_death",
+          boss ? { gain: 1.5, rate: 0.6 } : big ? { gain: 1.3, rate: 0.8 } : {},
+        );
         this.trauma.add(boss ? 0.5 : big ? 0.18 : 0.1);
       }
       rec.gfx.destroy();
@@ -4773,7 +4796,11 @@ export class GameScene extends Phaser.Scene {
           // Phase-1/3 muzzle bloom during the windup.
           const p = Math.min(1, (e.telegraphUntil - now) / 600);
           g.fillStyle(ENEMY_SPECS.dreadnought.tint, 0.5);
-          g.fillCircle(e.x + Math.cos(e.angle) * 40, e.y + Math.sin(e.angle) * 40, 4 + 10 * (1 - p));
+          g.fillCircle(
+            e.x + Math.cos(e.angle) * 40,
+            e.y + Math.sin(e.angle) * 40,
+            4 + 10 * (1 - p),
+          );
         }
       }
     }
@@ -5850,13 +5877,7 @@ function blinkAlpha(now: number): number {
   return Math.floor(now / INVULN_BLINK_MS) % 2 === 0 ? 0.9 : 0.3;
 }
 
-function inWorld(
-  x: number,
-  y: number,
-  margin: number,
-  w = WORLD_W,
-  h = WORLD_H,
-): boolean {
+function inWorld(x: number, y: number, margin: number, w = WORLD_W, h = WORLD_H): boolean {
   return x >= -margin && x <= w + margin && y >= -margin && y <= h + margin;
 }
 

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -180,8 +180,14 @@
         <div class="group">
           <div class="pill" id="score">SCORE 0</div>
           <div class="pill" id="lines">LINES 0</div>
-          <div class="pill preview"><span class="plabel">NEXT</span><canvas id="next-canvas" width="200" height="132"></canvas></div>
-          <div class="pill preview"><span class="plabel">HOLD</span><canvas id="hold-canvas" width="200" height="132"></canvas></div>
+          <div class="pill preview">
+            <span class="plabel">NEXT</span
+            ><canvas id="next-canvas" width="200" height="132"></canvas>
+          </div>
+          <div class="pill preview">
+            <span class="plabel">HOLD</span
+            ><canvas id="hold-canvas" width="200" height="132"></canvas>
+          </div>
         </div>
         <div class="group">
           <div class="pill" id="charge">POWER 0%</div>
@@ -190,8 +196,14 @@
       </div>
       <div class="bottom">
         <div id="legend">
-          <span><b>keys</b>move ←→↑↓ · rotate R · turn view Q/E · drop SPACE · soft SHIFT · hold C · power F · recenter V · pause P</span>
-          <span><b>webcam</b>nose = move · spin = rotate · circle a hand = turn view · cross arms = hold · T-pose = power · hands up = start/catch</span>
+          <span
+            ><b>keys</b>move ←→↑↓ · rotate R · turn view Q/E · drop SPACE · soft SHIFT · hold C ·
+            power F · recenter V · pause P</span
+          >
+          <span
+            ><b>webcam</b>nose = move · spin = rotate · circle a hand = turn view · cross arms =
+            hold · T-pose = power · hands up = start/catch</span
+          >
         </div>
         <div class="pill" id="controls">move ←→↑↓ · rotate R · orbit Q/E · hold C · drop ⎵</div>
       </div>

--- a/games/tetris/src/fx/particles.ts
+++ b/games/tetris/src/fx/particles.ts
@@ -3,7 +3,17 @@
 // background tone, so they dissolve cleanly on the dark backdrop. One pool,
 // preallocated, no per-event allocation (adapted from pong's pool).
 
-import { Color, DynamicDrawUsage, InstancedMesh, Matrix4, MeshBasicMaterial, Quaternion, type Scene, SphereGeometry, Vector3 } from "three";
+import {
+  Color,
+  DynamicDrawUsage,
+  InstancedMesh,
+  Matrix4,
+  MeshBasicMaterial,
+  Quaternion,
+  type Scene,
+  SphereGeometry,
+  Vector3,
+} from "three";
 
 import { BG } from "../shared/constants";
 

--- a/games/tetris/src/game/board.ts
+++ b/games/tetris/src/game/board.ts
@@ -208,9 +208,7 @@ export class Board {
   }
 
   /** Visit every locked cube (for rendering / physics handoff). */
-  forEachCube(
-    cb: (x: number, y: number, z: number, colorIndex: number, id: number) => void,
-  ): void {
+  forEachCube(cb: (x: number, y: number, z: number, colorIndex: number, id: number) => void): void {
     for (let x = 0; x < this.width; x++) {
       for (let y = 0; y < this.height; y++) {
         for (let z = 0; z < this.depth; z++) {

--- a/games/tetris/src/game/camera-correction.ts
+++ b/games/tetris/src/game/camera-correction.ts
@@ -13,13 +13,33 @@ export type Move = { dx: number; dz: number };
 // mapping a quarter turn so the slab always tracks the player's screen.
 const TABLE: Record<ScreenDir, Move>[] = [
   // corner 0
-  { left: { dx: -1, dz: 0 }, right: { dx: 1, dz: 0 }, away: { dx: 0, dz: -1 }, near: { dx: 0, dz: 1 } },
+  {
+    left: { dx: -1, dz: 0 },
+    right: { dx: 1, dz: 0 },
+    away: { dx: 0, dz: -1 },
+    near: { dx: 0, dz: 1 },
+  },
   // corner 1
-  { left: { dx: 0, dz: 1 }, right: { dx: 0, dz: -1 }, away: { dx: -1, dz: 0 }, near: { dx: 1, dz: 0 } },
+  {
+    left: { dx: 0, dz: 1 },
+    right: { dx: 0, dz: -1 },
+    away: { dx: -1, dz: 0 },
+    near: { dx: 1, dz: 0 },
+  },
   // corner 2
-  { left: { dx: 1, dz: 0 }, right: { dx: -1, dz: 0 }, away: { dx: 0, dz: 1 }, near: { dx: 0, dz: -1 } },
+  {
+    left: { dx: 1, dz: 0 },
+    right: { dx: -1, dz: 0 },
+    away: { dx: 0, dz: 1 },
+    near: { dx: 0, dz: -1 },
+  },
   // corner 3
-  { left: { dx: 0, dz: -1 }, right: { dx: 0, dz: 1 }, away: { dx: 1, dz: 0 }, near: { dx: -1, dz: 0 } },
+  {
+    left: { dx: 0, dz: -1 },
+    right: { dx: 0, dz: 1 },
+    away: { dx: 1, dz: 0 },
+    near: { dx: -1, dz: 0 },
+  },
 ];
 
 /** Resolve a screen-relative direction to a world move for the active corner. */

--- a/games/tetris/src/input/pose-control.ts
+++ b/games/tetris/src/input/pose-control.ts
@@ -103,7 +103,15 @@ export class PoseControls {
     const rightHip = find("right_hip");
     const nose = find("nose");
 
-    if (!leftWrist || !rightWrist || !leftShoulder || !rightShoulder || !leftHip || !rightHip || !nose) {
+    if (
+      !leftWrist ||
+      !rightWrist ||
+      !leftShoulder ||
+      !rightShoulder ||
+      !leftHip ||
+      !rightHip ||
+      !nose
+    ) {
       this.hasPrev = false;
       return;
     }
@@ -150,7 +158,10 @@ export class PoseControls {
       const shoulderSign = Math.sign(rightShoulder.x - leftShoulder.x);
       const wristSign = Math.sign(rightWrist.x - leftWrist.x);
       const wristsAtChest =
-        leftWrist.y > shoulderY && leftWrist.y < hipY && rightWrist.y > shoulderY && rightWrist.y < hipY;
+        leftWrist.y > shoulderY &&
+        leftWrist.y < hipY &&
+        rightWrist.y > shoulderY &&
+        rightWrist.y < hipY;
       const crossed = shoulderSign !== 0 && wristSign === -shoulderSign && wristsAtChest;
       if (!crossed) this.holdArmed = true;
       if (this.holdArmed && crossed && now - this.lastHoldTime > HOLD_COOLDOWN_MS) {
@@ -242,7 +253,10 @@ export class PoseControls {
     this.circleAngle = ang;
     this.hasCircleAngle = true;
 
-    if (Math.abs(this.circleAccum) > CIRCLE_TRIGGER_RAD && now - this.lastOrbitTime > ORBIT_COOLDOWN_MS) {
+    if (
+      Math.abs(this.circleAccum) > CIRCLE_TRIGGER_RAD &&
+      now - this.lastOrbitTime > ORBIT_COOLDOWN_MS
+    ) {
       this.actions.orbit(this.circleAccum > 0 ? 1 : -1);
       this.lastOrbitTime = now;
       this.circleAccum = 0;

--- a/games/tetris/src/physics/collapse.ts
+++ b/games/tetris/src/physics/collapse.ts
@@ -39,7 +39,11 @@ export class Collapse {
         (Math.random() - 0.5) * 6,
         (Math.random() - 0.5) * 6,
       );
-      body.velocity.set((Math.random() - 0.5) * 4 * lift, 2 * lift, (Math.random() - 0.5) * 4 * lift);
+      body.velocity.set(
+        (Math.random() - 0.5) * 4 * lift,
+        2 * lift,
+        (Math.random() - 0.5) * 4 * lift,
+      );
       world.addBody(body);
       this.pairs.push({ mesh, body });
     }

--- a/games/tetris/src/render/cube-field.ts
+++ b/games/tetris/src/render/cube-field.ts
@@ -92,7 +92,13 @@ export class CubeField {
       mesh.position.set(x, y, z);
       mesh.scale.setScalar(0.01); // pop in
       this.group.add(mesh);
-      this.locked.set(id, { mesh, material, target: new Vector3(x, y, z), scale: 0.01, scaleTarget: 1 });
+      this.locked.set(id, {
+        mesh,
+        material,
+        target: new Vector3(x, y, z),
+        scale: 0.01,
+        scaleTarget: 1,
+      });
     });
     // Cubes no longer present begin shrinking out.
     for (const [id, cube] of this.locked) {

--- a/games/tetris/src/render/piece-preview.ts
+++ b/games/tetris/src/render/piece-preview.ts
@@ -95,8 +95,32 @@ export function drawPiecePreview(
       ctx.stroke();
     };
     // left face, right face, then top diamond on top
-    face([[cx - hw, cy], [cx, cy + hh], [cx, cy + hh + d], [cx - hw, cy + d]], left);
-    face([[cx + hw, cy], [cx, cy + hh], [cx, cy + hh + d], [cx + hw, cy + d]], right);
-    face([[cx, cy - hh], [cx + hw, cy], [cx, cy + hh], [cx - hw, cy]], top);
+    face(
+      [
+        [cx - hw, cy],
+        [cx, cy + hh],
+        [cx, cy + hh + d],
+        [cx - hw, cy + d],
+      ],
+      left,
+    );
+    face(
+      [
+        [cx + hw, cy],
+        [cx, cy + hh],
+        [cx, cy + hh + d],
+        [cx + hw, cy + d],
+      ],
+      right,
+    );
+    face(
+      [
+        [cx, cy - hh],
+        [cx + hw, cy],
+        [cx, cy + hh],
+        [cx - hw, cy],
+      ],
+      top,
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "dev:farm": "turbo watch dev -F @repo/farm...",
     "dev:moba": "turbo watch dev -F @repo/moba...",
     "dev:cli": "turbo watch dev -F vibedgames...",
-    "dev:agents": "turbo watch dev -F @repo/agents...",
     "lint": "oxlint --report-unused-disable-directives",
     "r2:lifecycle": "pnpm -C apps/web exec wrangler r2 bucket lifecycle set vibedgames-games --file ./infra/r2/vibedgames-games.lifecycle.json --force",
     "typecheck": "turbo run typecheck",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dev:farm": "turbo watch dev -F @repo/farm...",
     "dev:moba": "turbo watch dev -F @repo/moba...",
     "dev:cli": "turbo watch dev -F vibedgames...",
+    "dev:agents": "turbo watch dev -F @repo/agents...",
     "lint": "oxlint --report-unused-disable-directives",
     "r2:lifecycle": "pnpm -C apps/web exec wrangler r2 bucket lifecycle set vibedgames-games --file ./infra/r2/vibedgames-games.lifecycle.json --force",
     "typecheck": "turbo run typecheck",

--- a/plugins/game-craft/skills/game-playbook/SKILL.md
+++ b/plugins/game-craft/skills/game-playbook/SKILL.md
@@ -40,8 +40,8 @@ ship before the craft pass.
    rates until the core loop is satisfying in the first 10 seconds.
 6. **Ship.** `vg deploy ./dist` (see `deploy`); `add multiplayer` / `add touch
 controls` / `make it forkable` are one prompt each (see `multiplayer`,
-`gamepad`, `fork`). Link-shared games get opened on phones — if the game is
-mouse/keyboard-only, add on-screen touch controls so it's playable there.
+   `gamepad`, `fork`). Link-shared games get opened on phones — if the game is
+   mouse/keyboard-only, add on-screen touch controls so it's playable there.
 
 ## The craft checklist
 

--- a/plugins/game-features/skills/gamepad/SKILL.md
+++ b/plugins/game-features/skills/gamepad/SKILL.md
@@ -27,7 +27,7 @@ npm install @vibedgames/gamepad
 ## Core concepts
 
 - **Floating stick** — the first free touch anchors a virtual analog stick wherever the finger lands; dragging from the anchor steers. Reads back as `angle` + `magnitude` (0–1 thrust after a dead zone).
-- **Action buttons** — either **fixed** (a circle pinned on-screen, e.g. a bottom-right bomb/jump button) or **"rest"** (no position — catches *any* touch that isn't the stick or a fixed button; this is the "any second finger fires" model).
+- **Action buttons** — either **fixed** (a circle pinned on-screen, e.g. a bottom-right bomb/jump button) or **"rest"** (no position — catches _any_ touch that isn't the stick or a fixed button; this is the "any second finger fires" model).
 - **Touch is the overlay.** The adapter ignores the mouse, so a desktop game keeps whatever controls it already had. `isTouch` flips true the first time a finger lands — use it to switch control schemes or swap an on-screen hint.
 
 ### Touch routing
@@ -35,7 +35,7 @@ npm install @vibedgames/gamepad
 Each touch-down is routed in order: **fixed buttons → the stick → a "rest" button**. This one model covers both common layouts:
 
 - **Twin-stick / shooter:** a stick + a rest "fire" button → move with one thumb, any other finger fires.
-- **Grid / platformer:** a stick + a *fixed* action button → move with the stick, tap the button to bomb/jump.
+- **Grid / platformer:** a stick + a _fixed_ action button → move with the stick, tap the button to bomb/jump.
 
 ## Phaser quickstart (twin-stick shooter)
 
@@ -101,7 +101,7 @@ if (dir) this.step(dir);
 
 ## Keep desktop controls; touch is additive
 
-The gamepad never touches the mouse path, so wire it *alongside* your existing
+The gamepad never touches the mouse path, so wire it _alongside_ your existing
 keyboard/mouse code and read whichever is active:
 
 ```ts
@@ -128,15 +128,15 @@ if (this.gamepad.isTouch) {
 ```ts
 attachVirtualGamepad(this, {
   stick: {
-    radius: 64,      // drag distance (px) that maps to full magnitude
-    deadZone: 8,     // no thrust / no re-aim within this drag (parked thumb)
-    knobRadius: 26,  // visual puck size
+    radius: 64, // drag distance (px) that maps to full magnitude
+    deadZone: 8, // no thrust / no re-aim within this drag (parked thumb)
+    knobRadius: 26, // visual puck size
   },
   // stick: false,   // disable the stick entirely (buttons-only)
-  extraPointers: 2,  // simultaneous touches beyond the default (default 2 → 3 total)
+  extraPointers: 2, // simultaneous touches beyond the default (default 2 → 3 total)
   render: {
-    depth: 95,                        // above the world, below a DOM HUD
-    tint: 0xffffff,                   // knob + button color
+    depth: 95, // above the world, below a DOM HUD
+    tint: 0xffffff, // knob + button color
     blendMode: Phaser.BlendModes.ADD, // ADD glows on dark scenes; NORMAL for bright
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,25 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  apps/agents:
+    dependencies:
+      citty:
+        specifier: ^0.2.2
+        version: 0.2.2
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+    devDependencies:
+      '@kyh/tsconfig':
+        specifier: 'catalog:'
+        version: 1.1.14
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   apps/cli:
     dependencies:
       '@trpc/client':


### PR DESCRIPTION
## What

Adds **`apps/agents`** (`@repo/agents`) — a long-running, multi-agent orchestrator that builds **one** browser game end-to-end and then **runs it like a studio**, shipping bug fixes, new features, gameplay/balance iteration, content, and polish. You give it a one-line idea; it runs until you stop it. **Nothing deploys to production without your approval.**

You drive it with the package's **pnpm scripts** (`start` / `stop` / `status` / `approve`) — no separate CLI binary to install. Each script maps to the orchestrator's subcommand and passes the slug and flags straight through.

It reuses everything the repo already has rather than reimplementing game knowledge: it drives the **vibedgames skills** and the **`vg` CLI** by spawning headless Claude Code sessions (`claude -p --output-format stream-json`), one specialist at a time, on your existing Claude login.

## How it works

A single Node process runs a **phase machine**. Each phase invokes one specialist as a fresh headless Claude Code session with a role-specific system prompt:

```
spec → scaffold → assets → build → playtest → ship
then forever:  plan → work → playtest → ship → plan → …
```

| Phase | Specialist | Does |
| --- | --- | --- |
| spec | 🧭 Designer | seed idea → build-ready `spec.md` (self-answers the `ask-me` tree) |
| scaffold | 🛠️ Engineer | `vg new` the engine (phaser/threejs) + install |
| assets | 🎨 Artist | `vg generate` the first art set |
| build | 🛠️ Engineer | core loop + mandatory craft pass |
| playtest | 🔎 QA | drives the build, files findings/bugs |
| ship | 🚀 Shipper | **only with your approval:** `vg deploy ./dist` → `{slug}.vibedgames.com` |
| plan | 🎬 Director | triages the backlog, assigns the next item |

### Runs like a studio (not a polishing machine)

After the first build it enters the forever loop, where the **Director** acts as a creative director / product owner: it triages a **typed backlog** (`bug | feature | gameplay | balance | content | polish | art`), fixes ship-stoppers first, then picks the highest-impact work for the game's current maturity — rotating across new features, gameplay/balance iteration, content, and polish so the game keeps *growing*. It can route work to the designer (to spec a new feature/mode), engineer, artist, or QA.

### Coordination & memory: a file blackboard

Specialists never talk directly — they coordinate through `<workspace>/.studio/` (`state.json`, `spec.md`, `backlog.json`, `next.json`, `playtest.md`, `journal.md`, `context.md`), which doubles as durable memory so the loop survives restarts and individual context windows.

## Operator controls

- **Deploys require human approval (default).** The studio builds, playtests, and keeps improving the game locally, but never publishes on its own. `pnpm approve <slug>` grants **one** deployment of the **current** build (the loop redirects straight to ship so what goes live is the build you approved); the next release needs fresh approval. `--auto-deploy` opts into continuous unattended deploys.
- **Choose where the game lives.** `--dir <path>` puts the game's project directory anywhere (default `apps/agents/.workspaces/<slug>`, gitignored). Outside this repo, run `vg init` there first so the skills resolve.
- **Optional context.** `--context` accepts literal text, a file (read inline), or a directory (the agents get read access and build upon it). Pointing `--dir` at an existing project adopts and evolves it instead of scaffolding fresh.

## Usage

Run from `apps/agents/` (or with `-F @repo/agents` from the repo root):

```bash
pnpm dogfood && pnpm -F @repo/agents build
pnpm start   neon-slasher --idea "a top-down neon slasher where every hit shakes the screen"
pnpm status  neon-slasher        # phase / shipped / live URL / pending approval (--json for machine output)
pnpm approve neon-slasher        # publish the current build
pnpm stop    neon-slasher        # graceful stop (or Ctrl-C)
```

`pnpm start <slug>` resumes from the saved phase. Key flags: `--model` (default `sonnet`, try `opus`), `--context`, `--auto-deploy`, `--dir`, `--max-cycles`, `--idle-timeout`, `--session-timeout`, `--skip-ship`, `--guarded`.

## Reliability

For unattended autonomy each agent runs with `--dangerously-skip-permissions`, so robustness matters. The runner (`runClaude`) and loop are hardened against the failure modes that would wedge an unattended process or hold the workspace lock forever:

- **Three-layer hang protection** so a session always settles: post-`result` exit grace (streamed but won't exit), an **idle watchdog** (total silence, resets on activity), and an **absolute session cap** (streams forever, never finishes). Handles are torn down on settle so an orphaned grandchild can't keep the loop alive.
- **Success is confirmed** by a parsed stream-json `result` event — a bare exit 0 is treated as a failure, not a silent phase advance.
- **Single-instance, crash-safe locking:** an atomic PID lockfile (`O_EXCL`) refuses a second `start` and reclaims stale locks; a duplicate `start` exits non-zero. The `STOP` sentinel is only cleared while the lock is held, so a restart can't wipe a running process's stop.
- **Faithful state:** `shipped` / `deployUrl` are set only on a real successful deploy (never on `--skip-ship` or after failures); the director is told the actual release status when planning.
- **Always makes progress:** a per-phase retry budget with exponential backoff, **persisted** across restarts, skips ahead after repeated failures; backoff and inter-cycle waits wake immediately on stop.
- **Path-safe:** slugs are validated (`SLUG_RE`) on every command, so `..` can't escape the workspaces dir.

## Testing

- `pnpm -F @repo/agents typecheck` / `build` pass; `oxlint` / `oxfmt` clean.
- The orchestrator was exercised end-to-end with a stubbed `claude` binary (`CLAUDE_BIN`): phase advancement, resume, cost tracking, journaling, `stop`; the approval gate (no deploy without approval; prompt deploy of the current build on approval; one-shot consumption); the deploy modes (`--auto-deploy`, `--skip-ship`); `--dir` / `--context`; the three hang safeguards; the lock (live-owner refusal, stale reclaim, non-zero exit); and the persisted failure counter across restarts. Generated workspaces live under `apps/agents/.workspaces/` (gitignored).

> [!NOTE]
> Not yet exercised against the **real** `claude` CLI end-to-end (which performs live builds, paid `vg generate`, and—on approval—a production deploy). The role prompts and the `vg new --here` / deploy flow should get one real validation run before relying on it fully unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New autonomous loop runs Claude with skip-permissions, can spend on `vg generate`, and can publish to production when approved or with `--auto-deploy`; reliability and cost depend on untested real-CLI end-to-end behavior.
> 
> **Overview**
> Introduces **`apps/agents`** (`@repo/agents`), a Node orchestrator that runs a long-lived **phase machine** (spec → scaffold → assets → build → playtest → ship, then plan → work → playtest → ship) by spawning headless **`claude -p`** sessions with role-specific prompts that drive existing **vibedgames skills** and **`vg`**.
> 
> Operators use **`pnpm start|stop|status|approve`** with flags for **`--idea`**, **`--context`** (text/file/dir), **`--dir`**, **`--auto-deploy`**, timeouts, and **`--guarded`**. Specialists coordinate via a **`.studio/` blackboard** (state, spec, backlog, journal, STOP/APPROVE sentinels); generated games default to gitignored **`apps/agents/.workspaces/<slug>`**.
> 
> **Production deploys are off by default** until **`pnpm approve`** grants a one-shot token; the loop can preempt to ship the approved build after the first release. **`runClaude`** adds stream-json streaming, idle/session watchdogs, and root **`IS_SANDBOX`** handling; the orchestrator adds **PID locking**, persisted phase retries, and ship guards so **`shipped`/`deployUrl`** only update on a successful deploy.
> 
> Also: release skill markdown tweak, minor skill doc formatting, **`pnpm-lock`** entry for agents, and incidental formatting in a few game/party files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44352f1bcb82a3a25d5697efeb444fd58b3b0d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->