### PR TITLE
playwright skill: bot-playtest pattern + diagnostics contract

### DIFF
--- a/apps/factory/README.md
+++ b/apps/factory/README.md
@@ -40,6 +40,19 @@ pnpm approve neon-slasher    # publish the current build to neon-slasher.vibedga
 pnpm stop    neon-slasher    # graceful stop (or just Ctrl-C the running process)
 ```
 
+### Live dashboard (TUI)
+
+In a terminal, `pnpm start` runs a live dashboard ([opentui](https://github.com/anomalyco/opentui)):
+header with phase / cycle / spend / deploy status, a streaming activity feed of
+what the current subagent is doing, and hotkeys —
+
+- **`a`** — approve one deployment (same as `pnpm approve <slug>`)
+- **`s`** — graceful stop after the current step (same as `pnpm stop <slug>`)
+- **`q` / Ctrl-C** — stop; press again to force quit
+
+When stdout isn't a TTY (CI, piped logs) — or with `--no-tui` — the factory
+streams the same events as plain log lines instead.
+
 ### Deploys need your approval
 
 By default **nothing goes live without you.** The agent builds, playtests, and
@@ -164,19 +177,21 @@ cat .agent/trace.jsonl | jq -s 'group_by(.role) | map({role: .[0].role, cost: (m
 
 ## Prerequisites
 
-1. **Claude Code CLI** logged in on your machine (`claude` on `PATH`, or set
+1. **Bun ≥ 1.2** on `PATH` — the scripts run the TypeScript/TSX sources
+   directly with Bun (the TUI's renderer requires the Bun runtime).
+2. **Claude Code CLI** logged in on your machine (`claude` on `PATH`, or set
    `CLAUDE_BIN`). The agent uses your existing Claude subscription/login — it
    shells out to `claude -p`.
-2. **`vg` CLI + skills linked locally:** run `pnpm dogfood` once at the repo
+3. **`vg` CLI + skills linked locally:** run `pnpm dogfood` once at the repo
    root. The orchestrator runs each subagent with its cwd inside this repo so
    Claude Code resolves the skills from `<repo>/.claude/skills`.
-3. Anything `vg generate` / `vg deploy` need (a logged-in `vg`, env from
+4. Anything `vg generate` / `vg deploy` need (a logged-in `vg`, env from
    `.env`). The subagents call `vg login`-gated commands.
 
 ## Run
 
-There's no build step — the scripts run the TypeScript sources directly with
-Node's built-in type stripping (Node ≥ 22.18). From `apps/factory/`:
+There's no build step — the scripts run the TypeScript/TSX sources directly
+with Bun. From `apps/factory/`:
 
 ```bash
 pnpm start <slug> --idea "<one-line idea>"
@@ -188,7 +203,7 @@ From the repo root, target the package with `-F`:
 pnpm -F @repo/factory start <slug> --idea "<one-line idea>"
 ```
 
-The `start`, `stop`, `status`, and `approve` scripts each run `node
+The `start`, `stop`, `status`, and `approve` scripts each run `bun
 src/index.ts <cmd>`; everything after the script name (the slug and any flags)
 is passed straight through. `pnpm typecheck` runs `tsc --noEmit` (the only
 TypeScript step — nothing is emitted).
@@ -209,6 +224,7 @@ TypeScript step — nothing is emitted).
 | `--skip-ship`       | off                               | Never prepare a release at all (use while testing).                             |
 | `--dir`             | `apps/factory/.workspaces/<slug>` | Where the game lives — its project directory.                                    |
 | `--guarded`         | off                               | Do **not** auto-approve tools — for debugging only; breaks autonomy.             |
+| `--no-tui`          | off                               | Plain streamed logs instead of the live dashboard (automatic when not a TTY).    |
 
 Re-running `pnpm start <slug>` **resumes** from the saved phase.
 

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -4,20 +4,24 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node src/index.ts start",
-    "stop": "node src/index.ts stop",
-    "status": "node src/index.ts status",
-    "approve": "node src/index.ts approve",
+    "start": "bun src/index.ts start",
+    "stop": "bun src/index.ts stop",
+    "status": "bun src/index.ts status",
+    "approve": "bun src/index.ts approve",
     "clean": "rm -rf .turbo .cache node_modules .workspaces",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@opentui/core": "^0.4.3",
+    "@opentui/react": "^0.4.3",
     "citty": "^0.2.2",
-    "consola": "^3.4.2"
+    "consola": "^3.4.2",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@kyh/tsconfig": "catalog:",
     "@types/node": "catalog:",
+    "@types/react": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/apps/factory/src/claude.ts
+++ b/apps/factory/src/claude.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
 
-import consola from "consola";
+import type { Activity } from "./reporter.ts";
 
 // Every resolution path funnels through the `settle()` helper below, which is
 // guarded by a `settled` flag so it resolves exactly once. oxlint's static
@@ -41,8 +41,8 @@ export type RunOptions = {
   skipPermissions: boolean;
   /** Aborts the underlying process (second Ctrl-C). */
   signal?: AbortSignal;
-  /** Label shown in streamed output, e.g. "engineer". */
-  label: string;
+  /** Receives a compact view of what the session does, as it happens. */
+  onActivity: (activity: Activity) => void;
   /**
    * Kill the session and fail if it produces NO output (no stream-json events,
    * no stderr) for this long — a watchdog for a wedged `claude`/stuck tool.
@@ -208,7 +208,7 @@ export function runClaude(opts: RunOptions): Promise<RunResult> {
       } catch {
         return; // ignore non-JSON noise
       }
-      printEvent(opts.label, evt);
+      emitActivity(opts.onActivity, evt);
       if (evt.type === "result") {
         gotResult = true;
         // The grace timer governs from here; stand down the watchdogs so a late
@@ -283,20 +283,22 @@ type ContentBlock =
   | { type: "tool_use"; name?: string; input?: Record<string, unknown> }
   | { type: "tool_result"; [k: string]: unknown };
 
-function printEvent(label: string, evt: StreamEvent): void {
-  const tag = `  ${label} ·`;
+/** Decode a stream-json event into the Activity view the reporter renders. */
+function emitActivity(onActivity: (activity: Activity) => void, evt: StreamEvent): void {
   if (evt.type === "system" && evt.subtype === "init") {
-    consola.log(
-      `${tag} session started (${evt.model ?? "model"}, ${evt.tools?.length ?? 0} tools)`,
-    );
+    onActivity({ kind: "init", model: evt.model, tools: evt.tools?.length ?? 0 });
     return;
   }
   if (evt.type === "assistant") {
     for (const block of evt.message?.content ?? []) {
       if (block.type === "text" && block.text?.trim()) {
-        for (const ln of block.text.trim().split("\n")) consola.log(`${tag} ${ln}`);
+        onActivity({ kind: "text", text: block.text.trim() });
       } else if (block.type === "tool_use") {
-        consola.log(`${tag} ⚙ ${block.name ?? "tool"}${summarizeTool(block.input)}`);
+        onActivity({
+          kind: "tool",
+          name: block.name ?? "tool",
+          detail: summarizeTool(block.input) || undefined,
+        });
       }
     }
   }
@@ -307,5 +309,5 @@ function summarizeTool(input?: Record<string, unknown>): string {
   const cmd = input.command ?? input.file_path ?? input.path ?? input.pattern ?? input.prompt;
   if (typeof cmd !== "string") return "";
   const oneLine = cmd.replace(/\s+/g, " ").trim();
-  return oneLine ? `  (${oneLine.slice(0, 80)}${oneLine.length > 80 ? "…" : ""})` : "";
+  return oneLine.length > 80 ? `${oneLine.slice(0, 80)}…` : oneLine;
 }

--- a/apps/factory/src/index.ts
+++ b/apps/factory/src/index.ts
@@ -177,6 +177,12 @@ const startCommand = defineCommand({
         "Do NOT pass --dangerously-skip-permissions. Agents will block waiting for approval — breaks unattended autonomy. For debugging only.",
       default: false,
     },
+    "no-tui": {
+      type: "boolean",
+      description:
+        "Disable the live dashboard and stream plain logs instead (automatic when stdout isn't a TTY).",
+      default: false,
+    },
   },
   run: async ({ args }) => {
     const slug = requireSlug(args.slug);
@@ -214,6 +220,7 @@ const startCommand = defineCommand({
       noShip: Boolean(args["skip-ship"]),
       autoDeploy: Boolean(args["auto-deploy"]),
       skipPermissions: !args.guarded,
+      tui: !args["no-tui"],
       context,
       contextDir,
     });

--- a/apps/factory/src/orchestrator.ts
+++ b/apps/factory/src/orchestrator.ts
@@ -4,7 +4,9 @@ import consola from "consola";
 
 import { claudeBin, findRepoRoot } from "./config.ts";
 import { runClaude } from "./claude.ts";
+import { ConsoleReporter, type Reporter } from "./reporter.ts";
 import { buildTask, roleForPhase, ROLES } from "./roles.ts";
+import { TuiReporter } from "./tui/tui-reporter.tsx";
 import {
   acquireLock,
   appendJournal,
@@ -16,6 +18,7 @@ import {
   hasExistingProject,
   initWorkspace,
   releaseLock,
+  requestApproval,
   saveState,
   stopRequested,
   type AgentState,
@@ -43,6 +46,8 @@ export type AgentOptions = {
   autoDeploy: boolean;
   /** Pass --dangerously-skip-permissions so tools run unattended. */
   skipPermissions: boolean;
+  /** Show the live TUI dashboard (needs a TTY; falls back to streamed logs). */
+  tui: boolean;
   /** Optional operator brief written to .agent/context.md for the subagents. */
   context?: string;
   /** Optional reference directory the subagents are granted read access to. */
@@ -132,24 +137,83 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
   }
   saveState(bb, state);
 
-  banner(opts, state, repoRoot);
-
   let stopping = false;
   const abort = new AbortController();
-  const onSignal = () => {
+
+  // The live dashboard needs a real terminal on both ends (keyboard + screen);
+  // anything else (CI, piped logs, --no-tui) gets the plain streamed output.
+  const useTui = opts.tui && process.stdout.isTTY === true && process.stdin.isTTY === true;
+  const reporter: Reporter = useTui
+    ? new TuiReporter({
+        approve: () => {
+          requestApproval(bb);
+          reporter.info(
+            "Deploy approval granted — the current build ships at the next release point.",
+          );
+          reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
+        },
+        requestStop: () => gracefulStop(),
+        interrupt: () => interrupt(),
+      })
+    : new ConsoleReporter();
+
+  const gracefulStop = (): void => {
+    if (stopping) return;
+    stopping = true;
+    reporter.warn("Stop requested — finishing the current step.");
+  };
+  const interrupt = (): void => {
     if (!stopping) {
       stopping = true;
-      consola.warn(
-        "\nStop requested — finishing the current step. Press Ctrl-C again to force quit.",
-      );
+      reporter.warn("Stop requested — finishing the current step. Press again to force quit.");
     } else {
-      consola.warn("Force quitting.");
+      reporter.warn("Force quitting.");
+      reporter.close();
       abort.abort();
       process.exit(130);
     }
   };
+  const onSignal = () => interrupt();
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
+
+  reporter.start({
+    slug: state.slug,
+    idea: state.idea,
+    model: state.model,
+    workspace: opts.workspace,
+    repoRoot,
+    existingProject: state.existingProject,
+    hasContext: existsSync(bb.context),
+    contextDir: state.contextDir,
+    guarded: !opts.skipPermissions,
+    noShip: opts.noShip,
+    autoDeploy: opts.autoDeploy,
+    maxCycles: opts.maxCycles,
+  });
+  if (opts.skipPermissions) {
+    const deployNote = opts.noShip
+      ? "Deploys are disabled."
+      : opts.autoDeploy
+        ? "Deploys to production run AUTOMATICALLY."
+        : "Deploys are gated on `pnpm approve <slug>` — nothing goes live without you.";
+    reporter.warn(
+      `Running with --dangerously-skip-permissions: agents run shell/file tools and \`vg generate\` (which costs money) WITHOUT asking. ${deployNote} Stop with Ctrl-C.`,
+    );
+    // claude rejects --dangerously-skip-permissions under root unless the
+    // environment is marked as a sandbox; we set IS_SANDBOX=1 for the children
+    // so unattended container/CI runs (which are typically root) actually work.
+    if (
+      typeof process.getuid === "function" &&
+      process.getuid() === 0 &&
+      process.env.IS_SANDBOX !== "1"
+    ) {
+      reporter.info(
+        "Detected root: setting IS_SANDBOX=1 for agents so skip-permissions is allowed.",
+      );
+    }
+  }
+  reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
 
   // A sleep that wakes early if a stop is requested (Ctrl-C or STOP sentinel),
   // so backoff/interval waits never delay shutdown.
@@ -167,7 +231,7 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
   // oxlint-disable-next-line no-unmodified-loop-condition
   while (!stopping) {
     if (stopRequested(bb)) {
-      consola.warn("STOP sentinel found in .agent/ — halting.");
+      reporter.warn("STOP sentinel found in .agent/ — halting.");
       break;
     }
 
@@ -186,10 +250,11 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
       !opts.noShip &&
       approvalPending(bb, state.lastApproval)
     ) {
-      consola.info("Approval received — shipping the current build before continuing.");
+      reporter.info("Approval received — shipping the current build before continuing.");
       state.phase = "ship";
       state.phaseFailures = 0; // entering a new phase: fresh retry budget
       saveState(bb, state);
+      reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
     }
 
     // An operator-approved deploy is a deliberate command — let that single ship
@@ -200,25 +265,27 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
       !opts.noShip &&
       approvalPending(bb, state.lastApproval);
     if (opts.maxCycles > 0 && state.cycle >= opts.maxCycles && !approvedShipPending) {
-      consola.info(`Reached --max-cycles=${opts.maxCycles}. Stopping.`);
+      reporter.info(`Reached --max-cycles=${opts.maxCycles}. Stopping.`);
       break;
     }
 
     // Optionally skip shipping (no prod deploy) while testing.
     if (state.phase === "ship" && opts.noShip) {
-      consola.info("--skip-ship set; skipping the ship phase.");
+      reporter.info("--skip-ship set; skipping the ship phase.");
       advance(state);
       saveState(bb, state);
+      reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
       continue;
     }
 
     // Never deploy without a recorded successful build — e.g. if the build
     // phase was skipped after repeated failures. Wait until a build lands.
     if (state.phase === "ship" && !state.built) {
-      consola.warn("Reached ship with no successful build recorded — not deploying yet.");
+      reporter.warn("Reached ship with no successful build recorded — not deploying yet.");
       appendJournal(bb, "ship: skipped — no successful build recorded.");
       advance(state);
       saveState(bb, state);
+      reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
       continue;
     }
 
@@ -227,12 +294,13 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
     // ready, we just don't publish it — the loop keeps improving the game
     // locally until a human runs `pnpm approve <slug>`.
     if (state.phase === "ship" && !opts.autoDeploy && !approvalPending(bb, state.lastApproval)) {
-      consola.warn(
+      reporter.warn(
         `Build ready but NOT deployed — approval required. Run \`pnpm approve ${state.slug}\` to publish it (or start with --auto-deploy).`,
       );
       appendJournal(bb, "ship: build ready, awaiting human approval (not deployed).");
       advance(state);
       saveState(bb, state);
+      reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
       continue;
     }
 
@@ -240,12 +308,13 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
     const role = ROLES[roleForPhase(phase, bb)];
     const task = buildTask(phase, state, bb);
 
-    consola.log("");
-    consola.start(
-      `${role.emoji} ${role.name} — phase "${phase}" · cycle ${state.cycle + 1}${
-        state.shipped ? ` · iteration ${state.iteration + 1}` : ""
-      }`,
-    );
+    reporter.turnStart({
+      emoji: role.emoji,
+      role: role.name,
+      phase,
+      cycle: state.cycle + 1,
+      iteration: state.shipped ? state.iteration + 1 : null,
+    });
 
     const turnStartedAt = Date.now();
     const res = await runClaude({
@@ -260,12 +329,13 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
       addDirs: state.contextDir ? [repoRoot, state.contextDir] : [repoRoot],
       skipPermissions: opts.skipPermissions,
       signal: abort.signal,
-      label: role.name,
+      onActivity: (activity) => reporter.activity(activity),
     });
 
     state.cycle += 1;
     if (typeof res.costUsd === "number") state.totalCostUsd += res.costUsd;
     saveState(bb, state);
+    reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
 
     // One span per turn — the agent's durable observability trail.
     appendSpan(bb, {
@@ -290,9 +360,14 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
         bb,
         `${role.name} (${phase}) FAILED: ${truncate(res.error ?? "unknown error")}`,
       );
-      consola.error(`${role.name} failed: ${res.error ?? "unknown error"}`);
+      reporter.turnEnd({
+        ok: false,
+        costUsd: res.costUsd,
+        numTurns: res.numTurns,
+        error: res.error ?? "unknown error",
+      });
       if (state.phaseFailures >= MAX_RETRIES) {
-        consola.warn(
+        reporter.warn(
           `${MAX_RETRIES} consecutive failures on "${phase}" — skipping ahead to avoid a stuck loop.`,
         );
         // A spent attempt consumes the deploy approval too, so a broken ship
@@ -304,9 +379,10 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
         state.phaseFailures = 0;
         advance(state);
         saveState(bb, state);
+        reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
       } else {
         const backoff = Math.min(2 ** state.phaseFailures, 60);
-        consola.info(
+        reporter.info(
           `Retrying "${phase}" in ${backoff}s (attempt ${state.phaseFailures + 1}/${MAX_RETRIES}).`,
         );
         await sleepUnlessStopping(backoff * 1000);
@@ -319,7 +395,7 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
       bb,
       `${role.name} (${phase}) done${costNote(res.costUsd)}: ${truncate(res.result)}`,
     );
-    consola.success(`${role.name} done${costNote(res.costUsd)} · ${res.numTurns ?? "?"} turns`);
+    reporter.turnEnd({ ok: true, costUsd: res.costUsd, numTurns: res.numTurns });
 
     // A deployable build exists once a phase that builds the game succeeds:
     // scaffold (confirms the template/adopted project builds), build, or
@@ -338,6 +414,7 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
     }
     advance(state);
     saveState(bb, state);
+    reporter.stateChanged(state, approvalPending(bb, state.lastApproval));
 
     if (opts.interval > 0 && !stopping) await sleepUnlessStopping(opts.interval);
   }
@@ -349,6 +426,7 @@ export async function runAgent(opts: AgentOptions): Promise<boolean> {
 
   saveState(bb, state);
   releaseLock(bb);
+  reporter.close(); // restore the terminal before the final summary prints
   consola.box(
     [
       `Agent stopped for "${state.slug}".`,
@@ -393,58 +471,6 @@ function recordShip(state: AgentState): void {
   } else {
     state.shipped = true;
     state.deployUrl = `https://${state.slug}.vibedgames.com`;
-  }
-}
-
-function banner(opts: AgentOptions, state: AgentState, repoRoot: string): void {
-  const bb = blackboard(opts.workspace);
-  consola.box(
-    [
-      `🎮 vibedgames factory — autonomous game agent`,
-      ``,
-      `Game:      ${state.slug}`,
-      `Idea:      ${state.idea || "(from existing project / context)"}`,
-      `Model:     ${state.model}`,
-      `Game dir:  ${opts.workspace}`,
-      state.existingProject ? `Source:    building on existing files in the game dir` : null,
-      existsSync(bb.context)
-        ? `Context:   provided${state.contextDir ? ` (+ reference dir: ${state.contextDir})` : ""}`
-        : null,
-      `Repo:      ${repoRoot}`,
-      `Mode:      ${opts.skipPermissions ? "unattended (tools auto-approved)" : "guarded (will block on approvals!)"}`,
-      opts.noShip
-        ? `Deploy:    disabled (--skip-ship)`
-        : opts.autoDeploy
-          ? `Deploy:    AUTOMATIC → ${state.slug}.vibedgames.com`
-          : `Deploy:    on approval only — \`pnpm approve ${state.slug}\` → ${state.slug}.vibedgames.com`,
-      opts.maxCycles > 0
-        ? `Stops at:  ${opts.maxCycles} cycles`
-        : `Runs:      until you stop it (Ctrl-C or \`pnpm stop ${state.slug}\`)`,
-    ]
-      .filter(Boolean)
-      .join("\n"),
-  );
-  if (opts.skipPermissions) {
-    const deployNote = opts.noShip
-      ? "Deploys are disabled."
-      : opts.autoDeploy
-        ? "Deploys to production run AUTOMATICALLY."
-        : "Deploys are gated on `pnpm approve <slug>` — nothing goes live without you.";
-    consola.warn(
-      `Running with --dangerously-skip-permissions: agents run shell/file tools and \`vg generate\` (which costs money) WITHOUT asking. ${deployNote} Stop with Ctrl-C.`,
-    );
-    // claude rejects --dangerously-skip-permissions under root unless the
-    // environment is marked as a sandbox; we set IS_SANDBOX=1 for the children
-    // so unattended container/CI runs (which are typically root) actually work.
-    if (
-      typeof process.getuid === "function" &&
-      process.getuid() === 0 &&
-      process.env.IS_SANDBOX !== "1"
-    ) {
-      consola.info(
-        "Detected root: setting IS_SANDBOX=1 for agents so skip-permissions is allowed.",
-      );
-    }
   }
 }
 

--- a/apps/factory/src/reporter.ts
+++ b/apps/factory/src/reporter.ts
@@ -1,0 +1,154 @@
+import consola from "consola";
+
+import type { AgentState } from "./state.ts";
+
+/** A single observable thing a subagent did, decoded from stream-json. */
+export type Activity =
+  | { kind: "init"; model?: string; tools?: number }
+  | { kind: "text"; text: string }
+  | { kind: "tool"; name: string; detail?: string };
+
+/** Display-ready facts about the turn that is starting. */
+export type TurnInfo = {
+  emoji: string;
+  role: string;
+  phase: string;
+  /** 1-based display cycle. */
+  cycle: number;
+  /** 1-based display iteration, or null before the first ship. */
+  iteration: number | null;
+};
+
+export type TurnResult = {
+  ok: boolean;
+  costUsd?: number;
+  numTurns?: number;
+  error?: string;
+};
+
+/** Static facts about this run, shown once (console) or persistently (TUI). */
+export type RunSetup = {
+  slug: string;
+  idea: string;
+  model: string;
+  workspace: string;
+  repoRoot: string;
+  existingProject: boolean;
+  hasContext: boolean;
+  contextDir: string | null;
+  guarded: boolean;
+  noShip: boolean;
+  autoDeploy: boolean;
+  maxCycles: number;
+};
+
+/**
+ * Where the orchestrator narrates a run. Two implementations: plain streamed
+ * logs (non-TTY / --no-tui) and the live TUI dashboard (see tui.ts).
+ */
+export type Reporter = {
+  start(setup: RunSetup): void;
+  turnStart(turn: TurnInfo): void;
+  activity(activity: Activity): void;
+  turnEnd(result: TurnResult): void;
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+  /** Refresh the header/status view. No-op for the console reporter. */
+  stateChanged(state: AgentState, approvalPending: boolean): void;
+  /** Tear down (restores the terminal in TUI mode). Safe to call twice. */
+  close(): void;
+};
+
+const costNote = (c?: number): string => (typeof c === "number" ? ` ($${c.toFixed(2)})` : "");
+
+/** Plain streamed logs — the original output, kept for non-TTY runs and --no-tui. */
+export class ConsoleReporter implements Reporter {
+  #turn: TurnInfo | null = null;
+
+  start(setup: RunSetup): void {
+    consola.box(
+      [
+        `🎮 vibedgames factory — autonomous game agent`,
+        ``,
+        `Game:      ${setup.slug}`,
+        `Idea:      ${setup.idea || "(from existing project / context)"}`,
+        `Model:     ${setup.model}`,
+        `Game dir:  ${setup.workspace}`,
+        setup.existingProject ? `Source:    building on existing files in the game dir` : null,
+        setup.hasContext
+          ? `Context:   provided${setup.contextDir ? ` (+ reference dir: ${setup.contextDir})` : ""}`
+          : null,
+        `Repo:      ${setup.repoRoot}`,
+        `Mode:      ${setup.guarded ? "guarded (will block on approvals!)" : "unattended (tools auto-approved)"}`,
+        setup.noShip
+          ? `Deploy:    disabled (--skip-ship)`
+          : setup.autoDeploy
+            ? `Deploy:    AUTOMATIC → ${setup.slug}.vibedgames.com`
+            : `Deploy:    on approval only — \`pnpm approve ${setup.slug}\` → ${setup.slug}.vibedgames.com`,
+        setup.maxCycles > 0
+          ? `Stops at:  ${setup.maxCycles} cycles`
+          : `Runs:      until you stop it (Ctrl-C or \`pnpm stop ${setup.slug}\`)`,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+
+  turnStart(turn: TurnInfo): void {
+    this.#turn = turn;
+    consola.log("");
+    consola.start(
+      `${turn.emoji} ${turn.role} — phase "${turn.phase}" · cycle ${turn.cycle}${
+        turn.iteration !== null ? ` · iteration ${turn.iteration}` : ""
+      }`,
+    );
+  }
+
+  activity(activity: Activity): void {
+    const tag = `  ${this.#turn?.role ?? "agent"} ·`;
+    switch (activity.kind) {
+      case "init":
+        consola.log(
+          `${tag} session started (${activity.model ?? "model"}, ${activity.tools ?? 0} tools)`,
+        );
+        return;
+      case "text":
+        for (const ln of activity.text.split("\n")) consola.log(`${tag} ${ln}`);
+        return;
+      case "tool":
+        consola.log(`${tag} ⚙ ${activity.name}${activity.detail ? `  (${activity.detail})` : ""}`);
+        return;
+    }
+  }
+
+  turnEnd(result: TurnResult): void {
+    const role = this.#turn?.role ?? "agent";
+    this.#turn = null;
+    if (result.ok) {
+      consola.success(`${role} done${costNote(result.costUsd)} · ${result.numTurns ?? "?"} turns`);
+    } else {
+      consola.error(`${role} failed: ${result.error ?? "unknown error"}`);
+    }
+  }
+
+  info(msg: string): void {
+    consola.info(msg);
+  }
+
+  warn(msg: string): void {
+    consola.warn(msg);
+  }
+
+  error(msg: string): void {
+    consola.error(msg);
+  }
+
+  stateChanged(): void {
+    /* the header lives in the TUI; streamed logs already narrate state */
+  }
+
+  close(): void {
+    /* nothing to restore */
+  }
+}

--- a/apps/factory/src/tui/app.tsx
+++ b/apps/factory/src/tui/app.tsx
@@ -1,0 +1,256 @@
+import { TextAttributes } from "@opentui/core";
+import { useKeyboard, useTerminalDimensions } from "@opentui/react";
+import { Fragment, useEffect, useState, useSyncExternalStore } from "react";
+
+import type { FeedLine, Snapshot, Tone, TuiHandlers, TuiStore } from "./store.ts";
+import { color, panelBorder } from "./theme.ts";
+
+const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+
+// Fixed rows around the feed: header(2) + status(1) + panel border(2) +
+// turn bar(1) + footer(2).
+const CHROME_ROWS = 8;
+
+const toneColor: Record<Tone, string> = {
+  marker: color.accent,
+  text: color.text,
+  tool: color.dim,
+  info: color.accentDim,
+  warn: color.warn,
+  error: color.err,
+  success: color.ok,
+};
+
+const truncate = (s: string, width: number): string =>
+  width <= 0 ? "" : s.length > width ? `${s.slice(0, Math.max(0, width - 1))}…` : s;
+
+/** Word-wrap into rows of at most `width`; continuations get a 2-col indent. */
+function wrapText(text: string, width: number): string[] {
+  if (width <= 4 || text.length <= width) return [truncate(text, Math.max(1, width))];
+  const rows: string[] = [];
+  let row = "";
+  for (const word of text.split(" ")) {
+    const cap = rows.length === 0 ? width : width - 2;
+    const candidate = row ? `${row} ${word}` : word;
+    if (candidate.length <= cap) {
+      row = candidate;
+      continue;
+    }
+    if (row) rows.push(rows.length === 0 ? row : `  ${row}`);
+    // hard-split words longer than a full row
+    let rest = word;
+    while (rest.length > width - 2) {
+      rows.push(`  ${rest.slice(0, width - 2)}`);
+      rest = rest.slice(width - 2);
+    }
+    row = rest;
+  }
+  if (row) rows.push(rows.length === 0 ? row : `  ${row}`);
+  return rows;
+}
+
+const fmtElapsed = (ms: number): string => {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+};
+
+const fmtSpend = (usd: number): string => `~$${usd.toFixed(2)}`;
+
+// Elapsed-time driver for the spinner / turn clock, ~4 fps.
+function useTick(): number {
+  const [elapsed, setElapsed] = useState(0);
+  const [start] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setElapsed(Date.now() - start), 250);
+    return () => clearInterval(id);
+  }, [start]);
+  return elapsed;
+}
+
+/** Feed lines expanded to display rows (wrapped or truncated), newest last. */
+function feedRows(feed: readonly FeedLine[], width: number, maxRows: number) {
+  const rows: { key: string; tone: Tone; text: string; bold: boolean }[] = [];
+  for (const line of feed) {
+    const bold = line.tone === "marker";
+    if (line.tone === "text") {
+      wrapText(line.text, width).forEach((text, i) =>
+        rows.push({ key: `${line.id}:${i}`, tone: line.tone, text, bold }),
+      );
+    } else {
+      rows.push({ key: `${line.id}`, tone: line.tone, text: truncate(line.text, width), bold });
+    }
+  }
+  return rows.slice(-maxRows);
+}
+
+function Header({ snapshot, width }: { snapshot: Snapshot; width: number }) {
+  const { setup, state } = snapshot;
+  const idea = setup.idea || "(existing project)";
+  const left = 12 + 4 + setup.slug.length; // brand + separators + slug
+  return (
+    <box
+      flexDirection="row"
+      alignItems="center"
+      border={["bottom"]}
+      borderStyle="single"
+      customBorderChars={panelBorder}
+      borderColor={color.border}
+      paddingLeft={1}
+      paddingRight={1}
+    >
+      <text attributes={TextAttributes.BOLD} fg={color.accent}>
+        VIBEDGAMES
+      </text>
+      <text fg={color.faint}>{" // "}</text>
+      <text attributes={TextAttributes.BOLD} fg={color.text}>
+        {setup.slug}
+      </text>
+      <text fg={color.dim}>{`  ${truncate(idea, Math.max(0, width - left - 24))}`}</text>
+      <box flexGrow={1} />
+      <text fg={color.ok}>●</text>
+      <text fg={color.dim}> SPEND </text>
+      <text attributes={TextAttributes.BOLD} fg={color.text}>
+        {fmtSpend(state?.totalCostUsd ?? 0)}
+      </text>
+    </box>
+  );
+}
+
+function StatusRow({ snapshot }: { snapshot: Snapshot }) {
+  const { setup, state, approvalPending } = snapshot;
+  const deploy = setup.noShip
+    ? { text: "DEPLOY OFF (--skip-ship)", fg: color.faint }
+    : setup.autoDeploy
+      ? { text: "DEPLOY AUTO", fg: color.warn }
+      : approvalPending
+        ? { text: "APPROVAL PENDING — ships at the next release point", fg: color.accent }
+        : { text: "DEPLOY GATED — [A] approves one release", fg: color.dim };
+  return (
+    <box flexDirection="row" paddingLeft={1} paddingRight={1}>
+      <text fg={color.faint}>PHASE </text>
+      <text attributes={TextAttributes.BOLD} fg={color.accent}>
+        {(state?.phase ?? "…").toUpperCase()}
+      </text>
+      <text fg={color.faint}>{`  CYCLE ${state?.cycle ?? 0}`}</text>
+      <text fg={color.faint}>{`  ITER ${state?.iteration ?? 0}`}</text>
+      <text fg={color.ghost}>{"  │  "}</text>
+      <text fg={deploy.fg}>{deploy.text}</text>
+      <box flexGrow={1} />
+      <text fg={color.faint}>{setup.model}</text>
+    </box>
+  );
+}
+
+function TurnBar({ snapshot, tick }: { snapshot: Snapshot; tick: number }) {
+  const turn = snapshot.turn;
+  if (!turn) {
+    return (
+      <box paddingLeft={1}>
+        <text fg={color.faint}>idle — waiting for the next step</text>
+      </box>
+    );
+  }
+  const spinner = SPINNER[Math.floor(tick / 250) % SPINNER.length];
+  return (
+    <box flexDirection="row" paddingLeft={1} paddingRight={1}>
+      <text fg={color.accent}>{`${spinner} `}</text>
+      <text attributes={TextAttributes.BOLD} fg={color.text}>
+        {`${turn.emoji} ${turn.role}`}
+      </text>
+      <text fg={color.dim}>{` — ${turn.phase} · cycle ${turn.cycle}${
+        turn.iteration !== null ? ` · iteration ${turn.iteration}` : ""
+      }`}</text>
+      <box flexGrow={1} />
+      <text
+        fg={color.dim}
+      >{`${fmtElapsed(Date.now() - turn.startedAt)} · ${turn.events} events`}</text>
+    </box>
+  );
+}
+
+const FOOTER_KEYS = [
+  { keys: "A", label: "APPROVE DEPLOY" },
+  { keys: "S", label: "STOP AFTER STEP" },
+  { keys: "Q", label: "QUIT" },
+] as const;
+
+function Footer({ snapshot, width }: { snapshot: Snapshot; width: number }) {
+  const live = snapshot.state?.deployUrl;
+  const keysWidth = FOOTER_KEYS.reduce((sum, k) => sum + k.keys.length + k.label.length + 3, 0) + 6;
+  const budget = width - 2 - keysWidth - 2;
+  return (
+    <box
+      flexDirection="row"
+      alignItems="center"
+      border={["top"]}
+      borderStyle="single"
+      customBorderChars={panelBorder}
+      borderColor={color.border}
+      paddingLeft={1}
+      paddingRight={1}
+    >
+      {FOOTER_KEYS.map((k, i) => (
+        <Fragment key={k.keys}>
+          {i > 0 && <text fg={color.ghost}>{"   "}</text>}
+          <text fg={color.faint}>[</text>
+          <text fg={color.accent}>{k.keys}</text>
+          <text fg={color.faint}>]</text>
+          <text fg={color.dim}>{` ${k.label}`}</text>
+        </Fragment>
+      ))}
+      <box flexGrow={1} />
+      {live && budget >= 16 ? (
+        <text fg={color.accentDim}>{truncate(`LIVE ▸ ${live}`, budget)}</text>
+      ) : null}
+    </box>
+  );
+}
+
+export function App({ store, handlers }: { store: TuiStore; handlers: TuiHandlers }) {
+  const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  const { width, height } = useTerminalDimensions();
+  const tick = useTick();
+
+  useKeyboard((key) => {
+    if ((key.ctrl && key.name === "c") || key.name === "q") handlers.interrupt();
+    else if (key.name === "s") handlers.requestStop();
+    else if (key.name === "a") handlers.approve();
+  });
+
+  const innerWidth = Math.max(1, width - 4); // panel border(2) + padding(2)
+  const maxRows = Math.max(1, height - CHROME_ROWS);
+  const rows = feedRows(snapshot.feed, innerWidth, maxRows);
+
+  return (
+    <box flexDirection="column" width={width} height={height} backgroundColor={color.bg}>
+      <Header snapshot={snapshot} width={width} />
+      <StatusRow snapshot={snapshot} />
+      <box
+        border
+        borderStyle="single"
+        customBorderChars={panelBorder}
+        borderColor={color.border}
+        title=" ACTIVITY "
+        titleAlignment="left"
+        backgroundColor={color.bg}
+        flexDirection="column"
+        flexGrow={1}
+        paddingLeft={1}
+        paddingRight={1}
+      >
+        <box flexGrow={1} />
+        {rows.map((row) => (
+          <text
+            key={row.key}
+            fg={toneColor[row.tone]}
+            attributes={row.bold ? TextAttributes.BOLD : undefined}
+          >
+            {row.text || " "}
+          </text>
+        ))}
+      </box>
+      <TurnBar snapshot={snapshot} tick={tick} />
+      <Footer snapshot={snapshot} width={width} />
+    </box>
+  );
+}

--- a/apps/factory/src/tui/store.ts
+++ b/apps/factory/src/tui/store.ts
@@ -1,0 +1,80 @@
+import type { RunSetup, TurnInfo } from "../reporter.ts";
+import type { AgentState } from "../state.ts";
+
+/** How a feed line is toned when rendered. */
+export type Tone = "marker" | "text" | "tool" | "info" | "warn" | "error" | "success";
+
+export type FeedLine = { id: number; tone: Tone; text: string };
+
+export type CurrentTurn = TurnInfo & { startedAt: number; events: number };
+
+/** Immutable view of everything the TUI renders. Replaced on every mutation. */
+export type Snapshot = {
+  setup: RunSetup;
+  state: AgentState | null;
+  approvalPending: boolean;
+  turn: CurrentTurn | null;
+  feed: readonly FeedLine[];
+};
+
+/** Keys the dashboard listens for; the orchestrator supplies the behavior. */
+export type TuiHandlers = {
+  /** Grant a one-shot deploy approval (`a`). */
+  approve: () => void;
+  /** Graceful stop after the current step (`s`). Idempotent. */
+  requestStop: () => void;
+  /** Ctrl-C / `q`: graceful stop first, force quit on the second press. */
+  interrupt: () => void;
+};
+
+const FEED_CAP = 400;
+
+/**
+ * External store bridging the (non-React) orchestrator to the React tree via
+ * useSyncExternalStore. The reporter mutates it; the App renders snapshots.
+ */
+export class TuiStore {
+  #snapshot: Snapshot;
+  #listeners = new Set<() => void>();
+  #nextId = 1;
+
+  constructor(setup: RunSetup) {
+    this.#snapshot = { setup, state: null, approvalPending: false, turn: null, feed: [] };
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): Snapshot => this.#snapshot;
+
+  #set(patch: Partial<Snapshot>): void {
+    this.#snapshot = { ...this.#snapshot, ...patch };
+    for (const listener of this.#listeners) listener();
+  }
+
+  push(tone: Tone, text: string): void {
+    const lines = text.split("\n").map((t): FeedLine => ({ id: this.#nextId++, tone, text: t }));
+    this.#set({ feed: [...this.#snapshot.feed, ...lines].slice(-FEED_CAP) });
+  }
+
+  turnStart(turn: TurnInfo): void {
+    this.#set({ turn: { ...turn, startedAt: Date.now(), events: 0 } });
+  }
+
+  bumpEvents(): void {
+    const turn = this.#snapshot.turn;
+    if (turn) this.#set({ turn: { ...turn, events: turn.events + 1 } });
+  }
+
+  turnEnd(): void {
+    this.#set({ turn: null });
+  }
+
+  stateChanged(state: AgentState, approvalPending: boolean): void {
+    this.#set({ state, approvalPending });
+  }
+}

--- a/apps/factory/src/tui/theme.ts
+++ b/apps/factory/src/tui/theme.ts
@@ -1,0 +1,37 @@
+// Near-black HUD palette with a violet accent — same family as the kyh.io
+// terminal dashboards, tinted for vibedgames.
+export const color = {
+  bg: "#0A0A0F",
+  // grayscale ramp
+  text: "#E6E6E6",
+  dim: "#8A8A8A",
+  faint: "#4A4A4A",
+  ghost: "#2A2A2A",
+  // borders
+  border: "#2E2E38",
+  borderActive: "#54487E",
+  // accent
+  accent: "#A78BFA",
+  accentDim: "#6D5BAA",
+  // feed tones
+  ok: "#4ADE80",
+  warn: "#FBBF24",
+  err: "#F87171",
+  tool: "#67E8F9",
+  black: "#000000",
+} as const;
+
+// Thin technical border set used for every panel — single-line, squared corners.
+export const panelBorder = {
+  topLeft: "┌",
+  topRight: "┐",
+  bottomLeft: "└",
+  bottomRight: "┘",
+  horizontal: "─",
+  vertical: "│",
+  topT: "┬",
+  bottomT: "┴",
+  leftT: "├",
+  rightT: "┤",
+  cross: "┼",
+} as const;

--- a/apps/factory/src/tui/tui-reporter.tsx
+++ b/apps/factory/src/tui/tui-reporter.tsx
@@ -1,0 +1,139 @@
+import { createCliRenderer, type CliRenderer } from "@opentui/core";
+import { createRoot, type Root } from "@opentui/react";
+
+import type { Activity, Reporter, RunSetup, TurnInfo, TurnResult } from "../reporter.ts";
+import type { AgentState } from "../state.ts";
+import { App } from "./app.tsx";
+import { TuiStore, type TuiHandlers } from "./store.ts";
+
+export type { TuiHandlers } from "./store.ts";
+
+const costNote = (c?: number): string => (typeof c === "number" ? ` ($${c.toFixed(2)})` : "");
+
+/**
+ * The live dashboard reporter. Mounts an opentui/react app on the alternate
+ * screen; the orchestrator narrates through the Reporter interface and the
+ * store bridges those events into the React tree. Keyboard: `a` approves one
+ * deploy, `s` stops after the current step, `q`/Ctrl-C interrupts.
+ */
+export class TuiReporter implements Reporter {
+  #handlers: TuiHandlers;
+  #store: TuiStore | null = null;
+  #renderer: CliRenderer | null = null;
+  #root: Root | null = null;
+  #closed = false;
+
+  constructor(handlers: TuiHandlers) {
+    this.#handlers = handlers;
+  }
+
+  start(setup: RunSetup): void {
+    const store = new TuiStore(setup);
+    this.#store = store;
+    // The renderer mounts async; events that arrive first land in the store
+    // and render on mount.
+    void this.#mount(store);
+  }
+
+  async #mount(store: TuiStore): Promise<void> {
+    try {
+      // We own Ctrl-C (graceful-then-force) and signals, so the renderer must
+      // not exit the process itself.
+      const renderer = await createCliRenderer({
+        exitOnCtrlC: false,
+        exitSignals: [],
+        targetFps: 30,
+      });
+      if (this.#closed) {
+        renderer.destroy();
+        return;
+      }
+      this.#renderer = renderer;
+      this.#root = createRoot(renderer);
+      this.#root.render(<App store={store} handlers={this.#handlers} />);
+    } catch (err) {
+      // A failed mount leaves us with a blank screen otherwise; surface it and
+      // keep the loop alive — the trace/journal still record everything.
+      store.push(
+        "error",
+        `TUI failed to start: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  turnStart(turn: TurnInfo): void {
+    this.#store?.turnStart(turn);
+    this.#store?.push(
+      "marker",
+      `▶ ${turn.emoji} ${turn.role} — ${turn.phase} · cycle ${turn.cycle}${
+        turn.iteration !== null ? ` · iteration ${turn.iteration}` : ""
+      }`,
+    );
+  }
+
+  activity(activity: Activity): void {
+    this.#store?.bumpEvents();
+    switch (activity.kind) {
+      case "init":
+        this.#store?.push(
+          "info",
+          `session started (${activity.model ?? "model"}, ${activity.tools ?? 0} tools)`,
+        );
+        return;
+      case "text":
+        this.#store?.push("text", activity.text);
+        return;
+      case "tool":
+        this.#store?.push(
+          "tool",
+          `⚙ ${activity.name}${activity.detail ? ` · ${activity.detail}` : ""}`,
+        );
+        return;
+    }
+  }
+
+  turnEnd(result: TurnResult): void {
+    if (result.ok) {
+      this.#store?.push(
+        "success",
+        `✔ done${costNote(result.costUsd)} · ${result.numTurns ?? "?"} turns`,
+      );
+    } else {
+      this.#store?.push("error", `✘ failed: ${result.error ?? "unknown error"}`);
+    }
+    this.#store?.turnEnd();
+  }
+
+  info(msg: string): void {
+    this.#store?.push("info", msg);
+  }
+
+  warn(msg: string): void {
+    this.#store?.push("warn", msg);
+  }
+
+  error(msg: string): void {
+    this.#store?.push("error", msg);
+  }
+
+  stateChanged(state: AgentState, approvalPending: boolean): void {
+    this.#store?.stateChanged(state, approvalPending);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    try {
+      this.#root?.unmount();
+    } catch {
+      /* teardown is best-effort */
+    }
+    try {
+      this.#renderer?.destroy();
+    } catch {
+      /* teardown is best-effort */
+    }
+    this.#root = null;
+    this.#renderer = null;
+  }
+}

--- a/apps/factory/tsconfig.json
+++ b/apps/factory/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "lib": ["ES2023"],
     "types": ["node"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "@opentui/react",
     "allowImportingTsExtensions": true
   },
   "include": ["src"]

--- a/plugins/tooling/skills/playwright/SKILL.md
+++ b/plugins/tooling/skills/playwright/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright
-description: 'Plan, implement, and debug frontend tests: unit/integration/E2E/visual/a11y. Use for Playwright MCP browser automation, Vitest/Jest/RTL, flaky test triage, CI stabilization, and canvas/WebGL games (Phaser) needing deterministic input plus screenshot/state assertions. Trigger: "test", "E2E", "flaky", "visual regression", "Playwright", "game testing".'
+description: 'Plan, implement, and debug frontend tests: unit/integration/E2E/visual/a11y. Use for Playwright MCP browser automation, Vitest/Jest/RTL, flaky test triage, CI stabilization, and canvas/WebGL games (Phaser, Three.js) needing deterministic input, bot playtests, or screenshot/state assertions. Trigger: "test", "E2E", "flaky", "visual regression", "Playwright", "game testing", "playtest", "softlock".'
 ---
 
 # Frontend Testing
@@ -110,6 +110,16 @@ window.__TEST__ = {
 
 **Rule**: Expose IDs + essential fields, not raw Phaser/engine objects.
 
+For bot playtests and visual baselines, upgrade this minimal seam to the fuller diagnostics contract (`window.__GAME_DIAGNOSTICS__` + `window.__GAME_TEST_HOOKS__`) in `references/bot-playtest.md`.
+
+## Bot Playtest: Prove It Plays
+
+A smoke test proves the game loads; a bot playtest proves it *plays*. Drive scripted real input and assert progression: frames advanced (loop alive), distance travelled (input alive), score delta (objective reachable), softlock windows (frames advance but held input yields no motion and no progress — fail if > 2), zero errors. For difficulty claims, run the bot at two reaction speeds (0ms vs 300ms delay) — if the slow bot does as well as the fast one, the difficulty is decorative.
+
+Two headless-WebGL footguns: never report headless FPS as performance (SwiftShader software raster, ~2fps on scenes a GPU runs at 120), and set `workers: 1` for WebGL games or parallel contexts flake every timed phase.
+
+Full contract, metrics, and a copy-paste test template: `references/bot-playtest.md`.
+
 ## Anti-Patterns to Avoid
 
 ❌ **Testing the wrong layer**: E2E tests for pure logic
@@ -174,6 +184,8 @@ python scripts/imgdiff.py baseline.png current.png --max-rms 2.0
 
 Exit codes: 0 = identical, 1 = different, 2 = error
 
+**Freeze before every baseline**: seed RNG, pause particles, freeze camera shake / hit-stop / time-based post FX, hide debug UI, wait for fonts + textures/GLTFs + audio decode, fix viewport/DPR. Skip baselines for un-seedable prototypes or particle-dominated scenes — and say why — rather than masking the image into meaninglessness.
+
 ## UI Slicing Regressions (Nine-Slice / Ribbons / Bars)
 
 Canvas UI issues (panel seams, segmented ribbons, invisible HUD fills) are best caught with a dedicated UI harness instead of the full gameplay flow.
@@ -202,6 +214,7 @@ Read these when needed:
 - `references/playwright-mcp-cheatsheet.md`: Detailed MCP tool patterns
 - `references/phaser-canvas-testing.md`: Deterministic mode for Phaser games
 - `references/flake-reduction.md`: Flake classification and fixes
+- `references/bot-playtest.md`: Diagnostics contract + progression-measuring bot (softlock detection, fairness runs, headless WebGL footguns)
 
 ## Remember
 

--- a/plugins/tooling/skills/playwright/references/bot-playtest.md
+++ b/plugins/tooling/skills/playwright/references/bot-playtest.md
@@ -1,0 +1,130 @@
+# Bot Playtest: Prove the Game Plays, Not Just Renders
+
+A canvas check proves the game renders; a bot playtest proves it *plays*. The bot drives real scripted input and measures **progression** — objective movement, player responsiveness, softlock windows, error-free runtime. A game that renders beautifully but can't be progressed by a scripted sweep is not ready. Engine-agnostic: works for Phaser and Three.js alike.
+
+## The Diagnostics Contract
+
+The bot needs machine-readable game state. Expose two globals (this generalizes the per-game `window.__TEST__` harnesses we've hand-built — same idea, split into read-only telemetry vs mutation hooks):
+
+```javascript
+// Read-only, updated every frame from the game loop
+window.__GAME_DIAGNOSTICS__ = {
+  frame: 0, // increments every update — the loop's heartbeat
+  score: 0, // or the objective metric: waves, distance, gems
+  complete: false, // win/fail state reached
+  player: { x: 0, y: 0, speed: 0 }, // x/z for 3D games
+  entities: 0, // live entity count
+  renderer: null, // Three.js only: { calls, triangles } from renderer.info.render
+};
+
+// Mutations — keep them real as the game evolves; silent no-op hooks
+// make every downstream assertion lie
+window.__GAME_TEST_HOOKS__ = {
+  seed(n) {}, // reseed RNG — all gameplay randomness must route through it
+  setState(name) {}, // jump to a named state: 'active-play', 'fail', 'boss'
+  setPausedForScreenshot(paused) {},
+  setReducedMotion(enabled) {}, // freeze shake/particles/time-based FX
+  hideDebugUi() {},
+};
+```
+
+Rule: JSON-serializable primitives only, never raw engine objects. If gameplay randomness bypasses the seeded RNG, bot metrics are noise.
+
+## Metrics and What They Mean
+
+- `framesAdvanced > 100` — the loop survived the run. A stall is a crash or frozen loop.
+- `distanceTravelled > threshold` — input mapping is alive. Near-zero under held keys means broken input.
+- `scoreAfter > scoreBefore` + step-of-first-score — the objective is reachable, and how fast a naive player finds it. If a scripted sweep never scores, the objective is unreachable, unreadable, or broken.
+- `softlockWindows` — sampling windows where frames advanced but held input produced **neither motion nor score progress**. Repeated windows = stuck-on-geometry, dead input states, or unrecovered fail states. Fail if > 2.
+- Zero page errors, zero console errors, for the full run.
+- Games with fail states: add a "reckless" run that seeks hazards — assert the fail state triggers and retry restores play. A game that can't be failed has no pressure; a fail state that can't be retried is a release blocker.
+
+## Test Template
+
+Adapt `INPUT_SCRIPT` to the game's core verb — a runner holds forward and switches lanes, an arena game sweeps the space, a tower defense places towers via test hooks (game-specific hooks like `forceWave()` are encouraged where raw keys can't express the verb).
+
+```typescript
+import { expect, test } from "@playwright/test";
+
+const INPUT_SCRIPT: Array<{ keys: string[]; ms: number }> = [
+  { keys: ["KeyW"], ms: 1000 },
+  { keys: ["KeyA"], ms: 1900 },
+  { keys: ["KeyD"], ms: 3400 },
+  { keys: ["KeyS"], ms: 1700 },
+  { keys: ["KeyA"], ms: 3400 },
+];
+
+test("bot playtest: scripted input drives progress without errors", async ({ page }, testInfo) => {
+  test.setTimeout(90_000);
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+  page.on("pageerror", (e) => pageErrors.push(e.message));
+  page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text()));
+
+  await page.goto("/");
+  await page.waitForFunction(() => (window.__GAME_DIAGNOSTICS__?.frame ?? 0) > 10);
+  await page.evaluate(() => {
+    window.__GAME_TEST_HOOKS__?.seed(12345);
+    window.__GAME_TEST_HOOKS__?.setState("active-play");
+  });
+
+  const sample = () =>
+    page.evaluate(() => {
+      const d = window.__GAME_DIAGNOSTICS__;
+      return d && { frame: d.frame, score: d.score, x: d.player.x, y: d.player.y };
+    });
+
+  const before = await sample();
+  expect(before, "diagnostics must be published").not.toBeNull();
+  let prev = before, distance = 0, softlockWindows = 0, stepOfFirstScore = -1;
+
+  for (const [index, step] of INPUT_SCRIPT.entries()) {
+    for (const key of step.keys) await page.keyboard.down(key);
+    await page.waitForTimeout(step.ms);
+    for (const key of step.keys) await page.keyboard.up(key);
+
+    const snap = await sample();
+    if (!snap) continue;
+    const moved = Math.hypot(snap.x - prev.x, snap.y - prev.y);
+    distance += moved;
+    const progressed = snap.score > prev.score;
+    if (progressed && stepOfFirstScore === -1) stepOfFirstScore = index;
+    // Softlock signature: frames advance, held input moves nothing, no progress
+    if (snap.frame > prev.frame && moved < 0.2 && !progressed) softlockWindows += 1;
+    prev = snap;
+  }
+
+  const report = {
+    framesAdvanced: prev.frame - before.frame,
+    scoreBefore: before.score, scoreAfter: prev.score,
+    distanceTravelled: Number(distance.toFixed(2)),
+    stepOfFirstScore, softlockWindows, consoleErrors, pageErrors,
+  };
+  await testInfo.attach("bot-playtest-report", {
+    body: JSON.stringify(report, null, 2), contentType: "application/json",
+  });
+
+  expect(pageErrors).toEqual([]);
+  expect(consoleErrors).toEqual([]);
+  expect(report.framesAdvanced, "game loop must keep running").toBeGreaterThan(100);
+  expect(report.distanceTravelled, "player must respond to input").toBeGreaterThan(5);
+  expect(report.softlockWindows, "held input repeatedly produced nothing").toBeLessThanOrEqual(2);
+  expect(report.scoreAfter, "sweep should progress the objective").toBeGreaterThan(report.scoreBefore);
+});
+```
+
+Attach the JSON report and the seed to the test output — pass/fail alone isn't evidence.
+
+## Difficulty and Fairness Runs
+
+For games with fail states, run the bot at two skill levels — 0ms vs 300ms artificial reaction delay between script steps — and compare survival time and score:
+
+- Delayed bot survives as long as the fast one → difficulty pressure is decorative.
+- Even the fast script can't survive the first threat → the opening is unfair.
+
+Report both runs whenever difficulty tuning is in scope.
+
+## Headless WebGL Footguns
+
+- **Never report headless FPS as performance.** Headless Chromium renders WebGL on SwiftShader (software rasterizer) — ~2 fps on scenes a real GPU runs at 120. Headless runs are for correctness only; capture FPS on a real GPU (headed browser) and label headless numbers functional-only.
+- **Run Playwright with `workers: 1` for WebGL games.** Parallel headless contexts share the software rasterizer; the frame-time collapse drifts game time from wall time, flaking timed phases and screenshot baselines.

--- a/plugins/tooling/skills/playwright/references/bot-playtest.md
+++ b/plugins/tooling/skills/playwright/references/bot-playtest.md
@@ -20,7 +20,7 @@ window.__GAME_DIAGNOSTICS__ = {
 // Mutations — keep them real as the game evolves; silent no-op hooks
 // make every downstream assertion lie
 window.__GAME_TEST_HOOKS__ = {
-  seed(n) {}, // reseed RNG — all gameplay randomness must route through it
+  seed(n) {}, // reseed RNG AND restart/regenerate the run — see below
   setState(name) {}, // jump to a named state: 'active-play', 'fail', 'boss'
   setPausedForScreenshot(paused) {},
   setReducedMotion(enabled) {}, // freeze shake/particles/time-based FX
@@ -29,6 +29,8 @@ window.__GAME_TEST_HOOKS__ = {
 ```
 
 Rule: JSON-serializable primitives only, never raw engine objects. If gameplay randomness bypasses the seeded RNG, bot metrics are noise.
+
+**`seed(n)` must restart, not just reseed.** By the time the test can call it, the game has already run frames (and possibly generated the level) with unseeded RNG. The contract: `seed(n)` reseeds the RNG **and** restarts/regenerates the run from that seed, so everything the bot measures is deterministic. If a restart is expensive, the alternative is seeding before boot — `page.addInitScript(() => { window.__GAME_SEED__ = 12345; })` and the game reads `__GAME_SEED__` (or a `?seed=` query param) at init.
 
 ## Metrics and What They Mean
 
@@ -64,6 +66,8 @@ test("bot playtest: scripted input drives progress without errors", async ({ pag
   await page.goto("/");
   await page.waitForFunction(() => (window.__GAME_DIAGNOSTICS__?.frame ?? 0) > 10);
   await page.evaluate(() => {
+    // seed() restarts the run from this seed (see contract above) — frames
+    // rendered before this call were unseeded and must not be measured
     window.__GAME_TEST_HOOKS__?.seed(12345);
     window.__GAME_TEST_HOOKS__?.setState("active-play");
   });
@@ -71,7 +75,8 @@ test("bot playtest: scripted input drives progress without errors", async ({ pag
   const sample = () =>
     page.evaluate(() => {
       const d = window.__GAME_DIAGNOSTICS__;
-      return d && { frame: d.frame, score: d.score, x: d.player.x, y: d.player.y };
+      // optional chaining: diagnostics may publish before player init
+      return d ? { frame: d.frame, score: d.score, x: d.player?.x ?? 0, y: d.player?.y ?? 0 } : null;
     });
 
   const before = await sample();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ catalogs:
       version: 4.110.0
     zod:
       specifier: ^4.4.3
-      version: 3.25.76
+      version: 4.4.3
 
 overrides:
   react-hook-form: ^7.72.1
@@ -153,12 +153,21 @@ importers:
 
   apps/factory:
     dependencies:
+      '@opentui/core':
+        specifier: ^0.4.3
+        version: 0.4.3(typescript@7.0.2)(web-tree-sitter@0.25.10)
+      '@opentui/react':
+        specifier: ^0.4.3
+        version: 0.4.3(react-devtools-core@6.1.5)(react@19.2.7)(typescript@7.0.2)(web-tree-sitter@0.25.10)(ws@8.21.0)
       citty:
         specifier: ^0.2.2
         version: 0.2.2
       consola:
         specifier: ^3.4.2
         version: 3.4.2
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
     devDependencies:
       '@kyh/tsconfig':
         specifier: 'catalog:'
@@ -166,6 +175,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -260,7 +272,7 @@ importers:
         version: 11.18.0(@tanstack/react-query@5.101.2(react@19.2.7))(@trpc/client@11.18.0(@trpc/server@11.18.0(typescript@7.0.2))(typescript@7.0.2))(@trpc/server@11.18.0(typescript@7.0.2))(react@19.2.7)(typescript@7.0.2)
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(212155c4e59e78837d741703dea366e0)
+        version: 1.6.23(ea7420ac847205144efa036f87043625)
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
@@ -698,7 +710,7 @@ importers:
         version: 1.0.20
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(212155c4e59e78837d741703dea366e0)
+        version: 1.6.23(ea7420ac847205144efa036f87043625)
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
@@ -2617,6 +2629,60 @@ packages:
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
+  '@opentui/core-darwin-arm64@0.4.3':
+    resolution: {integrity: sha512-p5+7AAxpxGuDGagyQfewKtmTFnN7THvTVY4FyKqUtJomNaHdQXPHztapNNzMx0DGWbwOUbVKzpL+yc3CZY3chQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.4.3':
+    resolution: {integrity: sha512-+fh0vEUE0lwVC7RW5ijYLRlTLp5NfvCRj8SzxDVd7IL2j2ssB6YXcfIbXq2EW7UGnrejwPRXf1tgUrIXW9KmOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opentui/core-linux-arm64-musl@0.4.3':
+    resolution: {integrity: sha512-8p8g8/AEq/xFGpQ7XcIFKcAqjc0QwsZcv+Ll9RbCDpUA56FGH6jfLDir0KYTNTgYXJTIrBIENI9K46VuxMUMQA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-arm64@0.4.3':
+    resolution: {integrity: sha512-gl6qA5QJy6u8Cbt7gOtHbhhfMZ4qQDb0kEwFXHcMGmbnKzz4OHoq74D6tNjyvSQB9saoC7C6C0tvn2DcJOuNog==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opentui/core-linux-x64-musl@0.4.3':
+    resolution: {integrity: sha512-/QiFpCrpU2O7vy8QYmLIQYbvAtKDgmqcVjR7dGtqSzkiQk3ktNJoo5RozG7ueXnjung1Wp0nKldKxo2Csg/OrA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-x64@0.4.3':
+    resolution: {integrity: sha512-dXpJitiZdYE3hq2Pvx6e9I0uPQSOcnaLLp1pDgWAHv+3kvKSHEX//9Yr/pV/Ua6qqT7p+2D/K4vXNap/NKVo2w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opentui/core-win32-arm64@0.4.3':
+    resolution: {integrity: sha512-Mx2zuOjrhm/z2SDS6RExIyjP/SnN/8QhhagxURUw0jQi/NssGSeAllu1cBAFFnhobJL5QLTE4FU4CRhUK9svgg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@opentui/core-win32-x64@0.4.3':
+    resolution: {integrity: sha512-NuoqvWKGXaYnmlqvu7Gg2lLI6yVMnS9OfWBvxp+7Q+McSgHFSTQmYBXaPpvQ8HikpQXE1nCeMPtuSG4PdZHe2w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentui/core@0.4.3':
+    resolution: {integrity: sha512-rrJfAk13tALDqldYjhc78eWQ+aKq1iknJgffIOg3OwyZoqQo+p6gtuqyhmWvXIfQzlNUbpgpCPcxbXlhMnlaHQ==}
+    peerDependencies:
+      web-tree-sitter: 0.25.10
+
+  '@opentui/react@0.4.3':
+    resolution: {integrity: sha512-HtC/+lMURaZlifiJNVsn84YqKMywXQmkeSNbUTlbbeS6YM6reahaacnZEYZdnEUgklO6+r/J1tG8UBhqO26X7Q==}
+    peerDependencies:
+      react: '>=19.2.0'
+      react-devtools-core: ^7.0.1
+      ws: ^8.18.0
+
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
@@ -4091,6 +4157,11 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bun-ffi-structs@0.2.4:
+    resolution: {integrity: sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg==}
+    peerDependencies:
+      typescript: ^5
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -4478,6 +4549,10 @@ packages:
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dot-prop@6.0.1:
@@ -5616,6 +5691,11 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
@@ -6449,6 +6529,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -6815,6 +6901,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -7286,6 +7376,14 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -8199,7 +8297,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(212155c4e59e78837d741703dea366e0)
+      better-auth: 1.6.23(ea7420ac847205144efa036f87043625)
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -8229,7 +8327,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.23(212155c4e59e78837d741703dea366e0)
+      better-auth: 1.6.23(ea7420ac847205144efa036f87043625)
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -9393,6 +9491,61 @@ snapshots:
     optional: true
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
+
+  '@opentui/core-darwin-arm64@0.4.3':
+    optional: true
+
+  '@opentui/core-darwin-x64@0.4.3':
+    optional: true
+
+  '@opentui/core-linux-arm64-musl@0.4.3':
+    optional: true
+
+  '@opentui/core-linux-arm64@0.4.3':
+    optional: true
+
+  '@opentui/core-linux-x64-musl@0.4.3':
+    optional: true
+
+  '@opentui/core-linux-x64@0.4.3':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.4.3':
+    optional: true
+
+  '@opentui/core-win32-x64@0.4.3':
+    optional: true
+
+  '@opentui/core@0.4.3(typescript@7.0.2)(web-tree-sitter@0.25.10)':
+    dependencies:
+      bun-ffi-structs: 0.2.4(typescript@7.0.2)
+      diff: 9.0.0
+      marked: 17.0.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      web-tree-sitter: 0.25.10
+    optionalDependencies:
+      '@opentui/core-darwin-arm64': 0.4.3
+      '@opentui/core-darwin-x64': 0.4.3
+      '@opentui/core-linux-arm64': 0.4.3
+      '@opentui/core-linux-arm64-musl': 0.4.3
+      '@opentui/core-linux-x64': 0.4.3
+      '@opentui/core-linux-x64-musl': 0.4.3
+      '@opentui/core-win32-arm64': 0.4.3
+      '@opentui/core-win32-x64': 0.4.3
+    transitivePeerDependencies:
+      - typescript
+
+  '@opentui/react@0.4.3(react-devtools-core@6.1.5)(react@19.2.7)(typescript@7.0.2)(web-tree-sitter@0.25.10)(ws@8.21.0)':
+    dependencies:
+      '@opentui/core': 0.4.3(typescript@7.0.2)(web-tree-sitter@0.25.10)
+      react: 19.2.7
+      react-devtools-core: 6.1.5
+      react-reconciler: 0.33.0(react@19.2.7)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - typescript
+      - web-tree-sitter
 
   '@oxc-project/types@0.139.0': {}
 
@@ -10821,7 +10974,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
-  better-auth@1.6.23(212155c4e59e78837d741703dea366e0):
+  better-auth@1.6.23(ea7420ac847205144efa036f87043625):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260708.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2))(typescript@7.0.2))(kysely@0.29.3)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2))(sql.js@1.14.1))
@@ -10951,6 +11104,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
     optional: true
+
+  bun-ffi-structs@0.2.4(typescript@7.0.2):
+    dependencies:
+      typescript: 7.0.2
 
   bundle-name@4.1.0:
     dependencies:
@@ -11328,6 +11485,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   diff@8.0.4: {}
+
+  diff@9.0.0: {}
 
   dot-prop@6.0.1:
     dependencies:
@@ -12522,6 +12681,8 @@ snapshots:
       tmpl: 1.0.5
     optional: true
 
+  marked@17.0.1: {}
+
   marky@1.3.0:
     optional: true
 
@@ -13620,7 +13781,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    optional: true
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -13682,6 +13842,11 @@ snapshots:
       - supports-color
       - utf-8-validate
     optional: true
+
+  react-reconciler@0.33.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
 
   react-refresh@0.14.2:
     optional: true
@@ -14015,8 +14180,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.9.0:
-    optional: true
+  shell-quote@1.9.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -14170,6 +14334,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-ansi@7.2.0:
     dependencies:
@@ -14591,6 +14759,8 @@ snapshots:
   web-streams-polyfill@3.3.3:
     optional: true
 
+  web-tree-sitter@0.25.10: {}
+
   webidl-conversions@3.0.1:
     optional: true
 
@@ -14725,8 +14895,7 @@ snapshots:
       async-limiter: 1.0.1
     optional: true
 
-  ws@7.5.11:
-    optional: true
+  ws@7.5.11: {}
 
   ws@8.21.0: {}
 


### PR DESCRIPTION
Second sweep of majidmanzarpour/threejs-game-skills (MIT) surfaced a real capability gap: our playwright skill proves a game *renders and loads*, but nothing documented the "prove it actually plays" pattern we keep hand-building per game (lunerfall, battle-arena, starfall).

## What's added

**New `references/bot-playtest.md`:**
- **Diagnostics contract** — `window.__GAME_DIAGNOSTICS__` (read-only per-frame telemetry: frame, score, player pos, entity count, renderer stats) + `window.__GAME_TEST_HOOKS__` (`seed`, `setState`, `setPausedForScreenshot`, `setReducedMotion`, `hideDebugUi`). Generalizes the minimal `window.__TEST__` seam; engine-agnostic (Phaser + Three.js).
- **Progression-measuring bot** — copy-paste Playwright template asserting `framesAdvanced > 100`, distance travelled, score delta + step-of-first-score, **softlock windows** (frames advance, held input yields no motion and no progress → fail if > 2), zero page/console errors.
- **Fairness runs** — same script at 0ms vs 300ms reaction delay; equal outcomes = decorative difficulty.
- **Headless WebGL footguns** — never report headless FPS as perf (SwiftShader ~2fps vs 120 on GPU); `workers: 1` for WebGL or parallel contexts flake timed phases.

**SKILL.md:** bot-playtest section + pointer, baseline freeze checklist (seed RNG, pause particles, freeze shake/hit-stop/post FX, hide debug UI, wait fonts/GLTF/audio; skip un-seedable prototypes with reason), trigger words.

Scoped to `plugins/tooling/skills/playwright/` only — the threejs-skill sweep items land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bot playtest pattern and diagnostics contract to the Playwright skill, and introduces a live TUI dashboard for the factory powered by Bun. This proves games actually play and gives real-time visibility into agent runs.

- New Features
  - Playwright: `references/bot-playtest.md` with `window.__GAME_DIAGNOSTICS__` and `window.__GAME_TEST_HOOKS__`, a copy-paste bot measuring frames/distance/score and softlock windows, fairness runs, headless WebGL tips, and `SKILL.md` updates (includes: `seed(n)` must restart the run; guard partial diagnostics).
  - Factory: live TUI dashboard (activity feed + hotkeys: `a` approve, `s` stop, `q`/Ctrl-C quit) via `@opentui/core` and `@opentui/react`, reporter abstraction (TUI + console fallback with `--no-tui`), orchestrator emits structured activity, README updated, and scripts now run with `bun` (Bun ≥ 1.2).

<sup>Written for commit 3197666492b083d159b52d1f1abd2f0da9c56ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

