### PR TITLE
New game-ui skill + game-craft/generate top-ups from threejs-game-skills sweep

### DIFF
--- a/.claude/skills/game-ui
+++ b/.claude/skills/game-ui
@@ -1,0 +1,1 @@
+../../plugins/game-craft/skills/game-ui

--- a/plugins/game-craft/skills/design-lenses/SKILL.md
+++ b/plugins/game-craft/skills/design-lenses/SKILL.md
@@ -18,18 +18,37 @@ and emotionally dead. The lenses find where.
    break it (spam inputs, resize, lose on purpose, idle).
 2. **Write the MDA sentence**: "This game wants the player to feel X via
    dynamic Y produced by mechanics Z." Can't write it? That's finding #1 —
-   no essential experience.
-3. **Pick 8–12 lenses.** Always: Essential Experience, Fun, Feedback,
+   no essential experience. Then write the loop contract: "player does
+   [verb] to achieve [objective] while [pressure] creates risk; success →
+   [reward], failure → [cost/retry]". Any bracket you can't fill is a
+   finding too.
+3. **Run the rejection gates** (below). Each failed gate is an automatic
+   `blocker` — no lens needed.
+4. **Pick 8–12 lenses.** Always: Essential Experience, Fun, Feedback,
    Juiciness, Accessibility. Add by genre (Skill vs Chance for arcade,
    Curiosity for puzzle, the Toy for sandbox/physics).
-4. **Answer with evidence** — a timestamp, a code path, a missing sound —
+5. **Answer with evidence** — a timestamp, a code path, a missing sound —
    never vibes.
-5. **Severity**: `blocker` (player quits or never understands), `major`
+6. **Severity**: `blocker` (player quits or never understands), `major`
    (understood but flat), `minor` (polish), `idea` (opportunity).
-6. **Findings as lens → evidence → fix**, fixes concrete ("80ms hit-stop +
+7. **Findings as lens → evidence → fix**, fixes concrete ("80ms hit-stop +
    4px shake on collision", not "juicier"). Order: blockers, then cheapest
    major wins (audio + shake + score popups = highest fun-per-line).
-7. **Re-play after fixes**, re-asking only the failed lenses.
+8. **Re-play after fixes**, re-asking only the failed lenses and gates.
+
+## Rejection gates
+
+Binary go/no-go tests, self-applied in active play before claiming a game is
+fun. Any "true" = automatic blocker; fix or iterate before polishing:
+
+- The first 30 seconds lack a real decision.
+- The player can ignore the main mechanic and still progress.
+- The objective is unclear without reading source code or instructions.
+- Failure arrives before the player can understand why.
+- Challenge is only "more things", never better combinations.
+- Rewards change nothing — not strategy, score, progression, or feel.
+- The space is decorative and shapes no decisions.
+- The game is fun only in the designer's explanation, not in active play.
 
 ## The lens battery
 

--- a/plugins/game-craft/skills/game-ui/SKILL.md
+++ b/plugins/game-craft/skills/game-ui/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: game-ui
+description: "Game interface craft — HUD zoning and hierarchy, fixed-width numerals, alert-color roles, meters over stat cards, menu/overlay states, touch controls (44px targets, safe-area insets, pointer-release handling) — for Phaser, Three.js, and DOM overlays. Use when: building or reviewing a HUD, score/timer/health display, pause/fail/win menus, on-screen touch controls, 'the UI looks like a website', clipped or shifting text, or any in-game interface work."
+---
+
+# Game UI
+
+Build a game interface, not a web dashboard. The defining failure of
+prompt-built game UI: nested cards, marketing-hero title screens, generic
+dashboard styling, and web-app typography wrapped around a canvas.
+Anti-patterns to reject on sight: stat cards in rounded boxes inside boxes,
+a hero section with a tagline over the game, `<h1>`-styled headings in a HUD,
+one-note purple/blue gradient panels.
+
+Hierarchy follows gameplay priority: survival/status first, objective/progress
+second, immediate feedback third, flavor last. Prefer meters, icons, cooldown
+rings, badges, and compact clusters over labeled stat cards — a meter is read
+at glance-speed mid-dodge; a card is not.
+
+## HUD zoning
+
+- **Top-left**: objective, wave, distance, timer, progress.
+- **Top-right**: score, currency, combo, pause.
+- **Bottom-left/right**: touch movement/action controls (mobile).
+- **Center**: reserved for transient banners (wave start, combo, warnings) —
+  never persistent chrome, never stacked banners over the play path.
+- **In-world (diegetic) where possible**: target markers, off-screen threat
+  indicators, damage numbers, prompts anchored to the thing itself.
+- Keep all UI out of the play path — away from the player, threats, pickups,
+  and the next decision.
+
+## Numbers that don't dance
+
+- **Fixed-width numeric containers** for score, timer, ammo, speed, health:
+  tabular numerals (`font-variant-numeric: tabular-nums`) or a monospace face.
+  Changing values must never shift layout.
+- **Test the longest likely value**: max score, `MM:SS` timer, multi-digit
+  combo. No clipping, no wrap, no neighbor displacement.
+- Animate value changes briefly (count-up, meter fill, pulse) — a silently
+  incrementing corner number reads as broken (see `game-feel`).
+
+## Color roles
+
+One color = one meaning, everywhere: danger (damage, low health), reward
+(score, pickups), shield/defense, boost/power, objective, disabled. A limited
+status palette over neutral surfaces beats a rainbow. Critical states get two
+channels (color + shape/motion/sound) — never color alone.
+
+## Menus & overlays
+
+- Required states beyond the HUD: pause/resume, fail/retry, win/next when
+  relevant. Primary action first and biggest (resume, retry); secondary
+  actions (settings, quit) smaller.
+- Buttons have stable dimensions plus hover/pressed/focus/disabled states.
+- Overlays pause underneath, act in one input, and never look like a landing
+  page. Debug/tuning UI gates behind a dev flag or query param — it never
+  ships as player UI.
+- UI reads from the game state (single source of truth) and dispatches
+  intents; check for stale values after restart.
+
+## Touch controls (mobile)
+
+- **~44 CSS px minimum touch targets**, with enough separation that adjacent
+  controls can't be fat-fingered.
+- **Safe-area insets**: pad edge controls with `env(safe-area-inset-*)`;
+  nothing interactive under the notch or home indicator.
+- **Release paths**: handle `pointerup`, `pointercancel`,
+  `lostpointercapture`, window `blur`, and visibility change — a stuck
+  virtual button is a stuck key. Controls emit the same game intents as
+  keyboard.
+- `touch-action: none` only on the game surface and control regions, so page
+  scroll/zoom can't steal input.
+- Don't scale text with viewport width; use `clamp()` with sane floors.
+  Verify portrait and landscape if both are supported.
+
+## Ship checklist
+
+- [ ] First screen is the game (or a deliberate modal), not a landing page.
+- [ ] No nested cards / dashboard styling / marketing-hero layout.
+- [ ] HUD zones match the map above; center is transient-only.
+- [ ] Score/timer/ammo use fixed-width numerals; longest value tested.
+- [ ] Alert colors consistent; critical states have ≥2 feedback channels.
+- [ ] Pause, fail/retry (one input, <2s), win states exist and work.
+- [ ] Text legible over bright, dark, and moving backgrounds.
+- [ ] Mobile: 44px targets, safe-area insets, release-path handling, no
+      overlap between controls and HUD warnings.
+- [ ] No layout shift, clipping, or overlap at desktop / narrow / phone
+      widths.
+- [ ] Debug UI gated; no stale HUD values after restart.
+
+Related skills: `game-feel` (juice on value changes), `onboarding` (first-30s
+and control hints), `design-lenses` (Feedback/Accessibility lenses),
+`gamepad` (physical controller labels/glyphs).

--- a/plugins/game-craft/skills/level-design/SKILL.md
+++ b/plugins/game-craft/skills/level-design/SKILL.md
@@ -84,5 +84,37 @@ code-generated levels — generators should emit the same grammar.
 - **Risk/reward in waves**: bonus points/drops for risky play early — fights
   early-game boredom in score chasers (ABA Games).
 
+## Genre contracts
+
+Per-genre checkable design contracts — what the space must provide before it
+counts as designed. Apply on top of the core rules.
+
+- **Arcade racer**: define the handling fantasy first (drift, grip, hover,
+  combat). The track owes: readable apexes, braking/drift cues before
+  corners, recovery width after mistakes, landmarks for orientation, and a
+  route rhythm. Shortcuts cost risk. Skill tests: racing line, boost timing,
+  drift angle, traffic threading.
+- **Dogfight / space shooter**: pin engagement range, turn rate, projectile
+  speed, and lock-on/lead affordance — they define the dance. Encounters
+  need target readability, off-screen threat indicators, and deliberate
+  moments to reacquire orientation. Objectives must force movement, not
+  endless circular chasing.
+- **Tower defense**: path topology and chokepoints create the placement
+  decisions — a good map has non-obvious tile choices, not one optimal spot.
+  Define build zones, tower roles, economy cadence; expose upcoming enemy
+  types (wave tells) before they punish.
+- **Pool / mini-golf / physics table**: the physics and rules ARE the design.
+  Owed affordances: readable aim, force control, spin, legal-target and foul
+  feedback, camera reset. Each hole/table: one clear read, one trick, one
+  risk/reward route — reject any hole whose first shot is unreadable from
+  the tee.
+- **Boss fight**: every attack = readable tell → avoid/defend option →
+  impact feedback → cooldown (punish window). Phases add combinations and
+  arena pressure, never just more health. Define camera-lock behavior and
+  arena hazards up front.
+- **Puzzle**: state the rule each puzzle teaches. First puzzle teaches,
+  second confirms, third twists. Failure reveals information — no hidden
+  dependency chains that force guessing.
+
 Related skills: `game-playbook` (build order), `onboarding` (the first 30
 seconds), `game-balance` (wave economy/scaling math), `phaser` (tilemaps).

--- a/plugins/generate/skills/model-catalog/references/image-to-3d.md
+++ b/plugins/generate/skills/model-catalog/references/image-to-3d.md
@@ -33,8 +33,13 @@ Multiple view angles → 3D (front / side / three-quarter).
 
 ## Tips for best results
 
-- **Single object on plain background.** Photogrammetry-style 3D extraction works dramatically better when the subject is isolated.
+Input-image quality dominates output quality — fix the image before blaming the model.
+
+- **Single object on plain background, centered.** Photogrammetry-style 3D extraction works dramatically better when the subject is isolated.
 - **Remove the background first** if the source has clutter (use `fal-ai/bria/background/remove`).
+- **Readable silhouette + clear material zones.** The mesh comes from the silhouette; materials come from visually distinct regions (metal vs cloth vs skin). A muddy silhouette yields a blob.
+- **Avoid**: cropped limbs, hidden backs, extreme perspective, motion blur, heavy depth-of-field, crowded scenes, tiny baked-in text. When generating the source image, prompt for a neutral three-quarter or front view with even lighting.
+- **Characters/creatures bound for rigging**: full-body T- or A-pose, arms away from the body, legs separated, symmetric, complete head-to-feet, no props/cape fused into the silhouette — see `regenerate-3d` for the full rules.
 - **Multiple angles help** when the model supports multi-image input, front, side, three-quarter views give the best mesh.
 - **Generation is slow** (1-5 minutes), always run async with `vg generate status` polling.
 

--- a/plugins/generate/skills/model-catalog/references/text-to-image.md
+++ b/plugins/generate/skills/model-catalog/references/text-to-image.md
@@ -77,6 +77,26 @@ Open-weight, fine-tunable models.
 - `fal-ai/z-image/base`: Alibaba · Z Image Base
 - `fal-ai/z-image/turbo`: Alibaba · Z-Image Turbo
 
+## Game textures, skyboxes & UI plates
+
+Prompt patterns for 2D assets consumed by a game engine (Phaser/Three.js):
+
+- **Tileable/seamless textures** (ground, walls, terrain albedo): prompt
+  "seamless tileable texture, orthographic top-down view, uniform diffuse
+  lighting, no shadows, no perspective, no vignette" + the material ("mossy
+  cobblestone", "cracked asphalt"). Baked-in shadows and perspective are the
+  two failure modes that break tiling — reject and regenerate. Verify by
+  tiling the result 2×2 before shipping.
+- **Trim sheets & decals** (panel lines, hazard stripes, window bands, lane
+  glyphs): prompt flat orthographic strips on a plain background; generate
+  at the aspect they'll be sliced at.
+- **Sky / background plates**: prompt "layered depth, readable horizon line,
+  no foreground subject" — a centered subject ruins a backdrop. For Three.js
+  skydomes ask for wide aspect (2:1 or wider) so the wrap doesn't stretch.
+- **HUD icons, logos, badges**: generate on plain/transparent background
+  (`fal-ai/recraft/v4/text-to-vector` for crisp scalable marks), strong
+  silhouette, no tiny text.
+
 ## Family-specific prompting
 
 For prompt-craft details, see the `model-prompting` skill:

--- a/plugins/generate/skills/regenerate-3d/SKILL.md
+++ b/plugins/generate/skills/regenerate-3d/SKILL.md
@@ -44,6 +44,28 @@ All packaged into a single static HTML page with a Three.js scene. ~25–35 MB o
  transition lines + radial flash on swap
 ```
 
+## Riggable-character rules
+
+Auto-rigging quality is decided at image-generation time. For any character
+image headed into `enable_rigging=true`:
+
+- **Full-body T- or A-pose**, front-facing, arms clearly away from the body,
+  legs separated, symmetric. Whole body in frame — head to feet, no cropped
+  limbs.
+- **No props, capes, tabards, or long skirts fused into the silhouette** —
+  anything that merges limbs into the body confuses the auto-rigger. Give
+  weapons/props to the character afterward as separate meshes if needed.
+- **Verify the generated image actually shows the pose** before spending on
+  the 3D step. Models drift toward action poses; a cool contrapposto shot
+  rigs badly. Regenerate with a stronger pose instruction rather than
+  rigging a bad pose.
+- **Body plan drives animation choice**: the mesh's stance decides how
+  animation presets read. A quadruped walk on an upright dragon looks like a
+  human in a costume; an upright biped clip on a hunched creature warps.
+  Match the animation library entry to the stance you generated.
+- Hard-surface armored designs (plate knights, mechs) auto-rig worse than
+  organic silhouettes — budget a retry or prefer visible-anatomy designs.
+
 ## CREATE-YOUR-OWN flow
 
 Visitors with generation credentials can generate their own character + companion live, in-browser:


### PR DESCRIPTION
PR 3 of 3 from the second sweep of [majidmanzarpour/threejs-game-skills](https://github.com/majidmanzarpour/threejs-game-skills) (MIT). Ports the engine-agnostic craft gaps; PR 1 covers the threejs skill, PR 2 the playwright bot-playtest pattern.

## New skill: `game-craft/game-ui`

Genuine hole in game-craft — we covered feel/vfx/animation/onboarding/level/balance but nothing on interface craft. Engine-agnostic (Phaser, Three.js, DOM overlays):

- Build a game interface, not a web dashboard — concrete anti-patterns (nested cards, marketing-hero over the game, dashboard styling)
- HUD zoning (objective TL / score TR / touch controls bottom / center transient-only / diegetic in-world)
- Fixed-width numerals + longest-likely-value test so values never shift layout
- One color = one meaning alert roles; ≥2 feedback channels for critical states
- Menu/overlay states, debug-UI gating, stale-value-after-restart check
- Touch: ~44px targets, `env(safe-area-inset-*)`, `pointerup`/`pointercancel`/`lostpointercapture`/blur release paths, `touch-action` scoping
- Binary ship checklist

Symlink added to `.claude/skills/` (same relative form as the rest; no dogfood run needed).

## Top-ups

- **level-design**: per-genre design contracts — arcade racer, dogfight/space shooter, tower defense, pool/mini-golf, boss fights (phases add combinations not HP; tell→avoid→impact→cooldown), puzzle (teach/confirm/twist)
- **design-lenses**: core-loop contract one-liner in the procedure + 8 binary rejection gates (auto-blockers before lens work)
- **model-catalog/image-to-3d**: input-image prep discipline (silhouette/material zones; avoid cropped limbs, motion blur, DoF, crowds)
- **model-catalog/text-to-image**: game texture/skybox/UI-plate prompt patterns (tileable = orthographic + no baked shadows; sky plates = no foreground subject; verify 2×2 tiling)
- **regenerate-3d**: riggable-character rules (verified T/A-pose, no fused props/capes, body plan drives animation choice, armored designs rig worse)

`npx tsx scripts/check-skill-refs.ts` passes. No provider branding added to generate-skill prose (endpoint IDs verbatim per policy).

Note for follow-up (out of scope here): `apps/factory/agents/charter.md` line 14 enumerates skills — consider adding `game-ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `game-craft/game-ui` skill to standardize HUDs, menus, and touch controls across engines. Also adds concise contracts and asset-prep rules to close gaps in level design, lens reviews, and 3D generation.

- **New Features**
  - New `game-craft/game-ui` skill: HUD zoning, fixed-width numerals, alert color roles, pause/fail/win overlays, mobile touch controls (44px targets, safe-area insets, release paths), and a ship checklist. Symlinked in `.claude/skills/`.
  - `level-design`: genre contracts for arcade racer, dogfight/space shooter, tower defense, pool/mini-golf, boss fights, and puzzle.
  - `design-lenses`: add a core loop contract sentence and 8 binary rejection gates; run gates before lenses and re-test only failures.
  - `generate` top-ups: `model-catalog/image-to-3d` (input image prep: clean silhouette, clear materials, avoid blur/crops); `model-catalog/text-to-image` (prompts for tileable textures, sky/plates, HUD icons; verify 2×2 tiling); `regenerate-3d` (riggable-character rules: T/A-pose, no fused props, stance drives animation).

<sup>Written for commit 6b5aa16e7de7f31fe65c279547d96ade82199cf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

