### PR TITLE
fix(tetris): make keyboard controls work when the game is embedded

### DIFF
--- a/apps/web/src/components/canvas/iframe.tsx
+++ b/apps/web/src/components/canvas/iframe.tsx
@@ -4,6 +4,16 @@ type Props = {
 
 export const Iframe = ({ url }: Props) => {
   return (
-    <iframe key={url} src={url} className="h-full w-full" title="Game" allow="camera; microphone" />
+    <iframe
+      key={url}
+      src={url}
+      className="h-full w-full"
+      title="Game"
+      allow="camera; microphone"
+      // Games listen for keyboard input on their own window, but an iframe only
+      // receives key events once it holds focus. Focus it on load so keyboard
+      // controls work right away without the player first clicking the frame.
+      onLoad={(event) => event.currentTarget.focus()}
+    />
   );
 };

--- a/games/tetris/src/main.ts
+++ b/games/tetris/src/main.ts
@@ -28,6 +28,15 @@ window.addEventListener("resize", () => {
   renderer.setSize(window.innerWidth, window.innerHeight);
 });
 
+// Keyboard events only reach the frame that holds focus. When the game runs
+// inside an iframe (the vibedgames hub, a forked embed), the parent document
+// keeps focus on load, so our window keydown handlers never fire and the
+// controls appear dead until the player clicks in. Claim focus on load and on
+// any pointer interaction so the keys work immediately, no stray click first.
+const claimFocus = (): void => window.focus();
+claimFocus();
+window.addEventListener("pointerdown", claimFocus);
+
 const timer = new THREE.Timer();
 renderer.setAnimationLoop((time) => {
   timer.update(time);


### PR DESCRIPTION
## Problem

Keyboard controls for the Tetris game don't work — pressing Enter/Space to start or arrow keys to move does nothing.

## Root cause

The game registers its keyboard handlers on `window` (`games/tetris/src/input/keyboard.ts`), which is correct. But **keyboard events only reach the frame that holds focus**. The web-app hub plays games inside a cross-origin `<iframe>` (`apps/web/src/components/canvas/iframe.tsx`), and on load the *parent* document holds focus. So the game's `window` keydown handlers never fire, and the controls appear completely dead until the player clicks into the frame.

The in-page game logic is fine — verified headlessly that when the page has focus, Enter starts the game and arrow keys move the piece. The failure only manifests when embedded.

## Fix

Addressed from both sides:

- **`games/tetris/src/main.ts`** — the game claims focus on load and on any pointer interaction, so it reclaims the keyboard even when embedded somewhere we don't control (e.g. a forked/standalone embed).
- **`apps/web/src/components/canvas/iframe.tsx`** — the hub's game iframe focuses itself on load, a guaranteed focus hand-off from the parent that also covers the other embedded games.

## Verification

Reproduced and verified in a headless Chromium embed (parent page + game in an iframe):

- **Before:** pressing Enter without a prior click left the game on the title screen; keys only worked after clicking into the iframe.
- **After:** with no click at all, Enter starts the game and arrow keys move the piece.

Tetris `typecheck` passes. (Pre-existing web-app typecheck errors are unrelated — TanStack Router generated route types are absent in a fresh clone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015imbo8SKHMLTt98i8gbSrL

---
_Generated by [Claude Code](https://claude.ai/code/session_015imbo8SKHMLTt98i8gbSrL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX/focus-only changes with no auth, data, or gameplay logic modifications; possible minor side effect of stealing focus from parent UI on iframe load.
> 
> **Overview**
> Fixes **dead keyboard controls** when games run inside the hub’s `<iframe>`: the parent page kept focus on load, so `window` key handlers in embedded games never ran until the user clicked the frame.
> 
> The hub **`Iframe`** now calls **`focus()` on the iframe element in `onLoad`**, handing keyboard focus to the embedded game as soon as it loads (covers all hub games). **Tetris `main.ts`** additionally calls **`window.focus()` on startup** and on **`pointerdown`**, so keyboard input works in other embeds (forks, standalone) even without the parent change.
> 
> No changes to input mapping or game logic—only focus so existing key listeners receive events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aabb1dd9d24c95ec85e6007bfad13c8528a6655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dead keyboard controls when Tetris runs inside an iframe. The iframe and game window now auto-focus on load so Enter/Space/arrows work without a prior click.

- **Bug Fixes**
  - `apps/web/src/components/canvas/iframe.tsx`: focus the `<iframe>` on `onLoad` to hand off keyboard input to the game.
  - `games/tetris/src/main.ts`: call `window.focus()` on load and on `pointerdown` so the game keeps keyboard focus when embedded.

<sup>Written for commit 9aabb1dd9d24c95ec85e6007bfad13c8528a6655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

