### PR TITLE
fix(web): fix inverted discover scroll-fade, wrap strip in ScrollArea

### DIFF
--- a/apps/web/src/routes/_site/discover.tsx
+++ b/apps/web/src/routes/_site/discover.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useWebHaptics } from "web-haptics/react";
 
+import { ScrollArea } from "@repo/ui/components/scroll-area";
+
 import { GitHubLink, RegisterLink } from "@/components/auth/register-link";
 import { FadeInBlur } from "@/components/ui/fade-in-blur";
 import { featuredGames, gameSearchSchema } from "@/components/game/data";
@@ -19,32 +21,34 @@ function DiscoverPage() {
   return (
     <>
       <RegisterLink />
-      <header className="fixed bottom-16 left-0 z-10 flex max-h-[70vh] max-w-dvw flex-col px-4">
-        <FadeInBlur className="scroll-fade flex gap-4 overflow-auto pb-2 sm:flex-col-reverse">
-          {featuredGames.map((game) => (
-            <button
-              key={game.slug}
-              onMouseEnter={() => {
-                if (activeGame === game.slug) return;
-                void navigate({
-                  to: "/discover",
-                  search: { game: game.slug },
-                  replace: true,
-                });
-              }}
-              onClick={() => {
-                trigger("selection");
-                void navigate({ to: "/", search: { game: game.slug } });
-              }}
-              className="hover:border-foreground relative aspect-video w-30 shrink-0 overflow-clip rounded-lg border border-transparent transition-colors"
-            >
-              <img
-                src={game.preview}
-                alt={game.name}
-                className="absolute inset-0 h-full w-full object-cover"
-              />
-            </button>
-          ))}
+      <header className="fixed bottom-16 left-0 z-10 flex max-w-dvw flex-col px-4">
+        <FadeInBlur>
+          <ScrollArea viewportClassName="scroll-fade flex max-h-[70vh] gap-4 pb-2 sm:flex-col-reverse">
+            {featuredGames.map((game) => (
+              <button
+                key={game.slug}
+                onMouseEnter={() => {
+                  if (activeGame === game.slug) return;
+                  void navigate({
+                    to: "/discover",
+                    search: { game: game.slug },
+                    replace: true,
+                  });
+                }}
+                onClick={() => {
+                  trigger("selection");
+                  void navigate({ to: "/", search: { game: game.slug } });
+                }}
+                className="hover:border-foreground relative aspect-video w-30 shrink-0 overflow-clip rounded-lg border border-transparent transition-colors"
+              >
+                <img
+                  src={game.preview}
+                  alt={game.name}
+                  className="absolute inset-0 h-full w-full object-cover"
+                />
+              </button>
+            ))}
+          </ScrollArea>
         </FadeInBlur>
       </header>
       <GitHubLink />

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+
+import { cn } from "@repo/ui/lib/utils";
+
+function ScrollArea({
+  className,
+  viewportClassName,
+  children,
+  ...props
+}: ScrollAreaPrimitive.Root.Props & { viewportClassName?: string }) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        // The viewport is the scroll container (`overflow: scroll`), so the
+        // `scroll-fade` mask and its `scroll(self …)` timeline must live here.
+        className={cn("size-full", viewportClassName)}
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar orientation="vertical" />
+      <ScrollBar orientation="horizontal" />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      // Idle-hidden; fades in while hovering or scrolling. Base UI omits the
+      // scrollbar entirely for a non-overflowing axis, so both can be rendered.
+      className={cn(
+        "flex touch-none select-none opacity-0 transition-opacity delay-150 duration-300 data-hovering:opacity-100 data-hovering:delay-0 data-scrolling:opacity-100 data-scrolling:delay-0",
+        orientation === "vertical" && "h-full w-1.5 p-px",
+        orientation === "horizontal" && "h-1.5 w-full flex-col p-px",
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-foreground/25 transition-colors hover:bg-foreground/40"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -129,7 +129,11 @@
  * when the content isn't scrollable at all). Browsers without scroll-driven
  * animations fall back to no fade — the registered custom properties stay at 0.
  *
- * Horizontal by default; switches to vertical at the `md` breakpoint.
+ * Horizontal by default; switches to vertical at the `sm` breakpoint, matching
+ * the sole consumer (the discover header). That container is `column-reverse`
+ * (bottom-anchored), which reverses the scroll timeline — so the vertical mask
+ * fades `to top` (not `to bottom`) to keep the leading fade on the edge with
+ * hidden content. Flip back to `to bottom` only if used on a normal-flow column.
  */
 @property --scroll-fade-start {
   syntax: "<length-percentage>";
@@ -153,10 +157,10 @@
     );
   }
 
-  @media (width >= 48rem) {
+  @media (width >= 40rem) {
     .scroll-fade {
       mask: linear-gradient(
-        to bottom,
+        to top,
         transparent,
         black var(--scroll-fade-start),
         black calc(100% - var(--scroll-fade-end)),
@@ -177,7 +181,7 @@
       animation-fill-mode: both;
     }
 
-    @media (width >= 48rem) {
+    @media (width >= 40rem) {
       .scroll-fade {
         animation-timeline: scroll(self y), scroll(self y);
       }


### PR DESCRIPTION
## Problem

The discover header thumbnail strip is a `flex column-reverse` (bottom-anchored) scroll container. `column-reverse` reverses the scroll timeline, but the `.scroll-fade` mask was authored for normal flow — so the edge fades were swapped: the **bottom** you rest on showed a fade while the **top** (with hidden content) was hard-clipped.

## Fix

- Vertical mask now fades `to top`, cancelling the `column-reverse` timeline reversal (verified: fade sits on top at rest, moves to bottom when scrolled up).
- Aligned the fade breakpoint to the layout's (`40rem`/`sm`, was `48rem`) — closes a 640–768px dead zone where the layout was vertical but the fade axis was still horizontal.
- Added a Base UI `ScrollArea` (`packages/ui/src/components/scroll-area.tsx`, shadcn-style) for a styled, auto-hiding scrollbar; the discover viewport carries the `scroll-fade` mask + flex + `column-reverse`.

## Notes

- Base UI's `--scroll-area-overflow-*` vars clamp `scrollTop >= 0`, so they're dead under `column-reverse` — the fade stays scroll-driven (Chromium-only); the scrollbar is cross-browser. Cross-browser fade would require dropping `column-reverse`.

## Verified (Playwright, both breakpoints)

- Desktop (column-reverse): top faded at rest, bottom faded when scrolled up.
- Mobile (row): right faded at rest, left faded when scrolled.
- Scrollbar: only the overflowing axis renders; hidden at idle, fades in on hover/scroll.
- `typecheck` (`@repo/ui` + `@repo/web`) passes; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Discover-page UI and shared scroll styling only; no auth, data, or backend changes.
> 
> **Overview**
> Fixes **inverted edge fades** on the discover thumbnail strip and wraps it in a shared **ScrollArea** with auto-hiding scrollbars.
> 
> The strip’s scroll container moves into a new Base UI **`ScrollArea`** (`packages/ui`), with `scroll-fade`, flex layout, and `sm:flex-col-reverse` on the **viewport** so scroll-driven masks attach to the real scroll element. **`globals.css`** updates **`.scroll-fade`**: vertical breakpoint aligns with layout (**40rem / `sm`**, was **48rem**), and the vertical mask fades **`to top`** to match **`column-reverse`** (was **`to bottom`**, which swapped leading/trailing fades).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73c84460f924b6da68183f8919cb85bb4a4d313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the inverted scroll-fade on the Discover header strip and adds an auto-hiding scrollbar by wrapping the strip in a new ScrollArea component. Aligns the fade breakpoint with the layout for consistent behavior across breakpoints.

- **Bug Fixes**
  - Corrected vertical scroll-fade for the `column-reverse` strip; fade sits at the top at rest and moves down when scrolling up.
  - Adjusted breakpoint to `40rem` (`sm`) to match the layout and remove the 640–768px gap.

- **New Features**
  - Added a ScrollArea to `@repo/ui` using `@base-ui/react/scroll-area` with a styled, auto-hiding scrollbar.
  - Wrapped the Discover strip in the new ScrollArea; the viewport holds the fade mask and flex layout.

<sup>Written for commit e73c84460f924b6da68183f8919cb85bb4a4d313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

