### PR TITLE
Move Battle Arena and Crazy Taxi to end of discover list

### DIFF
--- a/apps/web/src/components/game/data.ts
+++ b/apps/web/src/components/game/data.ts
@@ -19,20 +19,6 @@ export type GameSearch = z.infer<typeof gameSearchSchema>;
 
 export const featuredGames: FeaturedGame[] = [
   {
-    name: "Battle Arena",
-    slug: "battle-arena",
-    preview: "/covers/battle-arena.webp",
-    previewPortrait: "/covers/battle-arena-portrait.webp",
-    colorScheme: "dark",
-  },
-  {
-    name: "Crazy Taxi",
-    slug: "crazy-taxi",
-    preview: "/covers/crazy-taxi.webp",
-    previewPortrait: "/covers/crazy-taxi-portrait.webp",
-    colorScheme: "light",
-  },
-  {
     name: "Starfall",
     slug: "starfall",
     preview: "/covers/starfall.webp",
@@ -86,6 +72,20 @@ export const featuredGames: FeaturedGame[] = [
     slug: "farm",
     preview: "/covers/farm.webp",
     previewPortrait: "/covers/farm-portrait.webp",
+    colorScheme: "light",
+  },
+  {
+    name: "Battle Arena",
+    slug: "battle-arena",
+    preview: "/covers/battle-arena.webp",
+    previewPortrait: "/covers/battle-arena-portrait.webp",
+    colorScheme: "dark",
+  },
+  {
+    name: "Crazy Taxi",
+    slug: "crazy-taxi",
+    preview: "/covers/crazy-taxi.webp",
+    previewPortrait: "/covers/crazy-taxi-portrait.webp",
     colorScheme: "light",
   },
 ];


### PR DESCRIPTION
## Summary

Reorders the `featuredGames` array in `apps/web/src/components/game/data.ts` so the recent additions **Battle Arena** and **Crazy Taxi** appear at the end of the discover list instead of the top.

## Changes

- Moved the `Battle Arena` and `Crazy Taxi` entries from the start of `featuredGames` to the end, preserving their relative order.
- `Starfall` is now the first entry again (which also matches the default game search value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyqpA2ipvXjABUAxCVZzkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyqpA2ipvXjABUAxCVZzkQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order-only change in a static config array; no logic, auth, or data handling changes.
> 
> **Overview**
> Reorders **`featuredGames`** in `data.ts` so **Battle Arena** and **Crazy Taxi** sit at the **end** of the discover stack instead of the top, keeping those two in the same order relative to each other.
> 
> **Starfall** is again the first entry, which lines up with the default `game` search value (`starfall`) and the canvas fallback that uses `featuredGames[0]`. Discover UI, game stack, and prev/next navigation all follow this array order, so only **display and cycle order** change—no new games or metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c71b1fc24151072e867b1bd8e583125e8c100c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the `featuredGames` array so Battle Arena and Crazy Taxi appear at the end of the discover list. Starfall is now first again, matching the default search value.

<sup>Written for commit e0c71b1fc24151072e867b1bd8e583125e8c100c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

