### PR TITLE
threejs skill: correctness fixes + graphics recipes + render-budget checks

### DIFF
--- a/plugins/game-engines/skills/threejs/SKILL.md
+++ b/plugins/game-engines/skills/threejs/SKILL.md
@@ -37,7 +37,8 @@ Scene setup is inline below. Read the relevant reference before working on that 
 | Game loop, state machine, object pooling, screen effects               | `references/game-patterns.md`           |
 | Dropping generated GLB models / SFX into a running scene               | `references/generated-assets.md`        |
 | Post-processing, shaders, instancing, env maps, color management       | `references/advanced-topics.md`         |
-| Black screen, low FPS, mobile issues, memory leaks                     | `references/debugging-and-profiling.md` |
+| Material values, shader injection (onBeforeCompile), sky, cheap tricks | `references/graphics-recipes.md`        |
+| Black screen, low FPS, mobile issues, memory leaks, physics debugging  | `references/debugging-and-profiling.md` |
 
 **Verify it actually renders.** `scripts/check-canvas.mjs` loads a build in headless Chromium and fails on a blank canvas or uncaught page error — run it in CI / before `vg deploy` (details in `references/debugging-and-profiling.md`).
 
@@ -173,6 +174,8 @@ Choose material based on lighting needs and visual style.
 }
 ```
 
+Concrete per-surface values (painted metal, rubber, ceramic, glass, cloth, emissive) are in `references/graphics-recipes.md`. Two rules that matter more than the numbers: metals/glossy surfaces need an environment map or they render flat gray (see `references/advanced-topics.md`), and objects should differ by roughness/metalness contrast, not hue alone.
+
 ---
 
 ## Lighting
@@ -200,6 +203,8 @@ const fillLight = new THREE.DirectionalLight(0x88ccff, 0.5);
 fillLight.position.set(-5, 0, -5);
 scene.add(fillLight);
 ```
+
+In a game, add a rim/back light behind the player (opposite the camera) — it separates the character's silhouette from a busy background, which matters more than a prettier key light.
 
 **Shadows** (advanced, use when needed):
 

--- a/plugins/game-engines/skills/threejs/references/advanced-topics.md
+++ b/plugins/game-engines/skills/threejs/references/advanced-topics.md
@@ -6,6 +6,7 @@ Topics beyond simple scenes.
 
 - [`gltf-loading-guide.md`](gltf-loading-guide.md) — loading 3D models (GLTF/GLB): basic/promise/fallback/batch loading, caching, cloning, normalization, troubleshooting
 - [`game-patterns.md`](game-patterns.md) — game loops, screen effects, animation states, parallax
+- [`graphics-recipes.md`](graphics-recipes.md) — PBR material values, onBeforeCompile shader injection, cheap visual tricks, sky dome
 - [`debugging-and-profiling.md`](debugging-and-profiling.md) — black-screen triage, draw-call/FPS profiling, mobile, memory leaks
 
 ---
@@ -37,47 +38,66 @@ GLTF loaders set these correctly automatically — only set them by hand for tex
 
 ---
 
-## Post-Processing (Bloom, Depth of Field)
+## Post-Processing (Bloom, Vignette)
 
-For visual effects like bloom, use the EffectComposer:
+Use the EffectComposer, and **always end the chain with `OutputPass`** — since r152 it performs tone mapping + sRGB conversion. Without it the composer outputs linear un-tonemapped color (washed-out or blown-out); keep `renderer.toneMapping` set so `OutputPass` reads it.
 
-```html
-<script type="module">
-  import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
-  import { EffectComposer } from "https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/EffectComposer.js";
-  import { RenderPass } from "https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/RenderPass.js";
-  import { UnrealBloomPass } from "https://unpkg.com/three@0.160.0/examples/jsm/postprocessing/UnrealBloomPass.js";
+```javascript
+import { EffectComposer } from "three/addons/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
+import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
+import { ShaderPass } from "three/addons/postprocessing/ShaderPass.js";
+import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 
-  // Basic setup...
-  const renderer = new THREE.WebGLRenderer({ antialias: true });
-  renderer.setSize(window.innerWidth, window.innerHeight);
-  renderer.toneMapping = THREE.ReinhardToneMapping;
+renderer.toneMapping = THREE.ACESFilmicToneMapping; // OutputPass applies this
 
-  // Post-processing
-  const renderScene = new RenderPass(scene, camera);
+const composer = new EffectComposer(renderer);
+composer.addPass(new RenderPass(scene, camera));
 
-  const bloomPass = new UnrealBloomPass(
-    new THREE.Vector2(window.innerWidth, window.innerHeight),
-    1.5, // strength
-    0.4, // radius
-    0.85, // threshold
-  );
+// UnrealBloomPass(resolution, strength, radius, threshold)
+const bloom = new UnrealBloomPass(
+  new THREE.Vector2(window.innerWidth, window.innerHeight),
+  0.45, // strength: 0.35–0.6
+  0.3, // radius: 0.2–0.4
+  0.85, // threshold: only pixels brighter than this bloom
+);
+composer.addPass(bloom);
+composer.addPass(new OutputPass()); // ALWAYS last: tone mapping + sRGB
 
-  const composer = new EffectComposer(renderer);
-  composer.addPass(renderScene);
-  composer.addPass(bloomPass);
-
-  renderer.setAnimationLoop(() => {
-    composer.render();
-  });
-</script>
+renderer.setAnimationLoop(() => {
+  composer.render(); // instead of renderer.render()
+});
+// resize: composer.setSize(w, h) alongside renderer.setSize(w, h)
 ```
+
+**Bloom discipline:** threshold `0.85` keeps mid-bright materials out, so only authored emissives (`emissiveIntensity > 1`) bloom. Bloom sells a glow you designed; it must never be the main source of detail — if a shape only reads because it glows, the geometry is missing.
+
+**Vignette** — a compact ShaderPass, added before `OutputPass`:
+
+```javascript
+const VignetteShader = {
+  uniforms: { tDiffuse: { value: null }, uStrength: { value: 0.85 }, uSize: { value: 0.72 } },
+  vertexShader: `varying vec2 vUv; void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }`,
+  fragmentShader: `uniform sampler2D tDiffuse; uniform float uStrength, uSize; varying vec2 vUv;
+    void main(){
+      vec4 c = texture2D(tDiffuse, vUv);
+      float d = distance(vUv, vec2(0.5));
+      c.rgb *= mix(1.0, smoothstep(uSize, uSize - 0.45, d), uStrength);
+      gl_FragColor = c;
+    }`,
+};
+composer.addPass(new ShaderPass(VignetteShader)); // before OutputPass
+```
+
+Keep `uStrength` subtle and never darken the play path.
+
+**Mobile:** the composer allocates full-resolution HDR render targets, so cost scales with **DPR²**. Cap DPR before adding passes (`composer.setPixelRatio(Math.min(devicePixelRatio, 1.25))`), and on low-end devices skip the composer entirely (plain `renderer.render()`). Budget ≤ 2 passes desktop, 0–1 mobile beyond render+output.
 
 ---
 
 ## Custom Shaders (ShaderMaterial)
 
-For custom visual effects, write GLSL shaders:
+For fully custom **unlit** effects, write GLSL from scratch with `ShaderMaterial`. To add effects to a **lit PBR surface** (rim glow, dissolve, wind sway) don't rewrite the lighting — inject into `MeshStandardMaterial` with `onBeforeCompile` instead; see [`graphics-recipes.md`](graphics-recipes.md).
 
 ```javascript
 const vertexShader = `
@@ -173,25 +193,37 @@ window.addEventListener("click", (event) => {
 
 ## Environment Maps (Reflections)
 
-For realistic reflections on metallic surfaces:
+**Metals and glossy surfaces render flat gray without an environment map** — there's nothing to reflect. This is the usual cause of "my metal doesn't look metallic."
+
+Default: `RoomEnvironment` — a neutral studio IBL with **zero external assets**, so it always works in a generated game:
 
 ```javascript
-import { RGBELoader } from "https://unpkg.com/three@0.160.0/examples/jsm/loaders/RGBELoader.js";
+import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
 
-const rgbeLoader = new RGBELoader();
-rgbeLoader.load("path/to/environment.hdr", (texture) => {
-  texture.mapping = THREE.EquirectangularReflectionMapping;
-  scene.environment = texture;
-  scene.background = texture;
-});
+const pmrem = new THREE.PMREMGenerator(renderer);
+scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+pmrem.dispose(); // one bake at startup, near-zero cost per frame
 
-// Material with reflections
+// Now this actually reads as metal:
 const material = new THREE.MeshStandardMaterial({
-  color: 0x444444,
+  color: 0xaeb4bd,
   metalness: 1,
   roughness: 0.1,
 });
 ```
+
+If you have a real HDR file (you usually don't in a generated game), load it with `RGBELoader`:
+
+```javascript
+import { RGBELoader } from "three/addons/loaders/RGBELoader.js";
+
+new RGBELoader().load("environment.hdr", (texture) => {
+  texture.mapping = THREE.EquirectangularReflectionMapping;
+  scene.environment = texture; // scene.background = texture for a visible backdrop
+});
+```
+
+Concrete per-surface material values (`metalness`/`roughness`/`envMapIntensity`) are in [`graphics-recipes.md`](graphics-recipes.md).
 
 ---
 

--- a/plugins/game-engines/skills/threejs/references/debugging-and-profiling.md
+++ b/plugins/game-engines/skills/threejs/references/debugging-and-profiling.md
@@ -41,7 +41,37 @@ console.log(renderer.info.render); // { calls, triangles, ... }
 console.log(renderer.info.memory); // { geometries, textures }
 ```
 
-**Draw calls (`render.calls`) are usually the bottleneck, not triangles.** A modern GPU eats millions of triangles but chokes on thousands of draw calls. Budget rough targets: **< 100–200 draw calls** for mobile, triangles in the low millions.
+**Draw calls (`render.calls`) are usually the bottleneck, not triangles.** A modern GPU eats millions of triangles but chokes on thousands of draw calls.
+
+### Render budget starting points
+
+Measure the **worst active-play view**, not the menu. These are starting contracts, not hard limits — overrun deliberately, but know you did. `check-canvas.mjs` compares these numbers automatically when the page exposes diagnostics (see below).
+
+| Metric (worst active-play view)    | Desktop  | Mobile   |
+| ---------------------------------- | -------- | -------- |
+| Draw calls (`info.render.calls`)   | ≤ 300    | ≤ 150    |
+| Triangles (`info.render.triangles`)| ≤ 750k   | ≤ 300k   |
+| Geometries (`info.memory.geometries`) | ≤ 300 | ≤ 200    |
+| Textures (`info.memory.textures`)  | ≤ 60     | ≤ 40     |
+| Shadow-casting lights              | ≤ 2      | 1        |
+| Shadow map size                    | ≤ 2048   | ≤ 1024   |
+| DPR cap                            | 2        | 1.5–2    |
+| Post passes (beyond render+output) | ≤ 2      | 0–1      |
+
+To let headless checks read these numbers, expose a diagnostics snapshot and refresh it once a second:
+
+```javascript
+window.__GAME_DIAGNOSTICS__ = { renderer: {} };
+setInterval(() => {
+  const { render, memory } = renderer.info;
+  window.__GAME_DIAGNOSTICS__.renderer = {
+    calls: render.calls,
+    triangles: render.triangles,
+    geometries: memory.geometries,
+    textures: memory.textures,
+  };
+}, 1000);
+```
 
 ### Fixes, highest-leverage first
 
@@ -95,6 +125,29 @@ Also unregister the entity's **animation mixer and physics body** when removing 
 
 ---
 
+## Physics & collision
+
+When "the physics is broken," check these in order — each is a distinct bug with a distinct signature:
+
+1. **Collider doesn't match the visual mesh** — the player clips walls or bounces off air. Render debug shapes at collider positions (a wireframe `BoxHelper`/capsule mesh synced to each body) and compare. Colliders are primitives sized from measured bounds (`generated-assets.md`), and they drift if you scale the mesh after creating the collider.
+2. **Fast objects tunnel through walls** — a bullet/dasher skips past a thin collider between steps. Enable CCD **only on the fast bodies** (`RigidBodyDesc.setCcdEnabled(true)` in Rapier) — CCD everywhere wastes CPU. Or thicken the wall collider.
+3. **Kinematic platforms move the mesh but not the body** — the player falls through a "moving" platform. You must call `setNextKinematicTranslation()` on the body each step; setting `mesh.position` animates only the visual.
+4. **Sensors never fire** — Rapier sensor colliders need active events: `.setSensor(true).setActiveEvents(RAPIER.ActiveEvents.COLLISION_EVENTS)`, and you must drain the event queue each step.
+5. **Fixed-step accumulator wired to the render delta** — physics stepped with a variable `dt` explodes under frame drops (jitter, launches). Step at a fixed `1/60` inside an accumulator loop (`gameplay-systems.md`); never `world.step(renderDelta)`.
+6. **Restart leaks bodies** — after a restart the world gets slower and collisions double-fire: old bodies were never removed. The physics world owns body lifecycle; on restart remove every body/collider (or rebuild the world), don't just clear the scene graph.
+
+Diagnostics snippet — log once a second alongside `renderer.info`:
+
+```javascript
+console.log({
+  bodies: world.bodies.len(),      // Rapier
+  colliders: world.colliders.len(),
+});
+// If these climb across restarts, you're leaking bodies (see #6).
+```
+
+---
+
 ## Quick reference: what to check first
 
 | Problem | First thing to check |
@@ -104,3 +157,4 @@ Also unregister the entity's **animation mixer and physics body** when removing 
 | FPS drops over time | allocation in the loop, then undisposed resources |
 | Bad on mobile only | DPR cap, then resize handling |
 | Stretched after rotate | resize handler updating aspect + setSize |
+| Clipping through walls / falling through platforms | collider-vs-mesh match, then CCD / kinematic body updates |

--- a/plugins/game-engines/skills/threejs/references/game-patterns.md
+++ b/plugins/game-engines/skills/threejs/references/game-patterns.md
@@ -161,170 +161,204 @@ renderer.setAnimationLoop(gameLoop);
 
 ---
 
-## Time Scaling (Slow Motion)
+## Hitstop & Slow Motion (Time Scaling)
+
+**Never drive time-scale effects with `setTimeout` or wall clock** — they desync from the simulation on frame drops, keep running while the game is paused or the tab is hidden, and stack incorrectly. Decay them in the game loop with the frame delta.
+
+The rule for all feel effects: **gameplay reads the scaled delta; camera, shake, tweens, and HUD read the real delta.** If feedback is scaled too, the frozen moment is invisible.
 
 ```javascript
-// Trigger slow-mo
-function triggerSlowMo(factor, duration) {
-  state.timeScale = factor;
+// Fields on state:
+state.timeScale = 1;
+state.hitstopRemaining = 0; // seconds, decays in REAL time
 
-  setTimeout(() => {
-    state.timeScale = 1.0;
-  }, duration * 1000);
+function hitstop(durationMs, scale = 0.05) {
+  state.hitstopRemaining = Math.max(state.hitstopRemaining, durationMs / 1000);
+  state.timeScale = scale;
 }
 
-// Usage
-triggerSlowMo(0.3, 0.2); // 30% speed for 0.2 seconds
+function gameLoop() {
+  const dt = Math.min(clock.getDelta(), 0.1);
 
-// Gradual return to normal
-function triggerSlowMoSmooth(factor, holdTime, rampTime) {
-  state.timeScale = factor;
+  if (state.hitstopRemaining > 0) {
+    state.hitstopRemaining -= dt; // decay in REAL time
+    if (state.hitstopRemaining <= 0) state.timeScale = 1;
+  }
+  const gameplayDt = dt * state.timeScale;
 
-  setTimeout(() => {
-    const startTime = performance.now();
-    const rampMs = rampTime * 1000;
+  // Gameplay reads the scaled delta so the world crawls...
+  updatePlayer(gameplayDt);
+  updateObstacles(gameplayDt);
+  for (const mixer of mixers) mixer.update(gameplayDt);
 
-    function ramp() {
-      const elapsed = performance.now() - startTime;
-      const t = Math.min(elapsed / rampMs, 1);
-      state.timeScale = factor + (1 - factor) * t;
+  // ...but feedback reads the REAL delta so it stays live during the freeze.
+  updateShake(dt);
+  updateFov(dt);
+  updateScore(dt); // score in real time — never affected by slow-mo
 
-      if (t < 1) requestAnimationFrame(ramp);
-    }
-    ramp();
-  }, holdTime * 1000);
+  renderer.render(scene, camera);
 }
-
-// Usage: 0.15x for 0.2s, then ramp to 1x over 0.12s
-triggerSlowMoSmooth(0.15, 0.2, 0.12);
 ```
+
+Recommended: **60–90ms at scale `0.05`** on heavy hits only. Hitstop on every minor event makes the game feel laggy instead of weighty. Never stop the render loop to freeze — the frame must keep drawing or the frozen moment can't be seen.
+
+For longer slow-mo (bullet-time), set `state.timeScale = 0.3` and ease it back toward 1 in the loop: `state.timeScale += (1 - state.timeScale) * Math.min(1, dt * 5)`.
 
 ---
 
 ## Screen Effects
 
-### Camera Shake
+### Camera Shake (trauma-based)
+
+Add **trauma** on events; shake magnitude is `trauma²`, so small events barely move the camera and big ones snap hard. Deterministic value noise instead of `Math.random()` — smooth, seedable, reproducible under test.
 
 ```javascript
-const cameraBasePos = { x: 2, y: 5, z: 16 };
-let shakeIntensity = 0;
-let shakeDuration = 0;
+const TRAUMA_DECAY = 1.4; // trauma units per second
+const MAX_OFFSET = 0.55; // world units at full shake
+const MAX_ROLL = 0.1; // radians at full shake
 
-function shakeScreen(intensity, duration) {
-  shakeIntensity = intensity;
-  shakeDuration = duration;
+let trauma = 0;
+let shakeTime = 0;
+
+function addTrauma(amount) {
+  trauma = Math.min(1, trauma + amount); // hard cap: stacked events can't fling the camera
 }
 
-function updateShake(dt) {
-  if (shakeDuration > 0) {
-    shakeDuration -= dt;
-    const decay = shakeDuration / 0.3; // Assume 0.3s base duration
-    const offset = shakeIntensity * decay;
+// Deterministic value noise in [-1, 1]; per-axis seed keeps axes independent.
+function pseudoNoise(t, seed) {
+  const x = Math.sin(t * 12.9898 + seed * 78.233) * 43758.5453;
+  return (x - Math.floor(x)) * 2 - 1;
+}
 
-    camera.position.x = cameraBasePos.x + (Math.random() - 0.5) * offset;
-    camera.position.y = cameraBasePos.y + (Math.random() - 0.5) * offset;
-  } else {
-    camera.position.x = cameraBasePos.x;
-    camera.position.y = cameraBasePos.y;
-  }
+// Call every frame AFTER the camera's base transform is written (follow cam, lookAt).
+// The offset never accumulates because the base transform is re-derived each frame.
+function updateShake(dt) {
+  shakeTime += dt;
+  trauma = Math.max(0, trauma - TRAUMA_DECAY * dt);
+  if (trauma <= 0) return;
+  const shake = trauma * trauma;
+  const freq = shakeTime * 32;
+  camera.position.x += MAX_OFFSET * shake * pseudoNoise(freq, 1);
+  camera.position.y += MAX_OFFSET * shake * pseudoNoise(freq, 2);
+  camera.rotation.z += MAX_ROLL * shake * pseudoNoise(freq, 3);
+}
+
+// Usage — trauma per event:
+addTrauma(0.15); // pickup
+addTrauma(0.4); // player hit
+addTrauma(0.7); // explosion
+```
+
+Skipping the `trauma²` curve or the cap is the classic mistake: small events feel violent and stacked events launch the camera.
+
+### FOV Punch
+
+An additive FOV bump reads as acceleration or shock. Decay toward 0 with a ~200ms time constant. Applies to `camera.fov` (perspective), not `camera.zoom`.
+
+```javascript
+const BASE_FOV = 50;
+let fovPunch = 0; // additive degrees
+
+function punchFov(degrees) {
+  fovPunch = Math.min(10, fovPunch + degrees); // additive, clamped
+}
+
+function updateFov(dt) {
+  if (fovPunch <= 0.001) return;
+  fovPunch *= Math.exp(-dt / 0.2); // ~200ms decay
+  if (fovPunch < 0.001) fovPunch = 0;
+  camera.fov = BASE_FOV + fovPunch;
+  camera.updateProjectionMatrix(); // REQUIRED — without it the FOV never visibly changes
 }
 
 // Usage
-shakeScreen(0.5, 0.35); // Intensity 0.5 units, 0.35 seconds
+punchFov(6); // boost / dash
+punchFov(8); // explosion
 ```
 
 ### Screen Flash
 
+A DOM overlay is cheaper than a render-target flash and never touches the 3D pipeline. Use `element.animate()` (WAAPI) — self-cleaning, no `setTimeout` bookkeeping:
+
 ```html
-<div
-  id="flash-overlay"
-  style="
-    position: absolute;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.08s;
-"
-></div>
+<div id="flash-overlay" style="position: fixed; inset: 0; pointer-events: none; opacity: 0;"></div>
 ```
 
 ```javascript
-function flashScreen(color, duration) {
+function flashScreen(color, durationMs = 100, peak = 0.5) {
   const overlay = document.getElementById("flash-overlay");
   overlay.style.backgroundColor = color;
-  overlay.style.opacity = 0.3;
-
-  setTimeout(() => {
-    overlay.style.opacity = 0;
-  }, duration * 1000);
+  overlay.animate([{ opacity: peak }, { opacity: 0 }], { duration: durationMs, easing: "ease-out" });
 }
 
 // Usage
-flashScreen("#4DEBFF", 0.15); // Cyan flash for near-miss
-flashScreen("#ffffff", 0.08); // White flash for impact
+flashScreen("#4DEBFF", 150, 0.3); // cyan flash for near-miss
+flashScreen("#ffffff", 100, 0.8); // white flash for explosion/death
 ```
 
-### Zoom Pulse
+### Impact Flash (material)
+
+Pulse `emissiveIntensity` on the hit object and decay it in the loop. The material's `emissive` **color must be non-black** or nothing shows.
 
 ```javascript
-let zoomTarget = 1.0;
-let zoomCurrent = 1.0;
-
-function zoomPulse(scale, duration) {
-  zoomTarget = scale;
-
-  setTimeout(() => {
-    zoomTarget = 1.0;
-  }, duration * 500); // Half duration for in, half for out
+function flashHit(material, peak = 2.4) {
+  material.userData.baseEmissive ??= material.emissiveIntensity;
+  material.emissiveIntensity = peak;
 }
 
-function updateZoom(dt) {
-  // Smooth interpolation
-  zoomCurrent += (zoomTarget - zoomCurrent) * dt * 10;
-
-  // Apply to camera FOV (for perspective) or frustum (for ortho)
-  camera.zoom = zoomCurrent;
-  camera.updateProjectionMatrix();
+function updateFlashes(dt, materials) {
+  for (const m of materials) {
+    const base = m.userData.baseEmissive;
+    if (base === undefined || m.emissiveIntensity <= base) continue;
+    m.emissiveIntensity = Math.max(base, m.emissiveIntensity - dt * 10);
+  }
 }
-
-// Usage
-zoomPulse(1.02, 0.2); // 2% zoom in, 0.2s total
 ```
 
 ---
 
 ## Squash & Stretch
 
-For jump anticipation and landing impact:
+Preserve volume: when the Y axis scales by `s`, counter-scale X/Z by `1 / sqrt(s)` — otherwise the model visibly grows/shrinks instead of deforming. Decay in the loop, not with `setTimeout` chains.
 
 ```javascript
-function setModelScale(model, sx, sy, sz) {
-  model.scale.set(sx, sy, sz);
+let squashY = 1; // current Y scale; 1 = rest
+
+// squash < 1 on impact/landing, stretch > 1 on jump takeoff
+function squash(target, amount) {
+  squashY = amount;
 }
 
-// Jump anticipation
-function jumpAnticipation(model) {
-  setModelScale(model, 1.15, 0.8, 1.15); // Squash
-
-  setTimeout(() => {
-    setModelScale(model, 1, 1, 1); // Restore
-  }, 80);
+function updateSquash(dt, target) {
+  // spring back toward 1 with overshoot (the bounce is the feel)
+  squashY += (1 - squashY) * Math.min(1, dt * 14);
+  const xz = 1 / Math.sqrt(squashY); // volume-preserving counter-scale
+  target.scale.set(xz, squashY, xz);
 }
 
-// Landing impact
-function landingSquash(model) {
-  setModelScale(model, 1.2, 0.75, 1.2); // Heavy squash
-
-  setTimeout(() => {
-    setModelScale(model, 0.95, 1.1, 0.95); // Overshoot
-  }, 60);
-
-  setTimeout(() => {
-    setModelScale(model, 1, 1, 1); // Settle
-  }, 150);
-}
+// Usage
+squash(player, 1.15); // jump takeoff stretch
+squash(player, 0.85); // landing squash (0.75 for heavy impact)
 ```
+
+Both should return to rest over ~180ms. Apply to a visual wrapper `Group`, never the physics body.
+
+---
+
+## Per-Event Tuning Table
+
+Map each event to a full feedback stack — stronger events get more layers, not just bigger numbers:
+
+| Event        | Feedback stack                                                              |
+| ------------ | --------------------------------------------------------------------------- |
+| Pickup       | scale pop + HUD counter punch + pitch-varied chime + `0.15` trauma          |
+| Player hit   | hitstop 70ms + `0.4` trauma + impact flash + rumble 180ms                   |
+| Enemy killed | hitstop 40ms + `0.3` trauma + impact flash + pitch-varied boom              |
+| Boost / dash | FOV punch +6° + stretch 1.15 + whoosh                                       |
+| Jump / land  | stretch 1.15 on takeoff, squash 0.85 on landing + `0.2` trauma on land      |
+| Explosion    | hitstop 90ms + `0.7` trauma + white screen flash + FOV punch +8° + rumble   |
+
+(SFX pitch variation and audio wiring: [`generated-assets.md`](generated-assets.md). Deeper engine-agnostic feel theory and 2D numbers: the `game-feel` skill.)
 
 ---
 
@@ -565,10 +599,11 @@ function showFloatingText(text, color, x = "50%", y = "35%") {
 | Animation state management | Characters with multiple animations          |
 | Facing direction rotation  | Side-scrollers with GLTF models              |
 | Game state machine         | Any game with menu/play/pause/gameover       |
-| Time scaling               | Slow-mo for impact moments                   |
-| Screen shake               | Death, heavy impacts                         |
+| Hitstop / time scaling     | Weight on heavy contact, slow-mo moments     |
+| Trauma camera shake        | Death, heavy impacts (trauma², capped)       |
+| FOV punch                  | Boost, dash, explosion shock                 |
 | Screen flash               | Near-miss, milestones, damage                |
-| Squash & stretch           | Jump, land, any snappy motion                |
+| Squash & stretch           | Jump, land, any snappy motion (volume-preserving) |
 | Parallax layers            | Scrolling games with depth                   |
 | Object pooling             | Spawning many objects (obstacles, particles) |
 | Fixed camera               | Games (not model viewers)                    |
@@ -595,6 +630,17 @@ state.score += dt * state.timeScale;
 
 // GOOD - score uses real time
 state.score += dt;
+```
+
+❌ **Driving effects with `setTimeout` / wall clock**
+
+```javascript
+// BAD - keeps running while paused/tab-hidden, desyncs on frame drops,
+// stacks incorrectly when two hits land close together
+setTimeout(() => (state.timeScale = 1), 200);
+
+// GOOD - decay in the game loop with the frame delta
+state.hitstopRemaining -= dt;
 ```
 
 ❌ **Forgetting to clean up animation mixers**

--- a/plugins/game-engines/skills/threejs/references/game-patterns.md
+++ b/plugins/game-engines/skills/threejs/references/game-patterns.md
@@ -325,7 +325,7 @@ Preserve volume: when the Y axis scales by `s`, counter-scale X/Z by `1 / sqrt(s
 let squashY = 1; // current Y scale; 1 = rest
 
 // squash < 1 on impact/landing, stretch > 1 on jump takeoff
-function squash(target, amount) {
+function squash(amount) {
   squashY = amount;
 }
 
@@ -336,9 +336,9 @@ function updateSquash(dt, target) {
   target.scale.set(xz, squashY, xz);
 }
 
-// Usage
-squash(player, 1.15); // jump takeoff stretch
-squash(player, 0.85); // landing squash (0.75 for heavy impact)
+// Usage — updateSquash(dt, playerVisual) runs in the loop
+squash(1.15); // jump takeoff stretch
+squash(0.85); // landing squash (0.75 for heavy impact)
 ```
 
 Both should return to rest over ~180ms. Apply to a visual wrapper `Group`, never the physics body.

--- a/plugins/game-engines/skills/threejs/references/generated-assets.md
+++ b/plugins/game-engines/skills/threejs/references/generated-assets.md
@@ -95,11 +95,50 @@ world.createCollider(
 
 For animated characters, **don't normalize with `loadNormalized`** (its `setFromObject` bounds include the skeleton — see the note above); use the mesh-only normalization in `gltf-loading-guide.md` (Pattern 6), then keep `gltf.animations` and drive them with the mixer/crossfade patterns in `game-patterns.md`. For a full rigged-character generation pipeline, use the `regenerate-3d` skill.
 
+### 4. Validate rigged GLBs before wiring them in
+
+Auto-rigged models come back **silently degenerate** more often than broken: the file loads, the mesh renders, but the rig has one arm and no legs, or a clip has 3 tracks and holds the bind pose forever. Check before spending an hour debugging "the animation doesn't play":
+
+```javascript
+// Log clip names + track counts — a walk cycle on a humanoid has dozens of
+// tracks; a clip with a handful of tracks is frozen at bind pose. Reject it.
+console.log(gltf.animations.map((c) => `${c.name}: ${c.tracks.length} tracks, ${c.duration.toFixed(2)}s`));
+
+// Log the skeleton — a humanoid rig missing leg/arm bones animates as a lump.
+gltf.scene.traverse((o) => {
+  if (o.isSkinnedMesh) console.log(o.name, o.skeleton.bones.map((b) => b.name));
+});
+```
+
+If a clip is degenerate, regenerate the asset — don't try to fix the rig in code. And don't trust vendor "in-place" flags: if a walk clip slides the root across the world, strip/ignore the root bone's translation track in-engine rather than re-generating with a different flag.
+
+### Hero vs procedural: don't generate 40 GLBs
+
+Generate **one hero-fidelity asset per key entity** (player, boss, signature prop) and build high-volume repeated detail — crates, rocks, debris, background silhouettes — from primitives and `InstancedMesh` (see `advanced-topics.md`). Forty unique generated GLBs blow the download size, the texture budget, and the draw-call budget at once, and background props read fine as instanced primitives with good materials.
+
 ---
 
 ## Generated SFX → Web Audio triggers
 
 Three.js's `PositionalAudio` is fine for spatial ambience, but for gameplay SFX (jump, hit, pickup) a small Web Audio pool gives lower latency and lets you overlap the same sound.
+
+### 0. Plan the audio pass as a matrix, not a wishlist
+
+Before generating anything, list events by category — it surfaces what's missing (a game with hit sounds but no pickup sound feels broken) and tells you what loops:
+
+| Category    | Events                        | Count | Loops? | Mix note                          |
+| ----------- | ----------------------------- | ----- | ------ | --------------------------------- |
+| UI          | click, confirm, back          | 1 ea  | no     | quieter + shorter than gameplay SFX |
+| Movement    | jump, land, dash, footstep    | 1–2 ea| no     | footsteps need a cooldown         |
+| Interaction | pickup, door, switch          | 1 ea  | no     | —                                 |
+| Threat      | enemy hit, player hit, explosion | 2–3 variants ea | no | the sounds that must land hardest |
+| Ambience    | wind/room tone, music         | 1 ea  | YES    | low volume, ducks under SFX       |
+
+Rules that keep it from sounding cheap:
+
+- **High-frequency events get a variant pool + cooldown.** For footsteps/rapid fire, generate 2–3 variants and round-robin them, and rate-limit (~80ms) so overlaps don't comb-filter. ±5% rate variation (below) is the floor, not the fix.
+- **Test loops looping.** A generated "loop" usually has a click at the seam. Play it twice back-to-back in-engine before accepting it.
+- **Don't stack loops on restart.** Ambience/music started in `init()` plays twice after a restart. Keep a handle to the looping source and stop it (or guard with an `isPlaying` flag) before starting again.
 
 ### 1. Generate
 
@@ -158,7 +197,10 @@ Randomizing `playbackRate` ±5% per trigger is the cheapest way to stop repeated
 
 - [ ] Models generated `--async`, polled, downloaded to `public/` (not generated at runtime).
 - [ ] Every loaded model normalized to a target height and recentered onto y=0.
+- [ ] Rigged GLBs validated before wiring: clip track counts logged, degenerate clips rejected.
+- [ ] One hero GLB per key entity; repeated props are primitives/instances, not more GLBs.
 - [ ] Colliders are primitives sized to bounds, not the GLB triangle mesh.
 - [ ] SFX decoded once, played via fresh `BufferSource` per trigger.
 - [ ] `AudioContext` resumed on first gesture (mobile silence guard).
-- [ ] Repeated SFX get ±5% rate variation.
+- [ ] Repeated SFX get ±5% rate variation; high-frequency SFX get variant pools + cooldowns.
+- [ ] Loops tested at the seam; no duplicate ambience loops after restart.

--- a/plugins/game-engines/skills/threejs/references/graphics-recipes.md
+++ b/plugins/game-engines/skills/threejs/references/graphics-recipes.md
@@ -1,0 +1,241 @@
+# Graphics Recipes
+
+Concrete material values, shader injection patterns, and cheap visual tricks. Every recipe is copy-pasteable and mobile-conscious. Prerequisite: an environment map and a tone-mapped renderer (see [`advanced-topics.md`](advanced-topics.md)) — without them PBR values below won't read.
+
+The rule for all of it: **effects clarify gameplay, never hide missing geometry.** If a shape only reads because it glows, the geometry is missing.
+
+---
+
+## PBR Material Recipes
+
+Copy the config, tune `color` to your palette. `envMapIntensity` assumes a `RoomEnvironment` env map. Use `MeshStandardMaterial` unless a `MeshPhysicalMaterial`-only feature (clearcoat, transmission, sheen) is visible during play.
+
+```javascript
+// Painted metal (car body, ship hull) — dielectric paint over metal, read via clearcoat
+new THREE.MeshPhysicalMaterial({ color: 0x1f6feb, metalness: 0.0, roughness: 0.5,
+  clearcoat: 0.9, clearcoatRoughness: 0.15, envMapIntensity: 1.0 });
+
+// Bare brushed metal (steel, gun frame) — needs the env map to look metallic at all
+new THREE.MeshStandardMaterial({ color: 0xaeb4bd, metalness: 1.0, roughness: 0.4, envMapIntensity: 1.1 });
+
+// Rubber / tire — near-black, kills reflection
+new THREE.MeshStandardMaterial({ color: 0x0a0a0b, metalness: 0.0, roughness: 0.92, envMapIntensity: 0.35 });
+
+// Matte plastic (housings, crates)
+new THREE.MeshStandardMaterial({ color: 0xd23b3b, metalness: 0.0, roughness: 0.62, envMapIntensity: 0.6 });
+
+// Glossy ceramic / clean hull — clearcoat for the wet-look premium read
+new THREE.MeshPhysicalMaterial({ color: 0xf5f5f5, metalness: 0.0, roughness: 0.12,
+  clearcoat: 1.0, clearcoatRoughness: 0.05, envMapIntensity: 1.0 });
+
+// Emissive signal (beacon, pickup core) — dark base so only the glow reads; >1 intensity feeds bloom
+new THREE.MeshStandardMaterial({ color: 0x101010, emissive: 0x18e0ff, emissiveIntensity: 2.5,
+  metalness: 0.0, roughness: 0.4 });
+
+// Cloth / fabric — high roughness + sheen for the soft edge highlight
+new THREE.MeshPhysicalMaterial({ color: 0x3a4a6b, metalness: 0.0, roughness: 0.9,
+  sheen: 1.0, sheenRoughness: 0.5, sheenColor: new THREE.Color(0x8899bb), envMapIntensity: 0.5 });
+```
+
+**Separate roles by roughness/metalness contrast (matte vs glossy, metal vs plastic), not hue alone.** Two objects with different colors but identical material response read as the same "stuff."
+
+### Glass: real vs fake
+
+```javascript
+// REAL refractive glass — transmission
+new THREE.MeshPhysicalMaterial({ metalness: 0.0, roughness: 0.05, transmission: 1.0,
+  thickness: 0.5, ior: 1.5, envMapIntensity: 1.0 });
+```
+
+**Cost warning:** every transmissive material triggers an **extra full-scene render into a transmission buffer every frame**. Reserve it for one or two hero surfaces (cockpit canopy, potion vial) at close range. Never use it on repeated or instanced props.
+
+```javascript
+// CHEAP fake glass — one transparent draw call, no extra render target.
+// Use for repeated windows, visors, shields.
+new THREE.MeshPhysicalMaterial({ color: 0x88ccff, metalness: 0.0, roughness: 0.1,
+  transparent: true, opacity: 0.25, clearcoat: 1.0, envMapIntensity: 1.5, depthWrite: false });
+```
+
+Add the fresnel rim below for a readable edge.
+
+---
+
+## onBeforeCompile: Inject Into PBR Materials
+
+To add rim glow, dissolve, scrolling emissive, or wind sway to a lit surface, inject GLSL into a stock `MeshStandardMaterial` — you keep the whole PBR lighting pipeline for free instead of rewriting it in a `ShaderMaterial`. Three rules make this safe:
+
+- **Cache key (silent-failure gotcha):** any material whose `onBeforeCompile` injects code **must set `customProgramCacheKey`** returning a string unique to that injection. Without it Three.js can hand back a cached program compiled from a different, un-injected material of the same type — your code silently never runs, and it costs hours.
+- **Animating uniforms:** `onBeforeCompile` fires **once** per compiled program, so stash the shader (`material.userData.shader = shader`) and write uniforms each frame: `if (m.userData.shader) m.userData.shader.uniforms.uTime.value = t;`.
+- **Sharing:** reuse one material instance across meshes and its uniforms update once for all. For per-object variation, use separate instances (same cache key still reuses the program) or drive it from `instanceMatrix`.
+
+### Fresnel rim glow
+
+`vNormal` and `vViewPosition` (view space) already exist in the Standard fragment shader; `saturate` is defined in `<common>`.
+
+```javascript
+material.onBeforeCompile = (shader) => {
+  shader.uniforms.uRimColor = { value: new THREE.Color(0x33ccff) };
+  shader.uniforms.uRimPower = { value: 3.0 };
+  shader.uniforms.uRimStrength = { value: 1.5 };
+  shader.fragmentShader =
+    "uniform vec3 uRimColor;\nuniform float uRimPower;\nuniform float uRimStrength;\n" +
+    shader.fragmentShader.replace(
+      "#include <emissivemap_fragment>",
+      `#include <emissivemap_fragment>
+       float fres = pow(1.0 - saturate(dot(normalize(vNormal), normalize(vViewPosition))), uRimPower);
+       totalEmissiveRadiance += uRimColor * fres * uRimStrength;`,
+    );
+};
+material.customProgramCacheKey = () => "fresnel-rim";
+```
+
+Use for shields, invulnerability states, and silhouette separation from a busy background. Cost: a few ALU ops, no extra passes.
+
+### Scrolling emissive panels
+
+Inject a private UV varying so it works without any texture assigned.
+
+```javascript
+material.onBeforeCompile = (shader) => {
+  shader.uniforms.uTime = { value: 0 };
+  shader.uniforms.uPanelColor = { value: new THREE.Color(0x18e0ff) };
+  material.userData.shader = shader;
+  shader.vertexShader = "varying vec2 vPanelUv;\n" + shader.vertexShader.replace(
+    "#include <begin_vertex>", "#include <begin_vertex>\n vPanelUv = uv;");
+  shader.fragmentShader =
+    "uniform float uTime;\nuniform vec3 uPanelColor;\nvarying vec2 vPanelUv;\n" +
+    shader.fragmentShader.replace(
+      "#include <emissivemap_fragment>",
+      `#include <emissivemap_fragment>
+       float scroll = fract(vPanelUv.y * 6.0 - uTime * 0.5);
+       float band = smoothstep(0.46, 0.5, scroll) * smoothstep(0.54, 0.5, scroll);
+       totalEmissiveRadiance += uPanelColor * band * 2.0;`,
+    );
+};
+material.customProgramCacheKey = () => "scroll-emissive";
+```
+
+Energy conduits, charge bars, boost lanes. Scroll direction/speed should encode state (charging up, draining down).
+
+### Wind sway (foliage, flags)
+
+`transformed` is object space, displaced before `<project_vertex>` applies `instanceMatrix` — so read the instance translation for per-instance phase. Assumes model origin at the base, up = +Y.
+
+```javascript
+material.onBeforeCompile = (shader) => {
+  shader.uniforms.uTime = { value: 0 };
+  material.userData.shader = shader;
+  shader.vertexShader = "uniform float uTime;\n" + shader.vertexShader.replace(
+    "#include <begin_vertex>",
+    `#include <begin_vertex>
+     #ifdef USE_INSTANCING
+       float phase = instanceMatrix[3].x + instanceMatrix[3].z;
+     #else
+       float phase = 0.0;
+     #endif
+     float h = max(position.y, 0.0); // base stays planted, tips move most
+     transformed.x += sin(uTime * 1.5 + phase) * 0.08 * h;
+     transformed.z += cos(uTime * 1.1 + phase) * 0.05 * h;`,
+  );
+};
+material.customProgramCacheKey = () => "wind-sway";
+```
+
+Grass cards, banners, antennae — background life only. **Never sway collidable/interactable geometry**; visuals drifting off the collider reads as a hitbox bug.
+
+### Dissolve / spawn
+
+Threshold-discard with a glowing edge. Drive `uProgress` 0→1 to despawn, 1→0 to spawn.
+
+```javascript
+material.onBeforeCompile = (shader) => {
+  shader.uniforms.uProgress = { value: 0 };
+  shader.uniforms.uEdgeColor = { value: new THREE.Color(0xff6a00) };
+  material.userData.shader = shader;
+  shader.vertexShader = "varying vec3 vDisPos;\n" + shader.vertexShader.replace(
+    "#include <begin_vertex>", "#include <begin_vertex>\n vDisPos = position;");
+  shader.fragmentShader =
+    `uniform float uProgress;\nuniform vec3 uEdgeColor;\nvarying vec3 vDisPos;
+     float hash13(vec3 p){ p = fract(p * 0.1031); p += dot(p, p.yzx + 33.33); return fract((p.x + p.y) * p.z); }\n` +
+    shader.fragmentShader.replace(
+      "#include <dithering_fragment>",
+      `float n = hash13(floor(vDisPos * 12.0));
+       if (n < uProgress) discard;
+       float edge = smoothstep(uProgress, uProgress + 0.08, n);
+       gl_FragColor.rgb += uEdgeColor * (1.0 - edge) * 3.0; // post-tonemap add feeds bloom
+       #include <dithering_fragment>`,
+    );
+};
+material.customProgramCacheKey = () => "dissolve";
+```
+
+Enemy death, teleport-in, pickup spawn. `discard` disables early-Z — keep it on spawning objects, not the whole scene. Spawn and destroy must look different (edge color/direction telegraphs which).
+
+---
+
+## Gradient Sky Dome
+
+Cheaper than a cubemap for stylized outdoor scenes: a `BackSide` sphere with a horizon→zenith lerp plus a sun disc and halo. One draw call, no textures, and a flat clear-color background stops reading as "sparse."
+
+```javascript
+const sky = new THREE.Mesh(
+  new THREE.SphereGeometry(500, 32, 16),
+  new THREE.ShaderMaterial({
+    side: THREE.BackSide, depthWrite: false,
+    uniforms: {
+      uTop: { value: new THREE.Color(0x3a6fb0) },
+      uHorizon: { value: new THREE.Color(0xcfe4f5) },
+      uSunColor: { value: new THREE.Color(0xfff2cc) },
+      uSunDir: { value: new THREE.Vector3(0.4, 0.28, 0.6).normalize() },
+    },
+    vertexShader: `varying vec3 vDir;
+      void main(){ vDir = normalize(position); gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }`,
+    fragmentShader: `varying vec3 vDir;
+      uniform vec3 uTop, uHorizon, uSunColor, uSunDir;
+      void main(){
+        float h = clamp(vDir.y * 0.5 + 0.5, 0.0, 1.0);
+        vec3 col = mix(uHorizon, uTop, pow(h, 0.6));
+        float d = clamp(dot(normalize(vDir), normalize(uSunDir)), 0.0, 1.0);
+        col += uSunColor * (pow(d, 800.0) + pow(d, 8.0) * 0.25); // disc + halo
+        gl_FragColor = vec4(col, 1.0);
+      }`,
+  }),
+);
+sky.frustumCulled = false;
+scene.add(sky);
+```
+
+Gotcha: a raw `ShaderMaterial` **bypasses tone mapping and sRGB conversion** — author sky colors in display space, and nudge them brighter if the scene runs ACES. Keep the horizon value distinct from anything silhouetted against it.
+
+---
+
+## Cheap Visual Tricks
+
+Each is one draw call or less, mobile-safe, and solves a constant real need.
+
+- **Fake contact shadow** — a flat `PlaneGeometry` under the object with a radial-gradient `CanvasTexture`, `{ transparent: true, depthWrite: false }`; scale/fade alpha with the object's height. Grounds hovering or moving props with **no shadow pass at all** — the cheapest fix for "everything looks like it's floating."
+
+  ```javascript
+  function makeContactShadow(radius = 1) {
+    const c = document.createElement("canvas");
+    c.width = c.height = 128;
+    const ctx = c.getContext("2d");
+    const g = ctx.createRadialGradient(64, 64, 0, 64, 64, 64);
+    g.addColorStop(0, "rgba(0,0,0,0.4)");
+    g.addColorStop(1, "rgba(0,0,0,0)");
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 128, 128);
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(radius * 2, radius * 2),
+      new THREE.MeshBasicMaterial({ map: new THREE.CanvasTexture(c), transparent: true, depthWrite: false }),
+    );
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.position.y = 0.01; // just above the ground plane
+    return mesh;
+  }
+  ```
+
+- **Polygon-offset decals** — a coplanar decal mesh z-fights with the surface under it. Fix: `{ polygonOffset: true, polygonOffsetFactor: -1, polygonOffsetUnits: -1, transparent: true }` on the decal material. Panel lines, numbers, faction glyphs, scorch marks. +1 draw call each — instance repeats.
+- **Vertex-color AO** — bake occlusion into the mesh: darken a `color` attribute in cavities/creases, material `{ vertexColors: true }`. Static props and terrain get contact darkness for one attribute, zero extra draw calls.
+- **Matcap background props** — `new THREE.MeshMatcapMaterial({ matcap })` bakes lighting into one texture; needs no lights or env map. The cheapest lit-looking material for background/stylized props. It **ignores scene lights**, so never use it where a dynamic light or state glow must show.
+- **Emissive LOD signals** — far pickups/beacons keep reading by swapping `emissiveIntensity` by distance instead of adding geometry. Keep the signal color constant across the swap so identity survives.

--- a/plugins/game-engines/skills/threejs/scripts/check-canvas.mjs
+++ b/plugins/game-engines/skills/threejs/scripts/check-canvas.mjs
@@ -268,11 +268,17 @@ function report(opts, result) {
   if (result.out) console.log(`  screenshot: ${result.out}`);
   if (result.budget) {
     const over = result.budget.filter((row) => row.ok === false);
+    const missing = result.budget.filter((row) => row.ok === null);
     if (over.length) {
       console.log(`  render budget (${result.tier} tier, advisory) — OVER:`);
       for (const row of over) console.log(`    - ${row.metric}: ${row.actual} > ${row.limit}`);
+    } else if (missing.length === result.budget.length) {
+      console.log(`  render budget (${result.tier} tier): diagnostics present but no numeric metrics — not validated`);
     } else {
       console.log(`  render budget (${result.tier} tier): within limits`);
+    }
+    if (missing.length && missing.length < result.budget.length) {
+      console.log(`    (not reported by diagnostics: ${missing.map((row) => row.metric).join(", ")})`);
     }
   }
   if (result.pageErrors?.length) {

--- a/plugins/game-engines/skills/threejs/scripts/check-canvas.mjs
+++ b/plugins/game-engines/skills/threejs/scripts/check-canvas.mjs
@@ -8,11 +8,20 @@
  *
  * Usage:
  *   node check-canvas.mjs <url> [--selector <css>] [--out <png>] [--wait <ms>]
- *                               [--min-std <n>] [--json]
+ *                               [--min-std <n>] [--mobile] [--json]
  *
  * Examples:
  *   node check-canvas.mjs http://localhost:5173
  *   node check-canvas.mjs ./dist/index.html --out /tmp/frame.png --json
+ *   node check-canvas.mjs http://localhost:5173 --mobile
+ *
+ * --mobile emulates a phone-class device (390×844 viewport, DPR 3, touch) and
+ * applies the mobile render budget tier.
+ *
+ * Render budget (advisory, never fails the check): if the page exposes
+ * `window.__GAME_DIAGNOSTICS__.renderer` — a snapshot of renderer.info like
+ * { calls, triangles, geometries, textures } (see
+ * references/debugging-and-profiling.md) — over-budget metrics are reported.
  *
  * Exit codes:
  *   0 = canvas rendered non-blank content
@@ -27,8 +36,15 @@ import { pathToFileURL } from "node:url";
 import { writeFileSync } from "node:fs";
 import { inflateSync } from "node:zlib";
 
+// Starting-point render budgets (references/debugging-and-profiling.md).
+// Over-budget rows are reported, never fatal.
+const RENDER_BUDGETS = {
+  desktop: { calls: 300, triangles: 750_000, geometries: 300, textures: 60 },
+  mobile: { calls: 150, triangles: 300_000, geometries: 200, textures: 40 },
+};
+
 function parseArgs(argv) {
-  const opts = { selector: "canvas", out: null, wait: 1500, minStd: 4, json: false };
+  const opts = { selector: "canvas", out: null, wait: 1500, minStd: 4, json: false, mobile: false };
   const rest = [];
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -37,6 +53,7 @@ function parseArgs(argv) {
     else if (a === "--wait") opts.wait = Number(argv[++i]);
     else if (a === "--min-std") opts.minStd = Number(argv[++i]);
     else if (a === "--json") opts.json = true;
+    else if (a === "--mobile") opts.mobile = true;
     else rest.push(a);
   }
   opts.target = rest[0];
@@ -163,7 +180,7 @@ async function main() {
     return 2;
   }
   if (!opts.target) {
-    console.error("usage: node check-canvas.mjs <url|file> [--selector css] [--out png] [--wait ms] [--min-std n] [--json]");
+    console.error("usage: node check-canvas.mjs <url|file> [--selector css] [--out png] [--wait ms] [--min-std n] [--mobile] [--json]");
     return 2;
   }
 
@@ -182,7 +199,11 @@ async function main() {
   const pageErrors = []; // uncaught exceptions — fail the check
   try {
     browser = await chromium.launch();
-    const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+    const page = await browser.newPage(
+      opts.mobile
+        ? { viewport: { width: 390, height: 844 }, deviceScaleFactor: 3, isMobile: true, hasTouch: true }
+        : { viewport: { width: 1280, height: 720 } },
+    );
     page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text()));
     page.on("pageerror", (e) => pageErrors.push(String(e)));
 
@@ -197,6 +218,21 @@ async function main() {
     const png = await canvas.screenshot();
     if (opts.out) writeFileSync(opts.out, png);
 
+    // Advisory render-budget check: only when the page exposes a diagnostics
+    // snapshot (window.__GAME_DIAGNOSTICS__.renderer = renderer.info numbers).
+    const tier = opts.mobile ? "mobile" : "desktop";
+    const rendererInfo = await page
+      .evaluate(() => globalThis.__GAME_DIAGNOSTICS__?.renderer ?? null)
+      .catch(() => null);
+    const budget = rendererInfo
+      ? Object.entries(RENDER_BUDGETS[tier]).map(([metric, limit]) => ({
+          metric,
+          actual: typeof rendererInfo[metric] === "number" ? rendererInfo[metric] : null,
+          limit,
+          ok: typeof rendererInfo[metric] === "number" ? rendererInfo[metric] <= limit : null,
+        }))
+      : null;
+
     const stats = analyze(decodePng(png));
     // positive comparisons negated, so a non-finite metric fails (never a false pass)
     const blankLum = !(stats.stdLum >= opts.minStd);
@@ -210,7 +246,7 @@ async function main() {
         : nearEmpty
           ? `near-empty canvas (opaque ${(stats.opaqueFraction * 100).toFixed(1)}% ≤ 1%)`
           : `blank/solid (stdLum ${stats.stdLum.toFixed(2)} < ${opts.minStd})`;
-    report(opts, { ok, reason, ...stats, out: opts.out, consoleErrors, pageErrors });
+    report(opts, { ok, reason, ...stats, tier, budget, out: opts.out, consoleErrors, pageErrors });
     return ok ? 0 : 1;
   } catch (err) {
     report(opts, { ok: false, reason: String(err?.message || err), consoleErrors, pageErrors });
@@ -230,6 +266,15 @@ function report(opts, result) {
     console.log(`  luminance stddev: ${result.stdLum.toFixed(2)}  mean: ${result.meanLum.toFixed(1)}  opaque: ${(result.opaqueFraction * 100).toFixed(1)}%`);
   }
   if (result.out) console.log(`  screenshot: ${result.out}`);
+  if (result.budget) {
+    const over = result.budget.filter((row) => row.ok === false);
+    if (over.length) {
+      console.log(`  render budget (${result.tier} tier, advisory) — OVER:`);
+      for (const row of over) console.log(`    - ${row.metric}: ${row.actual} > ${row.limit}`);
+    } else {
+      console.log(`  render budget (${result.tier} tier): within limits`);
+    }
+  }
   if (result.pageErrors?.length) {
     console.log(`  uncaught page errors (${result.pageErrors.length}):`);
     for (const e of result.pageErrors.slice(0, 5)) console.log(`    - ${e}`);


### PR DESCRIPTION
Sweep of [majidmanzarpour/threejs-game-skills](https://github.com/majidmanzarpour/threejs-game-skills) (MIT) — PR 1 of 3: everything scoped to the `threejs` skill.

## Correctness fixes (we were teaching wrong code)

- **Post-processing** (`advanced-topics.md`): the bloom example used pre-r152 `ReinhardToneMapping` with no `OutputPass` — tone mapping was mis-applied. Now: `OutputPass` always last, bloom `threshold 0.85` so only authored emissives bloom, DPR² cost + skip-composer-on-mobile guidance, compact vignette pass.
- **Env maps** (`advanced-topics.md`): example pointed at a nonexistent `.hdr`, so generated games got flat-gray metals. Now defaults to `RoomEnvironment` (zero external assets), RGBELoader demoted to secondary.
- **Screen effects** (`game-patterns.md`): replaced `setTimeout` slow-mo (breaks on pause/tab-away), `Math.random()` linear-decay shake, and non-volume-preserving squash with: trauma²-curve shake (seeded value noise, world-unit caps, hard trauma cap), frame-driven hitstop that scales only the gameplay delta, FOV punch with ~200ms exponential decay + mandatory `updateProjectionMatrix()`, volume-preserving squash (`1/sqrt(s)` counter-scale). Added a per-event tuning table and a new anti-pattern entry.

## New: `references/graphics-recipes.md`

- PBR material recipes with concrete values (painted/brushed metal, rubber, plastic, ceramic, emissive, cloth) + the roughness/metalness-contrast rule
- Real vs fake glass, with the transmission-renders-the-scene-twice perf warning
- `onBeforeCompile` injection into `MeshStandardMaterial` (fresnel rim, scrolling emissive, wind sway, dissolve) + the silent `customProgramCacheKey` gotcha
- Gradient sky dome (one draw call, no cubemap; display-space color gotcha)
- Cheap tricks: fake contact shadow, polygon-offset decals, vertex-color AO, matcap props, emissive LOD

## Debugging + verification

- `debugging-and-profiling.md`: desktop/mobile render-budget tier table + a `window.__GAME_DIAGNOSTICS__` convention so headless checks can read `renderer.info`; new physics & collision debug checklist (collider-vs-mesh, tunneling/CCD, kinematic body updates, sensors, fixed-step accumulator, restart body leaks)
- `check-canvas.mjs`: `--mobile` (390×844, DPR 3, touch) + advisory render-budget check when the page exposes diagnostics. Kept the zero-dependency PNG decoder, `file://` support, NaN-strict checks, and exit-code semantics.

## Generated assets QA

- Validate rigged GLBs before wiring (auto-rigs come back silently degenerate — log clip track counts, reject bind-pose clips; ignore vendor in-place flags, strip root motion in-engine)
- Hero-vs-procedural doctrine (one hero GLB per key entity, instanced primitives for bulk)
- Audio planning matrix + variant pools/cooldowns, loop-seam testing, no duplicate loops on restart

## Verification

- `npx tsx scripts/check-skill-refs.ts` — clean
- `check-canvas.mjs` exercised end-to-end in headless Chromium: usage path, desktop + `--mobile`, budget over/within both reported correctly, `--json` shape intact; a control run of the unmodified script confirmed pass/fail semantics unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect three.js guidance (post‑processing order and env maps) and rebuilds screen‑effects patterns for reliable game feel. Adds `graphics-recipes.md`, physics/collision debugging, and render‑budget checks to help ship performant, correctly lit scenes.

- **Bug Fixes**
  - Post-processing ends with `OutputPass`; bloom threshold discipline; DPR²/mobile note.
  - Env maps default to `RoomEnvironment` (no external assets); `.hdr` is secondary.
  - Screen effects rebuilt: trauma² shake (seeded noise, caps), frame‑driven hitstop (scales gameplay delta only), FOV punch with `updateProjectionMatrix()`, volume‑preserving squash.
  - `check-canvas.mjs`: budget report no longer marks missing diagnostics fields as within limits.

- **New Features**
  - New `references/graphics-recipes.md`: PBR values, `onBeforeCompile` (fresnel, scrolling emissive, wind sway, dissolve) + `customProgramCacheKey`, gradient sky, cheap tricks (contact shadow, decals, vertex‑AO, matcap, emissive LOD).
  - Debugging/profiling: desktop/mobile render budgets, physics/collision checklist, and `window.__GAME_DIAGNOSTICS__` for `renderer.info`.
  - `scripts/check-canvas.mjs`: `--mobile` emulation (390×844, DPR 3, touch) and advisory budget checks vs tier limits.
  - Generated assets + audio QA: rigged GLB validation (reject degenerate clips), hero vs procedural guidance, audio matrix with variant pools/cooldowns and loop‑seam tests.

<sup>Written for commit 49fa22a814a12eda0393604c3f4ee1eb5b70064a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

