### PR TITLE
Defer login guidance: don't prompt at install, only at first auth'd action

### DIFF
--- a/apps/web/src/lib/install.md
+++ b/apps/web/src/lib/install.md
@@ -32,8 +32,14 @@ If you're a different agent, pass `--agent <name>` (supports 45+ agents
 
 The skills you just installed tell you how to handle prompts like _"add
 multiplayer"_, _"generate pixel art for the player"_, or _"deploy this
-game"_. The `deploy` skill will prompt the user to authenticate
-(`vg login`, device-code flow) the first time they ship something — no
-need to log in now.
+game"_.
+
+**Don't log in yet.** Authentication is only for actions that hit the
+vibedgames backend — deploying a game (`vg deploy`) or generating assets
+(`vg generate`). The first time you run one of those unauthenticated, the
+CLI stops and tells you to run `vg login` (device-code flow) — not before.
+Installing, scaffolding
+(`vg new`), building, and local preview need no account, so there's
+nothing to authenticate now.
 
 Docs: https://vibedgames.com/docs

--- a/plugins/generate/skills/generate/SKILL.md
+++ b/plugins/generate/skills/generate/SKILL.md
@@ -100,3 +100,5 @@ vg --help                 # confirm the CLI is on PATH
 ```
 
 In this repo, run `pnpm dogfood` instead — it links the local CLI build and syncs `.claude/skills/`. The vibedgames server holds the API key, so there is no per-machine API-key step. See [full-reference.md](references/full-reference.md) for output modes and JSON conventions.
+
+**Auth is just-in-time — don't log in at install.** `vg generate` proxies through the vibedgames backend (which attaches the credentials), so it needs a session. Run a `vg generate` command unauthenticated and the CLI stops with `Not logged in. Run vg login` (device-code flow); for headless/agent use set `VG_TOKEN` instead. Nothing needs authenticating until you actually generate. (The `--provider codex` path is the exception — it runs locally and needs no vibedgames auth at all.)


### PR DESCRIPTION
## What & why

An agent following the install flow could be nudged to log in too early. The install page framed authentication as a **deploy-only** gate ("the first time they ship something") and never mentioned that `vg generate` also needs a session, while the generate skill's Setup said nothing about auth at all. This clarifies that **login is just-in-time** — nothing needs authenticating at install, scaffold, build, or local-preview time.

No code or auth-boundary changes — this is a documentation/wording fix. The just-in-time behavior already exists: `createClient()` throws `Not logged in. Run vg login` on the first backend-hitting call.

## Changes

- **`apps/web/src/lib/install.md`** (served at `/install`, the first thing an agent reads): generalize the "no need to log in now" note to cover both `vg deploy` and `vg generate`, and describe the actual behavior — the CLI stops and tells you to run `vg login` the first time you run one of those unauthenticated.
- **`plugins/generate/skills/generate/SKILL.md`** Setup: state that auth is deferred and only surfaces on the first `vg generate` call (or set `VG_TOKEN` for headless/agent use); note the `--provider codex` path needs no vibedgames auth.

## Notes / out of scope

`vg generate`'s read-only discovery commands (`models`/`schema`/`pricing`/`docs`) still require login — they all proxy through one `protectedProcedure` that attaches the server's fal key. Making those public (so agents could browse the catalog pre-auth) would expose that shared key to unauthenticated callers, so it's left out of this docs-only change. Happy to do it in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nRjGjHD6tNM7MgRk1W4g2

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRjGjHD6tNM7MgRk1W4g2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no code or auth behavior changes.
> 
> **Overview**
> Updates agent-facing install and generate skill docs so **login is described as just-in-time**, not part of install.
> 
> **`install.md`** (served at `/install`) replaces deploy-only wording with a clear rule: no `vg login` until the user runs something that hits the backend — **`vg deploy`** or **`vg generate`**. It states that install, **`vg new`**, build, and local preview need no account, and that the CLI will stop with **`vg login`** on the first unauthenticated deploy/generate.
> 
> **`plugins/generate/skills/generate/SKILL.md`** adds a Setup note that auth is deferred until the first **`vg generate`** (or **`VG_TOKEN`** for headless), and that **`--provider codex`** does not require vibedgames auth.
> 
> No runtime or auth-boundary changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a18fcdedf316b2c79e0c544f3bdf403c54992e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies docs to defer login: no auth at install, scaffold, build, or local preview. Login is required only on the first backend action (`vg deploy` or `vg generate`), where the CLI prompts `vg login`; for headless use set `VG_TOKEN`, and `--provider codex` needs no vibedgames auth.

<sup>Written for commit a18fcdedf316b2c79e0c544f3bdf403c54992e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

