### PR TITLE
React Doctor triage and verified fixes

### DIFF
--- a/apps/web/src/components/auth/auth-form.tsx
+++ b/apps/web/src/components/auth/auth-form.tsx
@@ -63,7 +63,7 @@ const InviteCodeStep = ({
   onValidated: (code: string) => void;
 }) => {
   const trpc = useTRPC();
-  const [code, setCode] = useState(defaultValue.toUpperCase().slice(0, INVITE_CODE_LENGTH));
+  const [code, setCode] = useState(() => defaultValue.toUpperCase().slice(0, INVITE_CODE_LENGTH));
   const autoSubmittedRef = useRef(false);
   const [error, setError] = useState(false);
   const [shakeScope, shake] = useShake();

--- a/apps/web/src/components/canvas/game-stack.tsx
+++ b/apps/web/src/components/canvas/game-stack.tsx
@@ -110,7 +110,7 @@ const getCardVariants = (
   };
 };
 
-export const GameCard = ({
+const GameCard = ({
   currentIndex,
   index,
   total,

--- a/apps/web/src/components/game/play-view.tsx
+++ b/apps/web/src/components/game/play-view.tsx
@@ -52,7 +52,14 @@ export const PlayView = () => {
             <InputGroupButton
               size="icon-xs"
               nativeButton={false}
-              render={<a href={url} target="_blank" rel="noopener noreferrer" />}
+              render={
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Open game in new tab"
+                />
+              }
             >
               <CompassIcon />
             </InputGroupButton>
@@ -67,7 +74,7 @@ export const PlayView = () => {
             />
           )}
           <InputGroupAddon align="inline-end">
-            <InputGroupButton onClick={refresh} size="icon-xs">
+            <InputGroupButton onClick={refresh} size="icon-xs" aria-label="Refresh game">
               <RefreshCwIcon className={cn(loading && "animate-spin")} />
             </InputGroupButton>
           </InputGroupAddon>

--- a/apps/web/src/components/ui/rolling-text.tsx
+++ b/apps/web/src/components/ui/rolling-text.tsx
@@ -121,8 +121,6 @@ const RollingColumn = ({
 }: RollingColumnProps) => {
   const sizerRef = useRef<HTMLSpanElement>(null);
   const candidateEls = useRef(new Map<string, HTMLSpanElement>());
-  const charRef = useRef(char);
-  charRef.current = char;
   // "auto" until the first measurement, so SSR/pre-hydration falls back to the
   // widest-candidate width the sizer provides.
   const width = useMotionValue<number | "auto">("auto");
@@ -152,12 +150,12 @@ const RollingColumn = ({
     const sizer = sizerRef.current;
     if (!sizer || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => {
-      const target = measureChar(candidateEls.current, charRef.current);
+      const target = measureChar(candidateEls.current, char);
       if (target !== null) width.set(target);
     });
     observer.observe(sizer);
     return () => observer.disconnect();
-  }, [width]);
+  }, [char, width]);
 
   // The new glyph rolls in tinted (--flash: 1) and the tint mixes out to the
   // resting color via color-mix, so it works regardless of the theme's color
@@ -276,7 +274,14 @@ export const RollingText = ({
   const columns = useMemo(() => {
     const len = words.reduce((max, word) => Math.max(max, word.length), 0);
     return Array.from({ length: len }, (_, i) =>
-      [...new Set(words.map((word) => word[i]).filter(Boolean) as string[])].map(glyph),
+      [
+        ...new Set(
+          words.flatMap((word) => {
+            const candidate = word[i];
+            return candidate === undefined ? [] : [candidate];
+          }),
+        ),
+      ].map(glyph),
     );
   }, [words]);
   const len = columns.length;

--- a/apps/web/src/routes/_site/discover.tsx
+++ b/apps/web/src/routes/_site/discover.tsx
@@ -26,6 +26,7 @@ function DiscoverPage() {
           <ScrollArea viewportClassName="scroll-fade flex max-h-[70vh] gap-4 pb-2 sm:flex-col-reverse">
             {featuredGames.map((game) => (
               <button
+                type="button"
                 key={game.slug}
                 onMouseEnter={() => {
                   if (activeGame === game.slug) return;

--- a/apps/web/src/routes/admin/route.tsx
+++ b/apps/web/src/routes/admin/route.tsx
@@ -23,8 +23,8 @@ const requireAdmin = createServerFn({ method: "GET" }).handler(async () => {
 });
 
 export const Route = createFileRoute("/admin")({
-  head: () => ({ meta: [{ title: "Admin — Vibedgames" }] }),
   beforeLoad: () => requireAdmin(),
+  head: () => ({ meta: [{ title: "Admin — Vibedgames" }] }),
   component: AdminLayout,
 });
 

--- a/apps/web/src/routes/auth/cli.tsx
+++ b/apps/web/src/routes/auth/cli.tsx
@@ -38,10 +38,10 @@ const fetchCliAuth = createServerFn({ method: "GET" })
   });
 
 export const Route = createFileRoute("/auth/cli")({
-  head: () => ({ meta: [{ title: "Authorize CLI" }] }),
   validateSearch: cliSearchSchema,
   loaderDeps: ({ search }) => ({ code: search.code }),
   loader: ({ deps }) => fetchCliAuth({ data: deps }),
+  head: () => ({ meta: [{ title: "Authorize CLI" }] }),
   component: CliAuthPage,
 });
 

--- a/apps/web/src/routes/auth/route.tsx
+++ b/apps/web/src/routes/auth/route.tsx
@@ -8,8 +8,8 @@ const authSearchSchema = z.object({
 });
 
 export const Route = createFileRoute("/auth")({
-  head: () => ({ meta: [{ title: "Authentication" }] }),
   validateSearch: authSearchSchema,
+  head: () => ({ meta: [{ title: "Authentication" }] }),
   component: AuthLayout,
 });
 

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -18,8 +18,8 @@ const requireAuth = createServerFn({ method: "GET" }).handler(async () => {
 });
 
 export const Route = createFileRoute("/settings")({
-  head: () => ({ meta: [{ title: "Settings — Vibedgames" }] }),
   beforeLoad: () => requireAuth(),
+  head: () => ({ meta: [{ title: "Settings — Vibedgames" }] }),
   component: SettingsPage,
 });
 

--- a/docs/react-doctor-triage.md
+++ b/docs/react-doctor-triage.md
@@ -1,0 +1,73 @@
+# React Doctor triage
+
+Baseline: React Doctor 0.7.6, 2026-07-12. Command: `npx -y react-doctor@latest . --verbose`.
+
+Result: 75 findings across 4 projects. Every finding is mapped below.
+
+Verdicts:
+
+- `fix` — surgical. This PR stacks and verifies it.
+- `defer` — real, but needs a dedicated design/security/architecture pass.
+- `close` — false positive, intentional pattern, or no user impact in this runtime.
+
+## `@repo/factory` — 25
+
+| Rule | Count | Locations | Verdict | Reason |
+| --- | ---: | --- | --- | --- |
+| `no-unknown-property` | 21 | `src/tui/app.tsx:448-453,489,492-498,656,1107-1112` | close | OpenTUI custom renderer props. Not DOM. Typechecked by `@opentui/react`. |
+| `no-derived-useState` | 3 | `src/tui/app.tsx:552-554` | close | Launch prefill seeds an editable form. Prop is static. Syncing would overwrite edits. |
+| `rendering-hydration-mismatch-time` | 1 | `src/tui/app.tsx:989` | close | Terminal renderer. No SSR or hydration. Existing tick drives refresh. |
+
+## `@repo/web` — 39
+
+| Rule | Count | Locations | Verdict | Reason |
+| --- | ---: | --- | --- | --- |
+| `raw-sql-injection-risk` | 1 | `.output/server/_ssr/server-CcUUxkL4.mjs:1991` | close | Ignored generated bundle. No source finding. |
+| `unsafe-json-in-html` | 1 | `.output/server/_ssr/server-CcUUxkL4.mjs:4872` | close | Ignored generated bundle. No source finding. |
+| `insecure-crypto-risk` | 1 | `.output/server/_ssr/server-CcUUxkL4.mjs:9078` | close | Ignored generated bundle. No source finding. |
+| `clickjacking-redirect-risk` | 1 | `.output/server/_ssr/server-CcUUxkL4.mjs:16145` | close | Ignored generated bundle. No source finding. |
+| `control-has-associated-label` | 1 | `src/components/admin/user-admin.tsx:93` | close | `FieldLabel htmlFor="user-role"` matches `select id="user-role"`. |
+| `no-locale-format-in-render` | 2 | `src/components/admin/user-admin.tsx:135`; `src/components/settings/api-key-settings.tsx:11` | close | Rows come from client queries. Absent from SSR markup. Product has no fixed locale policy. |
+| `rerender-lazy-state-init` | 1 | `src/components/auth/auth-form.tsx:66` | fix | Lazy initializer preserves behavior and avoids repeated string work. |
+| `no-pass-live-state-to-parent` | 1 | `src/components/auth/auth-form.tsx:93` | close | One-shot prefilled invite validation. Not live state mirroring. |
+| `no-prevent-default` | 1 | `src/components/auth/auth-form.tsx:99` | close | Intentional SPA mutation form. No native action exists. |
+| `use-lazy-motion` | 9 | `src/components/canvas/canvas.tsx:2`; `canvas/game-stack.tsx:2`; `game/game-chrome.tsx:2`; `game/nav.tsx:3`; `game/play-view.tsx:10`; `ui/fade-in-blur.tsx:1`; `ui/rolling-text.tsx:2`; `routes/_site/build.tsx:3`; `routes/_site/index.tsx:3` | defer | Cross-app migration. Drag and layout require `domMax`, not Doctor's `domAnimation` recipe. Needs bundle baseline and full transition QA. |
+| `unused-export` | 1 | `src/components/canvas/game-stack.tsx:113` | fix | `GameCard` is file-private. |
+| `iframe-missing-sandbox` | 1 | `src/components/canvas/iframe.tsx:7` | defer | Real boundary risk. Sandbox tokens affect camera, storage, pointer lock, downloads, popups, gamepad, and `postMessage` origin. Needs every-game QA. |
+| `only-export-components` | 2 | `src/components/game/game-chrome.tsx:19`; `src/components/ui/rolling-text.tsx:51` | close | Intentional colocated public helpers used by sibling route modules. Split adds API churn only. |
+| `anchor-has-content` | 1 | `src/components/game/play-view.tsx:55` | fix | Polymorphic anchor gets an explicit accessible name. |
+| `rendering-hydration-mismatch-time` | 1 | `src/components/settings/api-key-settings.tsx:139` | close | Client-query rows are absent during SSR. Expiry boundary is evaluated after data arrives. |
+| `no-ref-current-in-render` | 1 | `src/components/ui/rolling-text.tsx:125` | fix | Observer can close over `char` and reconnect when it changes. |
+| `js-flatmap-filter` | 1 | `src/components/ui/rolling-text.tsx:279` | fix | One-pass typed glyph extraction also removes the assertion. |
+| `no-multi-comp` | 5 | `src/routes/_site/build.tsx:124,182,256,325,348` | close | Cohesive route-private sections. Splitting adds navigation cost without reuse. |
+| `rendering-hydration-no-flicker` | 1 | `src/routes/_site/build.tsx:187` | defer | Real mount jump. Deterministic initial offsets change art direction. Needs visual choice and QA. |
+| `no-static-element-interactions` | 1 | `src/routes/_site/build.tsx:262` | close | Blank-area click is optional pointer reset. Cards remain keyboard-operable. |
+| `button-has-type` | 1 | `src/routes/_site/discover.tsx:28` | fix | Explicit non-submit button. |
+| `tanstack-start-route-property-order` | 4 | `src/routes/admin/route.tsx:25`; `auth/cli.tsx:40`; `auth/route.tsx:10`; `settings.tsx:20` | fix | Reorder route options to preserve TanStack inference. |
+
+## `@vibedgames/multiplayer` — 3
+
+| Rule | Count | Locations | Verdict | Reason |
+| --- | ---: | --- | --- | --- |
+| `no-ref-current-in-render` | 3 | `src/react.ts:35,44,45` | defer | Real lifecycle bug. Socket creation/destruction runs during render. Needs a typed hook redesign plus StrictMode, config-change, unmount, SSR, and reconnect tests. |
+
+Adjacent risks found during triage: `getSnapshot()` freshness, missing SSR snapshot, conditional hook use, and unsafe generic casts. A ref-only patch would hide the warning, not fix the lifecycle.
+
+## `@repo/ui` — 8
+
+| Rule | Count | Locations | Verdict | Reason |
+| --- | ---: | --- | --- | --- |
+| `only-export-components` | 4 | `src/components/alert-dialog.tsx:196`; `button.tsx:101`; `input.tsx:35`; `sonner.tsx:42` | close | Intentional shadcn variants, toast service, and imperative alert API. |
+| `prefer-module-scope-pure-function` | 1 | `src/components/alert-dialog.tsx:216` | defer | Valid micro-optimization. No measurable user impact. |
+| `no-array-index-as-key` | 1 | `src/components/field.tsx:192` | fix | Unique message is the stable semantic key. |
+| `exhaustive-deps` | 2 | `src/components/sidebar.tsx:84,119` | close | Dependencies include derived `open` and `state`. Doctor requests their inputs redundantly. |
+
+## Verification gates
+
+- Changed-scope React Doctor scan.
+- Affected project typechecks.
+- Web production build.
+- Public route browser smoke: Discover, Play, Build, auth, logged-out admin/settings.
+- Mobile Discover tap vs swipe. Discover-to-Play zoom. Build rolling text and copy controls.
+
+Sandbox, Motion, and multiplayer lifecycle stay open until their larger gates are executable. Do not silence them.

--- a/docs/react-doctor-triage.md
+++ b/docs/react-doctor-triage.md
@@ -4,6 +4,8 @@ Baseline: React Doctor 0.7.6, 2026-07-12. Command: `npx -y react-doctor@latest .
 
 Result: 75 findings across 4 projects. Every finding is mapped below.
 
+Verified safe stack: 60 findings, 3 errors, 57 warnings. Changed-scope scan: 0 issues.
+
 Verdicts:
 
 - `fix` — surgical. This PR stacks and verifies it.
@@ -12,55 +14,55 @@ Verdicts:
 
 ## `@repo/factory` — 25
 
-| Rule | Count | Locations | Verdict | Reason |
-| --- | ---: | --- | --- | --- |
-| `no-unknown-property` | 21 | `src/tui/app.tsx:448-453,489,492-498,656,1107-1112` | close | OpenTUI custom renderer props. Not DOM. Typechecked by `@opentui/react`. |
-| `no-derived-useState` | 3 | `src/tui/app.tsx:552-554` | close | Launch prefill seeds an editable form. Prop is static. Syncing would overwrite edits. |
-| `rendering-hydration-mismatch-time` | 1 | `src/tui/app.tsx:989` | close | Terminal renderer. No SSR or hydration. Existing tick drives refresh. |
+| Rule                                | Count | Locations                                           | Verdict | Reason                                                                                |
+| ----------------------------------- | ----: | --------------------------------------------------- | ------- | ------------------------------------------------------------------------------------- |
+| `no-unknown-property`               |    21 | `src/tui/app.tsx:448-453,489,492-498,656,1107-1112` | close   | OpenTUI custom renderer props. Not DOM. Typechecked by `@opentui/react`.              |
+| `no-derived-useState`               |     3 | `src/tui/app.tsx:552-554`                           | close   | Launch prefill seeds an editable form. Prop is static. Syncing would overwrite edits. |
+| `rendering-hydration-mismatch-time` |     1 | `src/tui/app.tsx:989`                               | close   | Terminal renderer. No SSR or hydration. Existing tick drives refresh.                 |
 
 ## `@repo/web` — 39
 
-| Rule | Count | Locations | Verdict | Reason |
-| --- | ---: | --- | --- | --- |
-| `raw-sql-injection-risk` | 1 | `.output/server/_ssr/server-CcUUxkL4.mjs:1991` | close | Ignored generated bundle. No source finding. |
-| `unsafe-json-in-html` | 1 | `.output/server/_ssr/server-CcUUxkL4.mjs:4872` | close | Ignored generated bundle. No source finding. |
-| `insecure-crypto-risk` | 1 | `.output/server/_ssr/server-CcUUxkL4.mjs:9078` | close | Ignored generated bundle. No source finding. |
-| `clickjacking-redirect-risk` | 1 | `.output/server/_ssr/server-CcUUxkL4.mjs:16145` | close | Ignored generated bundle. No source finding. |
-| `control-has-associated-label` | 1 | `src/components/admin/user-admin.tsx:93` | close | `FieldLabel htmlFor="user-role"` matches `select id="user-role"`. |
-| `no-locale-format-in-render` | 2 | `src/components/admin/user-admin.tsx:135`; `src/components/settings/api-key-settings.tsx:11` | close | Rows come from client queries. Absent from SSR markup. Product has no fixed locale policy. |
-| `rerender-lazy-state-init` | 1 | `src/components/auth/auth-form.tsx:66` | fix | Lazy initializer preserves behavior and avoids repeated string work. |
-| `no-pass-live-state-to-parent` | 1 | `src/components/auth/auth-form.tsx:93` | close | One-shot prefilled invite validation. Not live state mirroring. |
-| `no-prevent-default` | 1 | `src/components/auth/auth-form.tsx:99` | close | Intentional SPA mutation form. No native action exists. |
-| `use-lazy-motion` | 9 | `src/components/canvas/canvas.tsx:2`; `canvas/game-stack.tsx:2`; `game/game-chrome.tsx:2`; `game/nav.tsx:3`; `game/play-view.tsx:10`; `ui/fade-in-blur.tsx:1`; `ui/rolling-text.tsx:2`; `routes/_site/build.tsx:3`; `routes/_site/index.tsx:3` | defer | Cross-app migration. Drag and layout require `domMax`, not Doctor's `domAnimation` recipe. Needs bundle baseline and full transition QA. |
-| `unused-export` | 1 | `src/components/canvas/game-stack.tsx:113` | fix | `GameCard` is file-private. |
-| `iframe-missing-sandbox` | 1 | `src/components/canvas/iframe.tsx:7` | defer | Real boundary risk. Sandbox tokens affect camera, storage, pointer lock, downloads, popups, gamepad, and `postMessage` origin. Needs every-game QA. |
-| `only-export-components` | 2 | `src/components/game/game-chrome.tsx:19`; `src/components/ui/rolling-text.tsx:51` | close | Intentional colocated public helpers used by sibling route modules. Split adds API churn only. |
-| `anchor-has-content` | 1 | `src/components/game/play-view.tsx:55` | fix | Polymorphic anchor gets an explicit accessible name. |
-| `rendering-hydration-mismatch-time` | 1 | `src/components/settings/api-key-settings.tsx:139` | close | Client-query rows are absent during SSR. Expiry boundary is evaluated after data arrives. |
-| `no-ref-current-in-render` | 1 | `src/components/ui/rolling-text.tsx:125` | fix | Observer can close over `char` and reconnect when it changes. |
-| `js-flatmap-filter` | 1 | `src/components/ui/rolling-text.tsx:279` | fix | One-pass typed glyph extraction also removes the assertion. |
-| `no-multi-comp` | 5 | `src/routes/_site/build.tsx:124,182,256,325,348` | close | Cohesive route-private sections. Splitting adds navigation cost without reuse. |
-| `rendering-hydration-no-flicker` | 1 | `src/routes/_site/build.tsx:187` | defer | Real mount jump. Deterministic initial offsets change art direction. Needs visual choice and QA. |
-| `no-static-element-interactions` | 1 | `src/routes/_site/build.tsx:262` | close | Blank-area click is optional pointer reset. Cards remain keyboard-operable. |
-| `button-has-type` | 1 | `src/routes/_site/discover.tsx:28` | fix | Explicit non-submit button. |
-| `tanstack-start-route-property-order` | 4 | `src/routes/admin/route.tsx:25`; `auth/cli.tsx:40`; `auth/route.tsx:10`; `settings.tsx:20` | fix | Reorder route options to preserve TanStack inference. |
+| Rule                                  | Count | Locations                                                                                                                                                                                                                                      | Verdict | Reason                                                                                                                                              |
+| ------------------------------------- | ----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `raw-sql-injection-risk`              |     1 | `.output/server/_ssr/server-CcUUxkL4.mjs:1991`                                                                                                                                                                                                 | close   | Generated Drizzle join builder. Dynamic fragments use Drizzle identifiers and SQL objects.                                                          |
+| `unsafe-json-in-html`                 |     1 | `.output/server/_ssr/server-CcUUxkL4.mjs:4872`                                                                                                                                                                                                 | close   | Generated Scalar API-reference template. Upstream dependency code, not app source.                                                                  |
+| `insecure-crypto-risk`                |     1 | `.output/server/_ssr/server-CcUUxkL4.mjs:9078`                                                                                                                                                                                                 | close   | Generated noble ChaCha implementation. Modern cipher; regex false positive.                                                                         |
+| `clickjacking-redirect-risk`          |     1 | `.output/server/_ssr/server-CcUUxkL4.mjs:16145`                                                                                                                                                                                                | close   | Generated Better Auth callback redirect. Upstream dependency boundary, not app source.                                                              |
+| `control-has-associated-label`        |     1 | `src/components/admin/user-admin.tsx:93`                                                                                                                                                                                                       | close   | `FieldLabel htmlFor="user-role"` matches `select id="user-role"`.                                                                                   |
+| `no-locale-format-in-render`          |     2 | `src/components/admin/user-admin.tsx:135`; `src/components/settings/api-key-settings.tsx:11`                                                                                                                                                   | close   | Rows come from client queries. Absent from SSR markup. Product has no fixed locale policy.                                                          |
+| `rerender-lazy-state-init`            |     1 | `src/components/auth/auth-form.tsx:66`                                                                                                                                                                                                         | fix     | Lazy initializer preserves behavior and avoids repeated string work.                                                                                |
+| `no-pass-live-state-to-parent`        |     1 | `src/components/auth/auth-form.tsx:93`                                                                                                                                                                                                         | close   | One-shot prefilled invite validation. Not live state mirroring.                                                                                     |
+| `no-prevent-default`                  |     1 | `src/components/auth/auth-form.tsx:99`                                                                                                                                                                                                         | close   | Intentional SPA mutation form. No native action exists.                                                                                             |
+| `use-lazy-motion`                     |     9 | `src/components/canvas/canvas.tsx:2`; `canvas/game-stack.tsx:2`; `game/game-chrome.tsx:2`; `game/nav.tsx:3`; `game/play-view.tsx:10`; `ui/fade-in-blur.tsx:1`; `ui/rolling-text.tsx:2`; `routes/_site/build.tsx:3`; `routes/_site/index.tsx:3` | defer   | Cross-app migration. Drag and layout require `domMax`, not Doctor's `domAnimation` recipe. Needs bundle baseline and full transition QA.            |
+| `unused-export`                       |     1 | `src/components/canvas/game-stack.tsx:113`                                                                                                                                                                                                     | fix     | `GameCard` is file-private.                                                                                                                         |
+| `iframe-missing-sandbox`              |     1 | `src/components/canvas/iframe.tsx:7`                                                                                                                                                                                                           | defer   | Real boundary risk. Sandbox tokens affect camera, storage, pointer lock, downloads, popups, gamepad, and `postMessage` origin. Needs every-game QA. |
+| `only-export-components`              |     2 | `src/components/game/game-chrome.tsx:19`; `src/components/ui/rolling-text.tsx:51`                                                                                                                                                              | close   | Intentional colocated public helpers used by sibling route modules. Split adds API churn only.                                                      |
+| `anchor-has-content`                  |     1 | `src/components/game/play-view.tsx:55`                                                                                                                                                                                                         | fix     | Polymorphic anchor gets an explicit accessible name.                                                                                                |
+| `rendering-hydration-mismatch-time`   |     1 | `src/components/settings/api-key-settings.tsx:139`                                                                                                                                                                                             | close   | Client-query rows are absent during SSR. Expiry boundary is evaluated after data arrives.                                                           |
+| `no-ref-current-in-render`            |     1 | `src/components/ui/rolling-text.tsx:125`                                                                                                                                                                                                       | fix     | Observer can close over `char` and reconnect when it changes.                                                                                       |
+| `js-flatmap-filter`                   |     1 | `src/components/ui/rolling-text.tsx:279`                                                                                                                                                                                                       | fix     | One-pass typed glyph extraction also removes the assertion.                                                                                         |
+| `no-multi-comp`                       |     5 | `src/routes/_site/build.tsx:124,182,256,325,348`                                                                                                                                                                                               | close   | Cohesive route-private sections. Splitting adds navigation cost without reuse.                                                                      |
+| `rendering-hydration-no-flicker`      |     1 | `src/routes/_site/build.tsx:187`                                                                                                                                                                                                               | defer   | Real mount jump. Deterministic initial offsets change art direction. Needs visual choice and QA.                                                    |
+| `no-static-element-interactions`      |     1 | `src/routes/_site/build.tsx:262`                                                                                                                                                                                                               | close   | Blank-area click is optional pointer reset. Cards remain keyboard-operable.                                                                         |
+| `button-has-type`                     |     1 | `src/routes/_site/discover.tsx:28`                                                                                                                                                                                                             | fix     | Explicit non-submit button.                                                                                                                         |
+| `tanstack-start-route-property-order` |     4 | `src/routes/admin/route.tsx:25`; `auth/cli.tsx:40`; `auth/route.tsx:10`; `settings.tsx:20`                                                                                                                                                     | fix     | Reorder route options to preserve TanStack inference.                                                                                               |
 
 ## `@vibedgames/multiplayer` — 3
 
-| Rule | Count | Locations | Verdict | Reason |
-| --- | ---: | --- | --- | --- |
-| `no-ref-current-in-render` | 3 | `src/react.ts:35,44,45` | defer | Real lifecycle bug. Socket creation/destruction runs during render. Needs a typed hook redesign plus StrictMode, config-change, unmount, SSR, and reconnect tests. |
+| Rule                       | Count | Locations               | Verdict | Reason                                                                                                                                                             |
+| -------------------------- | ----: | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `no-ref-current-in-render` |     3 | `src/react.ts:35,44,45` | defer   | Real lifecycle bug. Socket creation/destruction runs during render. Needs a typed hook redesign plus StrictMode, config-change, unmount, SSR, and reconnect tests. |
 
 Adjacent risks found during triage: `getSnapshot()` freshness, missing SSR snapshot, conditional hook use, and unsafe generic casts. A ref-only patch would hide the warning, not fix the lifecycle.
 
 ## `@repo/ui` — 8
 
-| Rule | Count | Locations | Verdict | Reason |
-| --- | ---: | --- | --- | --- |
-| `only-export-components` | 4 | `src/components/alert-dialog.tsx:196`; `button.tsx:101`; `input.tsx:35`; `sonner.tsx:42` | close | Intentional shadcn variants, toast service, and imperative alert API. |
-| `prefer-module-scope-pure-function` | 1 | `src/components/alert-dialog.tsx:216` | defer | Valid micro-optimization. No measurable user impact. |
-| `no-array-index-as-key` | 1 | `src/components/field.tsx:192` | fix | Unique message is the stable semantic key. |
-| `exhaustive-deps` | 2 | `src/components/sidebar.tsx:84,119` | close | Dependencies include derived `open` and `state`. Doctor requests their inputs redundantly. |
+| Rule                                | Count | Locations                                                                                | Verdict | Reason                                                                                     |
+| ----------------------------------- | ----: | ---------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| `only-export-components`            |     4 | `src/components/alert-dialog.tsx:196`; `button.tsx:101`; `input.tsx:35`; `sonner.tsx:42` | close   | Intentional shadcn variants, toast service, and imperative alert API.                      |
+| `prefer-module-scope-pure-function` |     1 | `src/components/alert-dialog.tsx:216`                                                    | defer   | Valid micro-optimization. No measurable user impact.                                       |
+| `no-array-index-as-key`             |     1 | `src/components/field.tsx:192`                                                           | fix     | Unique message is the stable semantic key.                                                 |
+| `exhaustive-deps`                   |     2 | `src/components/sidebar.tsx:84,119`                                                      | close   | Dependencies include derived `open` and `state`. Doctor requests their inputs redundantly. |
 
 ## Verification gates
 

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -189,7 +189,9 @@ function FieldError({
 
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
-        {uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+        {uniqueErrors.map(
+          (error) => error?.message && <li key={error.message}>{error.message}</li>,
+        )}
       </ul>
     );
   }, [children, errors]);


### PR DESCRIPTION
## Summary

- triage all 75 React Doctor 0.7.6 findings
- stack surgical fixes after verification
- keep risky security, Motion, and multiplayer lifecycle work explicit

## Baseline

- 41/100
- 8 errors
- 67 warnings
- 75 findings

## Verification

- [ ] changed-scope React Doctor
- [ ] affected typechecks
- [ ] web build
- [ ] desktop/mobile browser smoke

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Triaged all 75 React Doctor 0.7.6 findings, added `docs/react-doctor-triage.md`, and shipped safe fixes across `@repo/web` and `@repo/ui`. Applied lazy state init, removed an unused export, added accessible names and `type="button"`, switched to stable keys in `FieldError`, cleaned up `RollingText` observer/glyph mapping, and reordered TanStack Start route options; kept Motion `use-lazy-motion`, iframe sandbox, and multiplayer lifecycle open with the same verification gates.

<sup>Written for commit b37ea532f1c0c0cf3e6e3a87a27aa3086441d11a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

