### PR TITLE
starfall: adopt bot-playtest diagnostics contract

### DIFF
--- a/games/starfall/.gitignore
+++ b/games/starfall/.gitignore
@@ -1,0 +1,2 @@
+test-results
+playwright-report

--- a/games/starfall/e2e/bot-playtest.spec.ts
+++ b/games/starfall/e2e/bot-playtest.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+
+// Bot playtest — starfall adoption of the diagnostics contract in the
+// playwright skill (references/bot-playtest.md; lunerfall is the reference
+// implementation). Drives real MOUSE input (starfall's core verb: the ship
+// steers toward the cursor, holding the button autofires) through an offline
+// solo arena and asserts PROGRESSION, not pixels.
+//
+// Seeding: starfall's GameScene is single-start, so the seed rides the URL
+// (?seed=N, read in main.ts before boot) instead of a mid-run seed() hook —
+// the contract's sanctioned boot-time alternative. Determinism boundary:
+// local rolls (spawns, drops, weapon picks, shot jitter) are seeded; roll
+// CONSUMPTION order is frame-timing dependent, so replays are statistically
+// stable rather than frame-identical (same boundary as lunerfall).
+//
+// Headless caveat: SwiftShader renders this at single-digit FPS — everything
+// here is a correctness signal, never a performance one.
+
+type Diagnostics = {
+  frame: number;
+  score: number;
+  complete: boolean;
+  player: { x: number; y: number; speed: number };
+  entities: number;
+};
+
+type TestHooks = {
+  setState(name: string): void;
+};
+
+declare global {
+  interface Window {
+    __GAME_DIAGNOSTICS__?: Diagnostics;
+    __GAME_TEST_HOOKS__?: TestHooks;
+  }
+}
+
+// Cursor sweep in viewport coordinates (1280×720 default). The ship chases
+// the cursor, so far-flung waypoints keep it moving; the button stays down
+// the whole run (holding autofires) and enemies converge on the player, so a
+// sweep reliably farms fodder kills → XP.
+const SWEEP: Array<{ x: number; y: number; ms: number }> = [
+  { x: 1150, y: 120, ms: 2400 },
+  { x: 140, y: 620, ms: 2400 },
+  { x: 1150, y: 620, ms: 2400 },
+  { x: 140, y: 120, ms: 2400 },
+  { x: 640, y: 360, ms: 1600 },
+  { x: 1150, y: 360, ms: 2400 },
+  { x: 140, y: 360, ms: 2400 },
+  { x: 640, y: 120, ms: 2400 },
+];
+
+test("bot playtest: mouse sweep progresses a seeded offline solo arena", async ({ page }, testInfo) => {
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+  page.on("pageerror", (e) => pageErrors.push(e.message));
+  page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text()));
+
+  await page.goto("/?seed=12345");
+  await page.waitForFunction(() => (window.__GAME_DIAGNOSTICS__?.frame ?? 0) > 10);
+  // active-play forces the offline solo fallback immediately (no 4s connect
+  // grace) and dismisses the start overlay.
+  await page.evaluate(() => window.__GAME_TEST_HOOKS__?.setState("active-play"));
+  await page.waitForFunction(() => (window.__GAME_DIAGNOSTICS__?.entities ?? 0) > 0);
+
+  const sample = () =>
+    page.evaluate(() => {
+      const d = window.__GAME_DIAGNOSTICS__;
+      if (!d) return null;
+      return {
+        frame: d.frame,
+        score: d.score,
+        x: d.player?.x ?? 0,
+        y: d.player?.y ?? 0,
+        entities: d.entities,
+      };
+    });
+
+  const before = await sample();
+  expect(before, "diagnostics must be published").not.toBeNull();
+  if (!before) return;
+
+  // Hold fire for the whole sweep — pointer.isDown autofires.
+  await page.mouse.move(640, 360);
+  await page.mouse.down();
+
+  let prev = before;
+  let distance = 0;
+  let softlockWindows = 0;
+  let stepOfFirstScore = -1;
+
+  for (const [index, step] of SWEEP.entries()) {
+    await page.mouse.move(step.x, step.y, { steps: 10 });
+    await page.waitForTimeout(step.ms);
+
+    const snap = await sample();
+    if (!snap) continue;
+    const moved = Math.hypot(snap.x - prev.x, snap.y - prev.y);
+    distance += moved;
+    const progressed = snap.score > prev.score;
+    if (progressed && stepOfFirstScore === -1) stepOfFirstScore = index;
+    // Softlock signature: frames advance, the steered ship moves nowhere, and
+    // nothing progresses. (Respawn invulnerability still moves the ship, so a
+    // death mid-sweep doesn't false-positive.)
+    if (snap.frame > prev.frame && moved < 2 && !progressed) softlockWindows += 1;
+    prev = snap;
+  }
+
+  await page.mouse.up();
+
+  const report = {
+    framesAdvanced: prev.frame - before.frame,
+    scoreBefore: before.score,
+    scoreAfter: prev.score,
+    distanceTravelled: Number(distance.toFixed(1)),
+    stepOfFirstScore,
+    softlockWindows,
+    entitiesAtEnd: prev.entities,
+    consoleErrors,
+    pageErrors,
+  };
+  await testInfo.attach("bot-playtest-report", {
+    body: JSON.stringify(report, null, 2),
+    contentType: "application/json",
+  });
+
+  expect(pageErrors).toEqual([]);
+  expect(consoleErrors).toEqual([]);
+  expect(report.framesAdvanced, "game loop must keep running").toBeGreaterThan(100);
+  expect(report.distanceTravelled, "ship must chase the cursor").toBeGreaterThan(500);
+  expect(report.softlockWindows, "held input repeatedly produced nothing").toBeLessThanOrEqual(2);
+  // XP is the run objective: autofiring through a converging wave must score.
+  expect(report.scoreAfter, "sweep should earn XP").toBeGreaterThan(report.scoreBefore);
+});

--- a/games/starfall/package.json
+++ b/games/starfall/package.json
@@ -8,6 +8,7 @@
     "clean": "rm -rf .turbo dist node_modules",
     "dev": "vite",
     "preview": "vite preview",
+    "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "@kyh/tsconfig": "catalog:",
+    "@playwright/test": "^1.61.1",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"

--- a/games/starfall/playwright.config.ts
+++ b/games/starfall/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 90_000,
+  // WebGL games: parallel headless contexts share the software rasterizer and
+  // drift game time from wall time — never raise this (see the playwright
+  // skill's bot-playtest reference).
+  workers: 1,
+  use: { baseURL: "http://localhost:5198" },
+  webServer: {
+    command: "pnpm dev --port 5198 --strictPort",
+    url: "http://localhost:5198",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/games/starfall/src/main.ts
+++ b/games/starfall/src/main.ts
@@ -2,6 +2,15 @@ import Phaser from "phaser";
 
 import { BootScene } from "./scenes/boot-scene";
 import { GameScene } from "./scenes/game-scene";
+import { reseed } from "./shared/rng";
+
+// Bot-playtest seeding (boot-time variant of the diagnostics contract — see
+// shared/diag.ts): the scene is single-start, so the seed must land before
+// any gameplay roll rather than via a mid-run hook.
+const seedParam = new URLSearchParams(location.search).get("seed");
+if (seedParam !== null && seedParam !== "" && Number.isFinite(Number(seedParam))) {
+  reseed(Number(seedParam));
+}
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.WEBGL,

--- a/games/starfall/src/scenes/game-scene.ts
+++ b/games/starfall/src/scenes/game-scene.ts
@@ -910,7 +910,6 @@ export class GameScene extends Phaser.Scene {
 
   override update(time: number, delta: number): void {
     const dt = Math.min(delta, 100) / 1000; // clamp tab-switch spikes
-    this.publishDiag();
     this.starfield.update(dt, time);
     this.barrier.update(time, this.world.playW, this.world.playH);
     if (!this.offline) this.maybeGoOffline();
@@ -922,6 +921,7 @@ export class GameScene extends Phaser.Scene {
       // Connecting (pre-live): no world to tick, but still flush attract's fx.
       this.fx.update(dt, this.time.now);
       this.syncScreenUi(); // camera is static here; keep the vignette pinned
+      this.publishDiag(); // after this frame's work, so bots never read stale state
       return;
     }
     const now = Date.now();
@@ -978,6 +978,7 @@ export class GameScene extends Phaser.Scene {
     this.drawPadOverlay();
     this.syncScreenUi();
     this.updateHud(now);
+    this.publishDiag(); // after this frame's work, so bots never read stale state
   }
 
   /** Resize/rotation: re-read the safe-area insets and re-derive camera zoom. */

--- a/games/starfall/src/scenes/game-scene.ts
+++ b/games/starfall/src/scenes/game-scene.ts
@@ -276,6 +276,8 @@ import {
   type Weapon,
   type WeaponSfx,
 } from "../shared/constants";
+import { diag, installTestHooks } from "../shared/diag";
+import { rand } from "../shared/rng";
 
 /** What a HOMING beam (or ARC hop) is steering toward / hit. */
 type TargetRef =
@@ -759,6 +761,9 @@ export class GameScene extends Phaser.Scene {
   }
 
   create(): void {
+    // Bot-playtest diagnostics contract (shared/diag.ts): telemetry + the
+    // active-play hook. Single-start scene, so once per page load by design.
+    installTestHooks({ activePlay: () => this.forceOfflineSolo() });
     this.bossBarEl = document.getElementById("bossbar");
     this.bossHpEl = document.getElementById("bosshp");
     this.weaponEl = document.getElementById("weapon");
@@ -905,6 +910,7 @@ export class GameScene extends Phaser.Scene {
 
   override update(time: number, delta: number): void {
     const dt = Math.min(delta, 100) / 1000; // clamp tab-switch spikes
+    this.publishDiag();
     this.starfield.update(dt, time);
     this.barrier.update(time, this.world.playW, this.world.playH);
     if (!this.offline) this.maybeGoOffline();
@@ -1018,6 +1024,29 @@ export class GameScene extends Phaser.Scene {
     this.startEl?.classList.add("hide");
     // Drop it only after the fade, so it can't swallow taps on the way out.
     this.time.delayedCall(320, () => this.startEl?.remove());
+  }
+
+  /** Test hook (shared/diag.ts): jump straight into an offline solo run —
+   *  force the fallback that maybeGoOffline would reach after the 4s grace,
+   *  then dismiss the start overlay. Never called during real play. */
+  private forceOfflineSolo(): void {
+    if (!this.offline) {
+      this.offline = true;
+      this.client.destroy();
+      this.ensureSeeded();
+    }
+    this.beginPlay();
+  }
+
+  /** Per-frame diagnostics for bot playtests (shared/diag.ts). One object
+   *  mutated in place; primitives only. */
+  private publishDiag(): void {
+    diag.frame += 1;
+    diag.score = this.xp;
+    diag.player.x = this.shipX;
+    diag.player.y = this.shipY;
+    diag.player.speed = Math.hypot(this.shipVX, this.shipVY);
+    diag.entities = this.world.enemies.length + this.world.asteroids.length;
   }
 
   /** Wrapper pause → dock my ship out of the arena as a spectator. No death
@@ -1430,7 +1459,7 @@ export class GameScene extends Phaser.Scene {
     const n = weapon.pellets;
     for (let i = 0; i < n; i++) {
       const spread = n > 1 ? -weapon.spreadDeg / 2 + (weapon.spreadDeg * i) / (n - 1) : 0;
-      const jitter = (Math.random() * 2 - 1) * weapon.jitterDeg;
+      const jitter = (rand() * 2 - 1) * weapon.jitterDeg;
       const angle = aimAngle + (spread + jitter) * DEG;
       this.beams.push(this.makeBeam(origin, angle, weapon, now));
     }
@@ -3475,13 +3504,13 @@ export class GameScene extends Phaser.Scene {
 
     // UFO is the weapon piñata; the v2 gate relaxes to < 2 weapon items live.
     const weaponItemsInFlight = w.items.filter((it) => it.kind === "weapon").length;
-    if (!w.ufo && weaponItemsInFlight < 2 && Math.random() < UFO_SPAWN_RATE * dt) {
+    if (!w.ufo && weaponItemsInFlight < 2 && rand() < UFO_SPAWN_RATE * dt) {
       w.ufo = spawnUfoState(w.playW, w.playH);
       d.ufo = true;
     }
     if (w.ufo && w.ufo.x === w.ufo.destX && w.ufo.y === w.ufo.destY) {
-      w.ufo.destX = Math.random() * w.playW;
-      w.ufo.destY = Math.random() * w.playH;
+      w.ufo.destX = rand() * w.playW;
+      w.ufo.destY = rand() * w.playH;
       d.ufo = true;
     }
 
@@ -3704,8 +3733,8 @@ export class GameScene extends Phaser.Scene {
         nextBurstShotAt: 0,
         lancerPhase: "cruise",
         phaseUntil: 0,
-        orbitDir: Math.random() < 0.5 ? 1 : -1,
-        wobblePhase: Math.random() * Math.PI * 2,
+        orbitDir: rand() < 0.5 ? 1 : -1,
+        wobblePhase: rand() * Math.PI * 2,
         kbVx: 0,
         kbVy: 0,
         broodCount: 0,
@@ -4025,7 +4054,7 @@ export class GameScene extends Phaser.Scene {
       const ratio = newRadius / a.radius;
       a.verts = a.verts.map((v) => ({ x: v.x * ratio, y: v.y * ratio }));
       a.radius = newRadius;
-      const ang = Math.atan2(a.vy, a.vx) + (Math.random() * 60 - 30) * DEG;
+      const ang = Math.atan2(a.vy, a.vx) + (rand() * 60 - 30) * DEG;
       const speed = asteroidSpeed(newRadius);
       a.vx = Math.cos(ang) * speed;
       a.vy = Math.sin(ang) * speed;
@@ -4163,7 +4192,7 @@ export class GameScene extends Phaser.Scene {
     const w = this.world;
     const psim = this.simFor(parent.id);
     for (let i = 0; i < n; i++) {
-      const ang = parent.angle + (Math.PI * 2 * i) / Math.max(1, n) + Math.random() * 0.4;
+      const ang = parent.angle + (Math.PI * 2 * i) / Math.max(1, n) + rand() * 0.4;
       const m = spawnEnemyState(
         "drone",
         parent.x + Math.cos(ang) * 18,
@@ -4286,7 +4315,7 @@ export class GameScene extends Phaser.Scene {
       this.hostSpawnShards(
         e.x,
         e.y,
-        FODDER_SHARD_MIN + Math.floor(Math.random() * (FODDER_SHARD_MAX - FODDER_SHARD_MIN + 1)),
+        FODDER_SHARD_MIN + Math.floor(rand() * (FODDER_SHARD_MAX - FODDER_SHARD_MIN + 1)),
       );
       this.hostRollLoot(e.x, e.y, FODDER_DROP_CHANCE, true);
     } else {
@@ -4331,7 +4360,7 @@ export class GameScene extends Phaser.Scene {
       else if (this.lootPity.booster >= LOOT_PITY.booster) cls = "booster";
       else if (this.lootPity.weapon >= LOOT_PITY.weapon) cls = "weapon";
     }
-    if (!cls && Math.random() >= chance) {
+    if (!cls && rand() >= chance) {
       bumpAll();
       return;
     }
@@ -4354,7 +4383,7 @@ export class GameScene extends Phaser.Scene {
         boosterIdx: BOOSTER_KINDS.indexOf(rollWeightedKey(LOOT_BOOSTER_WEIGHTS)),
       };
     } else {
-      drop = { kind: "weapon", weaponIdx: Math.floor(Math.random() * WEAPONS_SPECIAL.length) };
+      drop = { kind: "weapon", weaponIdx: Math.floor(rand() * WEAPONS_SPECIAL.length) };
     }
     w.items.push(spawnItemState(x, y, drop));
     this.dirty.items = true;
@@ -6219,7 +6248,7 @@ function weightedEnemyRoll(kinds: ReadonlyArray<EnemyKind>, intensity: number): 
   let total = 0;
   for (const k of kinds) total += enemySpawnWeight(k, intensity);
   if (total <= 0) return null;
-  let roll = Math.random() * total;
+  let roll = rand() * total;
   for (const k of kinds) {
     roll -= enemySpawnWeight(k, intensity);
     if (roll <= 0) return k;

--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -1,3 +1,5 @@
+import { rand } from "./rng";
+
 // ---- world -------------------------------------------------------------------
 
 // WORLD_W/H is the fixed VISUAL/MAX extent — the starfield + off-world mask are
@@ -1121,7 +1123,7 @@ export const ITEMS_MAX_LIVE = 6;
 /** Roll the class split (always lands on a class; the chance gate is upstream). */
 export function rollLootClass(): LootClass {
   const total = LOOT_CLASS_WEIGHTS.reduce((sum, e) => sum + e.weight, 0);
-  let roll = Math.random() * total;
+  let roll = rand() * total;
   for (const e of LOOT_CLASS_WEIGHTS) {
     roll -= e.weight;
     if (roll <= 0) return e.cls;
@@ -1132,7 +1134,7 @@ export function rollLootClass(): LootClass {
 /** Roll a child table of [key, integer weight] entries. */
 export function rollWeightedKey<K extends string>(entries: ReadonlyArray<readonly [K, number]>): K {
   const total = entries.reduce((sum, [, w]) => sum + w, 0);
-  let roll = Math.random() * total;
+  let roll = rand() * total;
   for (const [key, w] of entries) {
     roll -= w;
     if (roll <= 0) return key;
@@ -1559,15 +1561,15 @@ export function randomWorldPoint(
   h = BASE_WORLD_H,
 ): Vec {
   return {
-    x: margin + Math.random() * (w - margin * 2),
-    y: margin + Math.random() * (h - margin * 2),
+    x: margin + rand() * (w - margin * 2),
+    y: margin + rand() * (h - margin * 2),
   };
 }
 
 export function makeAsteroidVerts(radius: number): Vec[] {
   const verts: Vec[] = [];
   for (let i = 0; i < ASTEROID_VERTEX_COUNT; i++) {
-    const r = radius * (0.5 + Math.random() * 0.5);
+    const r = radius * (0.5 + rand() * 0.5);
     const a = (Math.PI * 2 * i) / ASTEROID_VERTEX_COUNT;
     verts.push({ x: Math.cos(a) * r, y: Math.sin(a) * r });
   }
@@ -1580,15 +1582,15 @@ export function edgeSpawn(
   w = BASE_WORLD_W,
   h = BASE_WORLD_H,
 ): { x: number; y: number; ang: number } {
-  const side = Math.floor(Math.random() * 4);
-  const spread = Math.random() * (Math.PI / 2); // 90° fan, aimed inward below
+  const side = Math.floor(rand() * 4);
+  const spread = rand() * (Math.PI / 2); // 90° fan, aimed inward below
   if (side <= 1) {
-    const y = -margin + Math.random() * (h + margin * 2);
+    const y = -margin + rand() * (h + margin * 2);
     const x = side === 0 ? -margin : w + margin;
     const ang = side === 0 ? spread - Math.PI * 0.25 : spread + Math.PI * 0.75;
     return { x, y, ang };
   }
-  const x = -margin + Math.random() * (w + margin * 2);
+  const x = -margin + rand() * (w + margin * 2);
   const y = side === 2 ? -margin : h + margin;
   const ang = side === 2 ? spread + Math.PI * 0.25 : spread - Math.PI * 0.75;
   return { x, y, ang };
@@ -1596,7 +1598,7 @@ export function edgeSpawn(
 
 export function spawnAsteroidState(w = BASE_WORLD_W, h = BASE_WORLD_H): AsteroidState {
   const { x, y, ang } = edgeSpawn(ASTEROID_MAX_RADIUS, w, h);
-  const radius = ASTEROID_MIN_RADIUS + Math.random() * (ASTEROID_MAX_RADIUS - ASTEROID_MIN_RADIUS);
+  const radius = ASTEROID_MIN_RADIUS + rand() * (ASTEROID_MAX_RADIUS - ASTEROID_MIN_RADIUS);
   const speed = asteroidSpeed(radius);
   return {
     id: crypto.randomUUID(),
@@ -1616,8 +1618,8 @@ export function spawnUfoState(w = BASE_WORLD_W, h = BASE_WORLD_H): UfoState {
     id: crypto.randomUUID(),
     x,
     y,
-    destX: Math.random() * w,
-    destY: Math.random() * h,
+    destX: rand() * w,
+    destY: rand() * h,
     hp: UFO_HP,
     blinkUntil: 0,
   };
@@ -1625,7 +1627,7 @@ export function spawnUfoState(w = BASE_WORLD_W, h = BASE_WORLD_H): UfoState {
 
 /** Generic item factory — every drop class ships through here. */
 export function spawnItemState(x: number, y: number, drop: ItemDrop): ItemState {
-  const ang = Math.random() * Math.PI * 2;
+  const ang = rand() * Math.PI * 2;
   return {
     id: crypto.randomUUID(),
     x,
@@ -1640,8 +1642,8 @@ export function spawnItemState(x: number, y: number, drop: ItemDrop): ItemState 
 /** Score shard at (x,y) with a small position scatter + slow random drift,
  *  so a multi-shard drop fans out instead of stacking into one sprite. */
 export function spawnShardState(x: number, y: number): ShardState {
-  const ang = Math.random() * Math.PI * 2;
-  const scatter = Math.random() * 10;
+  const ang = rand() * Math.PI * 2;
+  const scatter = rand() * 10;
   return {
     id: crypto.randomUUID(),
     x: x + Math.cos(ang) * scatter,
@@ -1655,7 +1657,7 @@ export function spawnShardState(x: number, y: number): ShardState {
 export function spawnWeaponItemState(x: number, y: number): ItemState {
   return spawnItemState(x, y, {
     kind: "weapon",
-    weaponIdx: Math.floor(Math.random() * WEAPONS_SPECIAL.length),
+    weaponIdx: Math.floor(rand() * WEAPONS_SPECIAL.length),
   });
 }
 

--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -1569,7 +1569,9 @@ export function randomWorldPoint(
 export function makeAsteroidVerts(radius: number): Vec[] {
   const verts: Vec[] = [];
   for (let i = 0; i < ASTEROID_VERTEX_COUNT; i++) {
-    const r = radius * (0.5 + rand() * 0.5);
+    // Outline jitter is draw-only (collision is radius-based) — keep it on
+    // Math.random so art tweaks can't shift seeded gameplay streams.
+    const r = radius * (0.5 + Math.random() * 0.5);
     const a = (Math.PI * 2 * i) / ASTEROID_VERTEX_COUNT;
     verts.push({ x: Math.cos(a) * r, y: Math.sin(a) * r });
   }

--- a/games/starfall/src/shared/diag.ts
+++ b/games/starfall/src/shared/diag.ts
@@ -1,0 +1,51 @@
+// Bot-playtest diagnostics contract (see the playwright skill's
+// references/bot-playtest.md and the lunerfall reference implementation):
+// __GAME_DIAGNOSTICS__ is read-only per-frame telemetry, __GAME_TEST_HOOKS__
+// are the mutations a test may perform. Always exposed, like the existing
+// __game probe — JSON-serializable primitives only, one object mutated in
+// place (no per-frame allocation).
+//
+// Starfall-specific hook shape:
+// - No `seed(n)` hook: GameScene is single-start by design (create() fields
+//   assume one boot per page load), so an honest mid-run reseed+restart isn't
+//   possible. Seeding uses the contract's boot-time alternative instead — a
+//   `?seed=N` query param read in main.ts before the game constructs.
+// - No `setPausedForScreenshot`: the sim is Date.now-driven and shared, so
+//   freezing the loop is forbidden (a wake would teleport every entity).
+// - `setState('active-play')` forces the offline solo fallback immediately
+//   (instead of waiting out the 4s connect grace) and dismisses the start
+//   overlay. Online play is untouched: the hook only ever runs when a test
+//   calls it.
+
+export type Diagnostics = {
+  frame: number;
+  /** Run XP — the objective metric (kills award XP; levels derive from it). */
+  score: number;
+  /** Always false: starfall is endless (death respawns, a run never "ends"). */
+  complete: boolean;
+  player: { x: number; y: number; speed: number };
+  /** Live hostiles: enemies + asteroids in the local world. */
+  entities: number;
+};
+
+export const diag: Diagnostics = {
+  frame: 0,
+  score: 0,
+  complete: false,
+  player: { x: 0, y: 0, speed: 0 },
+  entities: 0,
+};
+
+export type TestHooks = {
+  setState(name: string): void;
+};
+
+export function installTestHooks(hooks: { activePlay(): void }): void {
+  Reflect.set(globalThis, "__GAME_DIAGNOSTICS__", diag);
+  const testHooks: TestHooks = {
+    setState(name: string): void {
+      if (name === "active-play") hooks.activePlay();
+    },
+  };
+  Reflect.set(globalThis, "__GAME_TEST_HOOKS__", testHooks);
+}

--- a/games/starfall/src/shared/rng.ts
+++ b/games/starfall/src/shared/rng.ts
@@ -1,0 +1,31 @@
+// Central gameplay RNG (mirrors games/lunerfall/src/sys/rng.ts). Unseeded it
+// behaves like Math.random; `reseed(n)` swaps in a deterministic mulberry32
+// stream so a solo run's local rolls (enemy/asteroid spawns, loot classes,
+// weapon drops, shot jitter) replay from one seed — which is what makes bot
+// playtests and bug repros reproducible.
+//
+// Determinism boundary: only LOCALLY rolled gameplay randomness routes through
+// `rand()`. Online, world rolls happen on whichever peer is host and travel
+// over the wire — seeding cannot (and must not) reach across the network.
+// View-only jitter (fx particles, fizzle bolts, debris, tint lerps) stays on
+// Math.random so cosmetic rolls never perturb the gameplay stream.
+
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+let next: () => number = Math.random;
+
+/** Uniform [0, 1) from the current gameplay stream. */
+export const rand = (): number => next();
+
+/** Seed the gameplay stream. All rand() calls after this are deterministic. */
+export function reseed(seed: number): void {
+  next = mulberry32(seed);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ catalogs:
       version: 4.110.0
     zod:
       specifier: ^4.4.3
-      version: 4.4.3
+      version: 3.25.76
 
 overrides:
   react-hook-form: ^7.72.1
@@ -260,7 +260,7 @@ importers:
         version: 11.18.0(@tanstack/react-query@5.101.2(react@19.2.7))(@trpc/client@11.18.0(@trpc/server@11.18.0(typescript@7.0.2))(typescript@7.0.2))(@trpc/server@11.18.0(typescript@7.0.2))(react@19.2.7)(typescript@7.0.2)
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(95fb2c648e722677cc2b3a3bc3f005f4)
+        version: 1.6.23(478363b50960934426661c20f40f6199)
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
@@ -638,6 +638,9 @@ importers:
       '@kyh/tsconfig':
         specifier: 'catalog:'
         version: 1.1.14
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -701,7 +704,7 @@ importers:
         version: 1.0.20
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(95fb2c648e722677cc2b3a3bc3f005f4)
+        version: 1.6.23(478363b50960934426661c20f40f6199)
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
@@ -8222,7 +8225,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(95fb2c648e722677cc2b3a3bc3f005f4)
+      better-auth: 1.6.23(478363b50960934426661c20f40f6199)
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -8252,7 +8255,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.23(95fb2c648e722677cc2b3a3bc3f005f4)
+      better-auth: 1.6.23(478363b50960934426661c20f40f6199)
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -10848,7 +10851,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
-  better-auth@1.6.23(95fb2c648e722677cc2b3a3bc3f005f4):
+  better-auth@1.6.23(478363b50960934426661c20f40f6199):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260708.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2))(typescript@7.0.2))(kysely@0.29.3)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2))(sql.js@1.14.1))


### PR DESCRIPTION
Second adopter of the bot-playtest contract (`plugins/tooling/skills/playwright/references/bot-playtest.md`), mirroring the lunerfall reference (#234). Local-only per request — no CI wiring.

## What's exposed
- `window.__GAME_DIAGNOSTICS__` — per-frame: frame, score (run XP), player x/y/speed, entities (enemies + asteroids). Published from `GameScene.update` via one mutated object (`src/shared/diag.ts`).
- `window.__GAME_TEST_HOOKS__.setState('active-play')` — forces the offline solo fallback immediately (skips the 4s connect grace) and dismisses the start overlay (keyup-dismiss preserved for real players).
- Seeding rides `?seed=N` read at boot in `main.ts` — the contract's boot-time alternative, because `GameScene` is single-start by design (create() fields assume one boot per page load), so an honest mid-run `seed()` hook isn't possible. `setPausedForScreenshot` omitted: the sim is Date.now-driven; freezing is forbidden.

## Determinism boundary
`src/shared/rng.ts` (mulberry32; unseeded = Math.random) now feeds every locally rolled gameplay decision: enemy/asteroid/UFO spawns, loot class + weapon rolls, shard counts, split/brood angles, shot jitter. Visual jitter (fx, fizzle bolts, debris, tint lerps) and anything a remote host rolls over the wire stay on Math.random. Roll consumption order is frame-timing dependent, so seeded replays are statistically stable rather than frame-identical — same boundary as lunerfall.

## Measured (seed 12345, headless, 2 consecutive green runs)
```json
{ "framesAdvanced": 924, "scoreBefore": 0, "scoreAfter": 20,
  "distanceTravelled": 3940.8, "stepOfFirstScore": 1,
  "softlockWindows": 0, "entitiesAtEnd": 15,
  "consoleErrors": [], "pageErrors": [] }
```

## Verified
- `pnpm test:e2e` green twice (26.9s / 27.7s)
- `tsc --noEmit` clean; oxlint exit 0 (only the repo's pre-existing underscore-global warnings)
- Normal boot untouched: overlay visible, `press any key to start`, no auto-start, diag ticking, zero page errors (headless load check)
- Online path untouched: hook-only offline forcing; connect/reconnect logic unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted the bot-playtest diagnostics contract for Starfall to enable deterministic, scriptable progression tests. Adds seedable gameplay RNG, end-of-frame diagnostics, and a Playwright bot test; local-only with no CI wiring.

- **New Features**
  - Expose `window.__GAME_DIAGNOSTICS__` (frame, score, player x/y/speed, entities).
  - Add `window.__GAME_TEST_HOOKS__.setState('active-play')` to jump into offline solo and dismiss the start overlay.
  - Seedable gameplay RNG via mulberry32 `rand()` with boot-time `?seed=N`; local gameplay rolls use `rand()` while visual-only jitter and networked host rolls stay on `Math.random`.
  - Add Playwright bot playtest that drives a mouse sweep and asserts progression; single-worker config and `pnpm test:e2e`. Normal boot and online flow unchanged.

- **Bug Fixes**
  - Publish diagnostics at the end of each frame to avoid stale reads in tests.
  - Keep asteroid outline jitter on `Math.random` so art noise does not perturb the seeded gameplay stream.

<sup>Written for commit f54aa5e0b8b3a3bb0798cb7be423326e9cf83ba2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

