### PR TITLE
starfall: pausable sim clock — real offline freeze + pause test hook

### DIFF
--- a/docs/games/shared-lib-proposals.md
+++ b/docs/games/shared-lib-proposals.md
@@ -76,6 +76,18 @@ Renderer + resize + loop + fatal-panel + dev-hook. Two engine shapes (subpath
 exports), loop injects `render(dt,rawDt)` so dither passes / perf governors / composers
 still fit. Lowest priority (most coupling). Constants stay per-game.
 
+### 8. `@vibedgames/game-clock` — pausable sim clock  ·  effort S · risk low
+Offset-based `now()/pauseClock()/resumeClock()`: wall time minus every ms spent
+paused, frozen while paused, seamless on resume (stored deadlines hold — no
+mass-detonation/teleport on wake). 2 byte-identical field-tested copies:
+bomberman `src/util/clock.ts` (pattern donor, "real pause" work) and starfall
+`src/shared/clock.ts` (2026-07-09, enables offline freeze + the
+`setPausedForScreenshot` test hook). **Contract:** only SIM timestamps read
+`now()`; net heartbeats/connection deadlines stay on raw `Date.now()`
+(pausing must not break reconnect), and pause is only honored offline/solo —
+freezing a shared online world stalls the other players. Engine-free, DOM-safe,
+zero-alloc. Extraction is a mechanical de-dupe.
+
 ---
 
 ## B. In-repo consistency alignment still to do (no package; do before extraction)

--- a/games/starfall/e2e/bot-playtest.spec.ts
+++ b/games/starfall/e2e/bot-playtest.spec.ts
@@ -26,6 +26,7 @@ type Diagnostics = {
 
 type TestHooks = {
   setState(name: string): void;
+  setPausedForScreenshot(paused: boolean): void;
 };
 
 declare global {
@@ -131,4 +132,55 @@ test("bot playtest: mouse sweep progresses a seeded offline solo arena", async (
   expect(report.softlockWindows, "held input repeatedly produced nothing").toBeLessThanOrEqual(2);
   // XP is the run objective: autofiring through a converging wave must score.
   expect(report.scoreAfter, "sweep should earn XP").toBeGreaterThan(report.scoreBefore);
+});
+
+// Offline-only real freeze (shared/clock.ts): the sim clock and the render loop
+// both stop, so the frame counter halts, positions hold, and — because every
+// stored deadline (boosts, fuses, respawns) is measured against the paused
+// clock — nothing detonates or teleports when the loop wakes.
+test("pause hook freezes the sim and resumes without a jump", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (e) => pageErrors.push(e.message));
+
+  await page.goto("/?seed=12345");
+  await page.waitForFunction(() => (window.__GAME_DIAGNOSTICS__?.frame ?? 0) > 10);
+  await page.evaluate(() => window.__GAME_TEST_HOOKS__?.setState("active-play"));
+  await page.waitForFunction(() => (window.__GAME_DIAGNOSTICS__?.entities ?? 0) > 0);
+  // Let the ship pick up some velocity toward the cursor before freezing.
+  await page.mouse.move(1150, 360);
+  await page.mouse.down();
+  await page.waitForTimeout(1200);
+
+  const grab = () =>
+    page.evaluate(() => {
+      const d = window.__GAME_DIAGNOSTICS__;
+      if (!d) return null;
+      return { frame: d.frame, x: d.player?.x ?? 0, y: d.player?.y ?? 0 };
+    });
+
+  await page.evaluate(() => window.__GAME_TEST_HOOKS__?.setPausedForScreenshot(true));
+  const atPause = await grab();
+  expect(atPause, "diagnostics must be published").not.toBeNull();
+  if (!atPause) return;
+  await page.waitForTimeout(1500); // a real pause span, so drift would show
+  const stillPaused = await grab();
+  expect(stillPaused, "diagnostics must survive the pause").not.toBeNull();
+  if (!stillPaused) return;
+  expect(stillPaused.frame, "frame counter must halt while paused").toBe(atPause.frame);
+  expect(stillPaused.x, "position must hold while paused").toBe(atPause.x);
+  expect(stillPaused.y, "position must hold while paused").toBe(atPause.y);
+
+  await page.evaluate(() => window.__GAME_TEST_HOOKS__?.setPausedForScreenshot(false));
+  // First frames after wake: motion continues from where it stopped. The ship's
+  // top speed is a few hundred px/s, so a short window bounds the legal delta —
+  // a stored-deadline blowup or dt spike would fling it much farther.
+  await page.waitForTimeout(250);
+  const afterResume = await grab();
+  expect(afterResume, "diagnostics must resume").not.toBeNull();
+  if (!afterResume) return;
+  await page.mouse.up();
+  expect(afterResume.frame, "loop must advance after resume").toBeGreaterThan(stillPaused.frame);
+  const jump = Math.hypot(afterResume.x - stillPaused.x, afterResume.y - stillPaused.y);
+  expect(jump, "resume must continue smoothly, not teleport").toBeLessThan(300);
+  expect(pageErrors).toEqual([]);
 });

--- a/games/starfall/src/scenes/game-scene.ts
+++ b/games/starfall/src/scenes/game-scene.ts
@@ -276,6 +276,7 @@ import {
   type Weapon,
   type WeaponSfx,
 } from "../shared/constants";
+import { now as simNow, pauseClock, resumeClock } from "../shared/clock";
 import { diag, installTestHooks } from "../shared/diag";
 import { rand } from "../shared/rng";
 
@@ -463,7 +464,7 @@ function emptyShared(): SharedState {
     enemyShots: [],
     shards: [],
     pulls: [],
-    arenaEpoch: Date.now(),
+    arenaEpoch: simNow(),
     playW: BASE_WORLD_W,
     playH: BASE_WORLD_H,
   };
@@ -595,6 +596,8 @@ export class GameScene extends Phaser.Scene {
   private maybeGoOffline(): void {
     // Start the grace window on the first tick, not at create(): counting
     // asset-load time would wrongly drop a slow-booting client to solo.
+    // Real wall clock, NOT the pausable sim clock — connection deadlines must
+    // keep counting through a pause (same contract as the clock module doc).
     if (this.bootedAt === 0) this.bootedAt = Date.now();
     if (this.client.connectionStatus === "connected") {
       this.everConnected = true;
@@ -763,7 +766,11 @@ export class GameScene extends Phaser.Scene {
   create(): void {
     // Bot-playtest diagnostics contract (shared/diag.ts): telemetry + the
     // active-play hook. Single-start scene, so once per page load by design.
-    installTestHooks({ activePlay: () => this.forceOfflineSolo() });
+    // setPaused rides the same offline-only freeze as the wrapper pause.
+    installTestHooks({
+      activePlay: () => this.forceOfflineSolo(),
+      setPaused: (paused) => (paused ? this.freezeSim() : this.unfreezeSim()),
+    });
     this.bossBarEl = document.getElementById("bossbar");
     this.bossHpEl = document.getElementById("bosshp");
     this.weaponEl = document.getElementById("weapon");
@@ -885,12 +892,15 @@ export class GameScene extends Phaser.Scene {
       enemyHull: (kind) => enemyHullPoints(kind),
     });
 
-    // Pause = the wrapper wants its chrome back. Freezing this sim is forbidden
-    // (Date.now-driven + shared online world), so we pause AS A SPECTATOR: dock
-    // my ship out of the arena, then re-enter through the respawn flow.
+    // Pause = the wrapper wants its chrome back. Online, freezing the shared
+    // world would stall the other players, so we pause AS A SPECTATOR: dock my
+    // ship out of the arena, then re-enter through the respawn flow. Offline
+    // (solo world, no one else to stall) we truly FREEZE: the pausable sim
+    // clock (shared/clock.ts) holds every stored deadline, so a boost with 3s
+    // left before the pause still has 3s after resume.
     setPauseHandlers({
-      onPause: () => this.pauseToSpectator(),
-      onResume: () => this.resumeFromSpectator(),
+      onPause: () => (this.offline ? this.freezeSim() : this.pauseToSpectator()),
+      onResume: () => (this.frozen ? this.unfreezeSim() : this.resumeFromSpectator()),
     });
 
     this.scale.on(Phaser.Scale.Events.RESIZE, this.onViewportChange, this);
@@ -924,7 +934,7 @@ export class GameScene extends Phaser.Scene {
       this.publishDiag(); // after this frame's work, so bots never read stale state
       return;
     }
-    const now = Date.now();
+    const now = simNow();
     // Parse every peer's net state once for this frame; readers below (aim,
     // mines, PvP, host sim, render, minimap) all pull from the map.
     this.peerStates.clear();
@@ -1050,10 +1060,31 @@ export class GameScene extends Phaser.Scene {
     diag.entities = this.world.enemies.length + this.world.asteroids.length;
   }
 
-  /** Wrapper pause → dock my ship out of the arena as a spectator. No death
-   *  penalty, no XP loss, no death explosion: my net state simply advertises
-   *  absence (present: false) so remotes drop me the way a disconnect would.
-   *  Freezing the sim is forbidden (Date.now-driven + shared world), so the
+  /** Offline-only REAL freeze: stop the sim clock (every stored deadline
+   *  holds), sleep the render loop, suspend audio. Never online — the shared
+   *  world would stall for the other players (they get the spectator path). */
+  private frozen = false;
+
+  private freezeSim(): void {
+    if (this.frozen || !this.offline) return;
+    this.frozen = true;
+    pauseClock();
+    sfx.setSuspended(true);
+    this.game.loop.sleep(); // stops update() until wake()
+  }
+
+  private unfreezeSim(): void {
+    if (!this.frozen) return;
+    this.frozen = false;
+    resumeClock();
+    sfx.setSuspended(false);
+    this.game.loop.wake();
+  }
+
+  /** Wrapper pause (online) → dock my ship out of the arena as a spectator. No
+   *  death penalty, no XP loss, no death explosion: my net state simply
+   *  advertises absence (present: false) so remotes drop me the way a
+   *  disconnect would. Freezing the shared online world is forbidden, so the
    *  arena keeps running behind the wrapper overlay. */
   private pauseToSpectator(): void {
     if (this.paused) return;
@@ -1069,7 +1100,7 @@ export class GameScene extends Phaser.Scene {
     this.streak = 0;
     this.comboTier = 1;
     // Immediate, so remotes drop my ship without a snapshot of lag.
-    if (this.started && this.myId) this.pushMyState(Date.now());
+    if (this.started && this.myId) this.pushMyState(simNow());
     sfx.setSuspended(true);
   }
 
@@ -1085,7 +1116,7 @@ export class GameScene extends Phaser.Scene {
     // me once, with invuln — never a double ship.
     this.spawned = true;
     this.alive = false;
-    this.respawnAt = Date.now();
+    this.respawnAt = simNow();
   }
 
   private ensureSpawned(): void {
@@ -1096,7 +1127,7 @@ export class GameScene extends Phaser.Scene {
     this.spawned = true;
     this.cameras.main.centerOn(pos.x, pos.y);
     this.spawnInFx(pos.x, pos.y);
-    this.pushMyState(Date.now());
+    this.pushMyState(simNow());
   }
 
   private tickRespawn(now: number): void {
@@ -1469,7 +1500,7 @@ export class GameScene extends Phaser.Scene {
   /** TWIN orbit phase — derived from the wall clock with the exact formula
    *  remotes use, so the owner's drone and every remote render agree. */
   private twinAngle(): number {
-    return (Date.now() / 1000) * TWIN_ORBIT_DEG_PER_S * DEG;
+    return (simNow() / 1000) * TWIN_ORBIT_DEG_PER_S * DEG;
   }
 
   /** TWIN drone position while the booster is live, else null. */
@@ -1491,7 +1522,7 @@ export class GameScene extends Phaser.Scene {
     if (!spec) return;
     const launch = (): void => {
       if (!this.alive || !this.spawned) return;
-      const t = Date.now();
+      const t = simNow();
       const nose = {
         x: this.shipX + Math.cos(this.shipAngle) * SHIP_RADIUS,
         y: this.shipY + Math.sin(this.shipAngle) * SHIP_RADIUS,
@@ -2608,7 +2639,7 @@ export class GameScene extends Phaser.Scene {
   private consumeShot(shot: EnemyShotState): void {
     const idx = this.world.enemyShots.findIndex((s) => s.id === shot.id);
     if (idx !== -1) this.world.enemyShots.splice(idx, 1);
-    this.recentConsumedShots.set(shot.id, Date.now());
+    this.recentConsumedShots.set(shot.id, simNow());
     if (this.amHost) this.dirty.enemyShots = true;
     this.netSendEvent("proj_consumed", { shotId: shot.id });
   }
@@ -3182,7 +3213,7 @@ export class GameScene extends Phaser.Scene {
     if (event === "player_killed") {
       // The killer awards itself: every client hears the victim's report.
       if (p && p["killerId"] === this.myId) {
-        this.registerKill(XP.PLAYER_KILL, Date.now(), "player");
+        this.registerKill(XP.PLAYER_KILL, simNow(), "player");
       }
       return;
     }
@@ -3675,7 +3706,7 @@ export class GameScene extends Phaser.Scene {
   /** Living player positions (mine locally + remotes from net state). */
   private livingPlayers(): Vec[] {
     const out: Vec[] = [];
-    if (this.alive && this.spawned && Date.now() >= this.phasedUntil) {
+    if (this.alive && this.spawned && simNow() >= this.phasedUntil) {
       out.push({ x: this.shipX, y: this.shipY });
     }
     const myId = this.myId;
@@ -4067,7 +4098,7 @@ export class GameScene extends Phaser.Scene {
     const u = this.world.ufo;
     if (!u) return;
     u.hp -= damage * 100;
-    u.blinkUntil = Date.now() + UFO_BLINK_MS;
+    u.blinkUntil = simNow() + UFO_BLINK_MS;
     if (u.hp <= 0) {
       this.world.items.push(spawnWeaponItemState(u.x, u.y));
       this.world.ufo = null;
@@ -4265,7 +4296,7 @@ export class GameScene extends Phaser.Scene {
       sim.kbVx += kx;
       sim.kbVy += ky;
     }
-    e.blinkUntil = Date.now() + UFO_BLINK_MS;
+    e.blinkUntil = simNow() + UFO_BLINK_MS;
     if (e.hp <= 0) this.hostKillEnemy(idx);
     this.dirty.enemies = true;
   }
@@ -4282,7 +4313,7 @@ export class GameScene extends Phaser.Scene {
     }
     w.enemies.splice(idx, 1);
     this.enemySim.delete(e.id);
-    const now = Date.now();
+    const now = simNow();
     if (e.kind === "dreadnought") {
       // Marquee reward: an XP fountain (2 bursts to dodge the live-shard cap) +
       // two guaranteed drops. Free the arena-wide slot + arm the cooldown.
@@ -5603,7 +5634,7 @@ export class GameScene extends Phaser.Scene {
         const lowered = raw.toLowerCase();
         const kind = SHIELD_MOD_KINDS.find((k) => k === lowered);
         if (!kind) return;
-        const now = Date.now();
+        const now = simNow();
         this.shieldMod = kind;
         this.shieldModUntil = now + SHIELD_MOD_DURATION_MS;
         this.overHp = kind === "overshield" ? OVERSHIELD_BONUS : 0;
@@ -5617,13 +5648,13 @@ export class GameScene extends Phaser.Scene {
           this.shieldHp = Math.max(this.shieldHp, SHIELD_MAX);
           this.lastDamageAt = 0;
         } else {
-          this.boosts.set(kind, Date.now() + BOOSTER_SPECS[kind].durationMs);
+          this.boosts.set(kind, simNow() + BOOSTER_SPECS[kind].durationMs);
         }
       },
       /** Set the base shield directly; stamps the damage clock so regen
        *  behaves as after a real drain. 0 = death (via the real pipeline). */
       setShield: (hp: number): void => {
-        const now = Date.now();
+        const now = simNow();
         this.shieldHp = Math.min(SIPHON_OVERHEAL_MAX, hp);
         this.lastDamageAt = now;
         this.regenActive = false;
@@ -5631,7 +5662,7 @@ export class GameScene extends Phaser.Scene {
       },
       /** Run a drain through the real applyDamage pipeline. */
       damage: (amount: number): string =>
-        this.applyDamage(amount, this.shipX + 12, this.shipY, "DEV", null, Date.now()),
+        this.applyDamage(amount, this.shipX + 12, this.shipY, "DEV", null, simNow()),
       grantWeapon: (ref: number | string): void => {
         const weapon =
           typeof ref === "number"
@@ -5640,7 +5671,7 @@ export class GameScene extends Phaser.Scene {
         if (!weapon) return;
         this.specialBase = weapon;
         this.weapon = scaleWeaponForLevel(weapon, this.level);
-        this.weaponUntil = Date.now() + SPECIAL_WEAPON_DURATION_MS;
+        this.weaponUntil = simNow() + SPECIAL_WEAPON_DURATION_MS;
         this.windupAcc = 0;
       },
       /** Host only: drop a live item at (x,y) (defaults to the ship, so it gets
@@ -5669,7 +5700,7 @@ export class GameScene extends Phaser.Scene {
       },
       /** Fire one volley of the current weapon, no pointer needed. */
       fire: (): void => {
-        this.fireWeapon(Date.now());
+        this.fireWeapon(simNow());
       },
       /** Host only: rewind/forward the intensity director. */
       setArenaEpoch: (epochMs: number): void => {
@@ -5678,7 +5709,7 @@ export class GameScene extends Phaser.Scene {
         if (!this.offline) this.client.updateSharedState({ arenaEpoch: epochMs });
       },
       intensity: (): number =>
-        arenaIntensity(Math.max(0, (Date.now() - this.world.arenaEpoch) / 1000)),
+        arenaIntensity(Math.max(0, (simNow() - this.world.arenaEpoch) / 1000)),
       summary: (): Record<string, unknown> => ({
         alive: this.alive,
         level: this.level,
@@ -5703,7 +5734,7 @@ export class GameScene extends Phaser.Scene {
         shards: this.world.shards.length,
         beams: this.beams.length,
         isHost: this.amHost,
-        intensity: arenaIntensity(Math.max(0, (Date.now() - this.world.arenaEpoch) / 1000)),
+        intensity: arenaIntensity(Math.max(0, (simNow() - this.world.arenaEpoch) / 1000)),
       }),
     };
   }

--- a/games/starfall/src/shared/clock.ts
+++ b/games/starfall/src/shared/clock.ts
@@ -1,0 +1,35 @@
+// Pausable wall clock for the sim.
+//
+// Bomb fuses, blast lifetimes, the round timer and AI cadence are all driven by
+// wall-clock timestamps (compare a stored `placedAt`/`nextMoveAt` against the
+// current time). Reading `Date.now()` directly makes those deadlines impossible
+// to pause: sleeping the render loop stops `update()`, but every stored fuse
+// keeps counting against real time, so on resume they all detonate at once.
+//
+// `now()` is real time minus every millisecond spent paused. While paused it
+// holds still; on resume it continues from exactly where it stopped, so a bomb
+// with 2s of fuse left before a pause still has ~2s left after. Only SIM timing
+// reads `now()` — net heartbeats, connection deadlines and logging stay on real
+// `Date.now()`, because pausing them would break reconnection.
+
+let pausedTotal = 0; // total ms elapsed while paused, accumulated across pauses
+let pausedAt = 0; // real timestamp the current pause began; 0 when not paused
+
+/** Sim clock: `Date.now()` minus all time spent paused. Frozen while paused. */
+export function now(): number {
+  if (pausedAt !== 0) return pausedAt - pausedTotal;
+  return Date.now() - pausedTotal;
+}
+
+/** Freeze the sim clock. Idempotent — a second call while paused is a no-op. */
+export function pauseClock(): void {
+  if (pausedAt !== 0) return;
+  pausedAt = Date.now();
+}
+
+/** Resume the sim clock, folding the pause span into the running offset. */
+export function resumeClock(): void {
+  if (pausedAt === 0) return;
+  pausedTotal += Date.now() - pausedAt;
+  pausedAt = 0;
+}

--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -1,3 +1,4 @@
+import { now as simNow } from "./clock";
 import { rand } from "./rng";
 
 // ---- world -------------------------------------------------------------------
@@ -1636,7 +1637,7 @@ export function spawnItemState(x: number, y: number, drop: ItemDrop): ItemState 
     y,
     vx: Math.cos(ang) * ITEM_SPEED,
     vy: Math.sin(ang) * ITEM_SPEED,
-    diesAt: Date.now() + ITEM_LIFETIME_MS,
+    diesAt: simNow() + ITEM_LIFETIME_MS,
     ...drop,
   };
 }
@@ -1652,7 +1653,7 @@ export function spawnShardState(x: number, y: number): ShardState {
     y: y + Math.sin(ang) * scatter,
     vx: Math.cos(ang) * SHARD_DRIFT_SPEED,
     vy: Math.sin(ang) * SHARD_DRIFT_SPEED,
-    diesAt: Date.now() + SHARD_LIFETIME_MS,
+    diesAt: simNow() + SHARD_LIFETIME_MS,
   };
 }
 

--- a/games/starfall/src/shared/diag.ts
+++ b/games/starfall/src/shared/diag.ts
@@ -10,8 +10,10 @@
 //   assume one boot per page load), so an honest mid-run reseed+restart isn't
 //   possible. Seeding uses the contract's boot-time alternative instead — a
 //   `?seed=N` query param read in main.ts before the game constructs.
-// - No `setPausedForScreenshot`: the sim is Date.now-driven and shared, so
-//   freezing the loop is forbidden (a wake would teleport every entity).
+// - `setPausedForScreenshot` is OFFLINE-ONLY: it rides the same real freeze as
+//   the wrapper pause (pausable sim clock in shared/clock.ts + loop sleep), so
+//   every stored deadline holds and nothing teleports on resume. Online it's a
+//   no-op — freezing the shared world would stall the other players.
 // - `setState('active-play')` forces the offline solo fallback immediately
 //   (instead of waiting out the 4s connect grace) and dismisses the start
 //   overlay. Online play is untouched: the hook only ever runs when a test
@@ -38,13 +40,21 @@ export const diag: Diagnostics = {
 
 export type TestHooks = {
   setState(name: string): void;
+  setPausedForScreenshot(paused: boolean): void;
 };
 
-export function installTestHooks(hooks: { activePlay(): void }): void {
+export function installTestHooks(hooks: {
+  activePlay(): void;
+  /** Offline-only real freeze (see header). No-op while online. */
+  setPaused(paused: boolean): void;
+}): void {
   Reflect.set(globalThis, "__GAME_DIAGNOSTICS__", diag);
   const testHooks: TestHooks = {
     setState(name: string): void {
       if (name === "active-play") hooks.activePlay();
+    },
+    setPausedForScreenshot(paused: boolean): void {
+      hooks.setPaused(paused);
     },
   };
   Reflect.set(globalThis, "__GAME_TEST_HOOKS__", testHooks);


### PR DESCRIPTION
## What

Ports bomberman's field-tested `util/clock.ts` (the "real pause" work) into starfall as `src/shared/clock.ts` — **byte-identical copies** (`diff` clean), per the shared-lib guiding rule: align in-repo first, extract later. Docs entry added (§A.8 `@vibedgames/game-clock`, effort S).

## Starfall changes

- **23 gameplay `Date.now()` sites → `simNow()`** (game-scene, constants' item/shard `diesAt`). The clock equals wall time whenever unpaused, so online wire timestamps are bit-identical to before. Connection deadlines (`bootedAt`/offline fallback) deliberately stay on raw `Date.now()` — same contract as bomberman: pausing must never break reconnect.
- **Wrapper pause now truly freezes when offline** (solo world, nobody to stall): `pauseClock()` + `game.loop.sleep()` + audio suspend. Every stored deadline (boosts, blink, respawn, weapon timers, item lifetimes) holds through the pause — no mass-expiry or teleport on wake. Online keeps the existing spectator-dock path unchanged.
- **`setPausedForScreenshot` test hook** (previously omitted as impossible) now rides the same offline-only freeze; `shared/diag.ts` contract comment updated.
- **New e2e test**: freeze → frame counter halts + position holds over a 1.5s pause → resume → loop advances, movement continues with no jump (bounded delta).

## Verification

- `tsc --noEmit` clean (starfall + bomberman)
- `pnpm test:e2e` (starfall): **2/2 green, twice** — sweep playtest + new pause test
- `diff` bomberman/starfall clock copies: identical
- Bomberman: zero changes (it's the pattern donor)
- Online behavior: unpaused clock ≡ wall clock; pause refused online (offline-gated) — no wire change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pausable sim clock and an offline freeze path so solo games truly pause without expiring timers. Online behavior stays the same with spectator pause.

- New Features
  - Added `shared/clock.ts` pausable clock (byte-identical to bomberman `util/clock.ts`).
  - Switched 23 gameplay `Date.now()` reads to `simNow()`; kept connection deadlines on real `Date.now()`.
  - Offline wrapper pause now freezes the sim clock, sleeps the loop, and suspends audio; online still uses spectator docking.
  - Exposed offline-only `setPausedForScreenshot` hook through `diag` and the scene.
  - Added an e2e pause test validating frame halt, position hold, and smooth resume; documented extraction proposal for `@vibedgames/game-clock`.

<sup>Written for commit 00b2ce837a6f4222b40b7a233ea4146127b98313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

