### PR TITLE
fix(battle-arena): FPS camera on touch — right stick turns the view

### DIFF
--- a/games/battle-arena/src/input/controls.ts
+++ b/games/battle-arena/src/input/controls.ts
@@ -91,6 +91,16 @@ export class Controls {
     return this.uiMode;
   }
 
+  /** Touch look stick: fold a deflection (unit-clamped, y-down screen axes)
+   *  into yaw/pitch at the same rates as the physical pad's right stick.
+   *  MOUSE-mode guarded like every other look path (menus own the pointer). */
+  applyStickLook(dx: number, dy: number, dt: number): void {
+    if (this.uiMode || (dx === 0 && dy === 0)) return;
+    this.yaw -= dx * dt * PAD_YAW_SPEED;
+    this.pitch = Math.max(PITCH_MIN, Math.min(PITCH_MAX, this.pitch - dy * dt * PAD_PITCH_SPEED));
+    this.hadInput = true;
+  }
+
   /** Poll the physical gamepad and fold it into the keyboard/mouse fields.
    *  Call once per frame, before the frame's reads (works without pointer
    *  lock — pad look integrates yaw/pitch directly, dt-scaled). */

--- a/games/battle-arena/src/input/touch.ts
+++ b/games/battle-arena/src/input/touch.ts
@@ -1,5 +1,7 @@
-// Twin-stick touch controls (build-doc §12). Left half = floating move stick;
-// right half = floating aim stick that auto-fires while held. Fixed bottom-right
+// Touch controls (build-doc §12). Left half = floating move stick (camera-
+// relative forward/strafe); right half = floating LOOK stick — it turns the
+// camera FPS-style (the scene folds its deflection into yaw/pitch at pad
+// rates, crosshair dead center) and auto-fires while held. Fixed bottom-right
 // button grid: Q/W/E · R/DASH/JUMP · hop/B. DASH casts the hero's dash, JUMP the
 // leaping strike (self-leaps if grounded); the hop button is the plain Space hop.
 // Ability buttons take champ icon backgrounds via bindChamp() and per-button
@@ -205,12 +207,10 @@ export class TouchControls {
   moveVec(): { x: number; y: number } {
     return this.move ? { x: this.move.dx, y: this.move.dy } : { x: 0, y: 0 };
   }
-  /** Aim direction (unit-ish) or null if the right stick isn't held. */
-  aimVec(): { x: number; y: number } | null {
-    if (!this.aim) return null;
-    const l = Math.hypot(this.aim.dx, this.aim.dy);
-    if (l < 0.2) return null;
-    return { x: this.aim.dx / l, y: this.aim.dy / l };
+  /** Raw look-stick deflection (unit-clamped, y-down screen axes) or null if
+   *  the right stick isn't held. The scene integrates this into yaw/pitch. */
+  lookVec(): { x: number; y: number } | null {
+    return this.aim ? { x: this.aim.dx, y: this.aim.dy } : null;
   }
   attackDown(): boolean {
     return this.aim !== null && Math.hypot(this.aim.dx, this.aim.dy) > 0.2;

--- a/games/battle-arena/src/render/hints.ts
+++ b/games/battle-arena/src/render/hints.ts
@@ -56,7 +56,7 @@ const RULES: Rule[] = [
   {
     id: "move",
     text: "WASD move · mouse aim",
-    touch: "Left stick move · right stick aim",
+    touch: "Left stick move · right stick turn",
     when: (w) => w.gameTime > INTRO_S + 0.5,
     done: (_w, me, st) => st.spawnSet && (me.x - st.spawnX) ** 2 + (me.y - st.spawnY) ** 2 > 25,
   },

--- a/games/battle-arena/src/render/hud.ts
+++ b/games/battle-arena/src/render/hud.ts
@@ -1040,10 +1040,11 @@ export class Hud {
   }
 
   /** Center reticle: fire-expand on your swings, gold/crit flash on your hits
-   *  (fed by fx.localHits). Hidden while unlocked / shopping / dead / touch. */
+   *  (fed by fx.localHits). Hidden while unlocked / shopping / dead. Touch is
+   *  FPS-framed too (look stick turns the view), so it keeps the crosshair. */
   private updateReticle(w: World, me: Unit): void {
     const touch = document.body.classList.contains("ba-touch-on");
-    const show = me.alive && !this.shopOpen && !touch && document.pointerLockElement !== null;
+    const show = me.alive && !this.shopOpen && (touch || document.pointerLockElement !== null);
     if (show !== this.reticleVisible) {
       this.reticleVisible = show;
       this.reticleEl.classList.toggle("show", show);
@@ -1449,7 +1450,6 @@ body.ba-touch-on .ba-item-chip{width:28px;height:28px}
 .ba-item-chip{width:32px;height:32px}
 .ba-buff{width:22px;height:22px}
 #ba-objective{display:none}
-#ba-reticle{display:none!important}
 #ba-goal-banner{font-size:14px;padding:9px 14px}
 #ba-hint{bottom:calc(186px + env(safe-area-inset-bottom));font-size:13px}
 #ba-intro{font-size:54px}

--- a/games/battle-arena/src/scenes/game-scene.ts
+++ b/games/battle-arena/src/scenes/game-scene.ts
@@ -189,9 +189,8 @@ export class GameScene {
       this.statusEl.textContent = "";
       this.hud.update(this.world, me, this.controls.scoreHeld());
       // listener facing must match the CAMERA frame so stereo pan tracks the
-      // screen — on touch the camera is fixed at -y (see follow() below)
-      if (this.touch?.active) this.fx.audio.setListener(me.x, me.y, 0, -1);
-      else this.fx.audio.setListener(me.x, me.y, this.aimX, this.aimY);
+      // screen — the camera chases the aim on every input source
+      this.fx.audio.setListener(me.x, me.y, this.aimX, this.aimY);
       if (this.touch && me.champId !== this.boundChamp) {
         this.boundChamp = me.champId;
         this.touch.bindChamp(me.champId); // icon backgrounds + keycaps, once
@@ -208,15 +207,18 @@ export class GameScene {
     this.driveMusic(frameDt, me);
     const cx = me ? me.x : 0;
     const cy = me ? me.y : 0;
-    // Touch is twin-stick: both sticks are SCREEN-space, so the camera yaw must
-    // stay fixed at the identity mapping (facing -y ⇒ stick-up = up-screen,
-    // stick-right = right-screen). Chasing behind the aim like desktop would
-    // rotate the frame under the thumbs and flip the sticks.
-    const fixedCam = this.touch?.active === true;
-    const pitch = fixedCam ? 0 : this.controls.aimPitch();
-    const faceX = fixedCam ? 0 : this.aimX;
-    const faceY = fixedCam ? -1 : this.aimY;
-    this.view.follow(cx, cy, faceX, faceY, pitch, rdt, terrainHeight(cx, cy));
+    // Every input source is FPS-framed: the camera chases behind the aim with
+    // the crosshair dead center (touch turns the view via the right stick, so
+    // both sticks stay camera-relative and never flip under the thumbs).
+    this.view.follow(
+      cx,
+      cy,
+      this.aimX,
+      this.aimY,
+      this.controls.aimPitch(),
+      rdt,
+      terrainHeight(cx, cy),
+    );
     this.view.tickAura(this.world.gameTime);
     this.environment.setLocalPos(cx, cy); // proximity-driven decor (fountain rims)
     if (me) this.environment.setHomeSlot(me.slot); // own fountain never warns
@@ -259,7 +261,7 @@ export class GameScene {
       return;
     }
     const me = this.localUnit();
-    if (me) this.readInput(me, true);
+    if (me) this.readInput(me, true, frameDt);
     this.acc += frameDt;
     let n = 0;
     while (this.acc >= SIM_DT && n < 5) {
@@ -423,7 +425,7 @@ export class GameScene {
     }
 
     const me = this.localUnit();
-    if (me) this.readInput(me, this.amHost);
+    if (me) this.readInput(me, this.amHost, frameDt);
 
     if (this.amHost) {
       this.becomeHostIfNeeded();
@@ -449,8 +451,17 @@ export class GameScene {
     }
   }
 
+  /** Compose forward/strafe into a world-space vector relative to the aim
+   *  ((-aimY, aimX) is screen-right when looking along the aim). */
+  private rotateToAim(fwd: number, strafe: number): { x: number; y: number } {
+    return {
+      x: this.aimX * fwd - this.aimY * strafe,
+      y: this.aimY * fwd + this.aimX * strafe,
+    };
+  }
+
   /** Read controls → apply locally (host) or send as an intent (guest). */
-  private readInput(me: Unit, host: boolean): void {
+  private readInput(me: Unit, host: boolean, dt: number): void {
     // MOUSE mode while a menu owns the cursor (shop, end screen); ACTION mode
     // (locked pointer) the rest of the match. Controls no-ops when unchanged.
     this.controls.setMouseMode(this.hud.isShopOpen || this.world.phase === "ended");
@@ -462,39 +473,37 @@ export class GameScene {
     let attack: boolean;
     let castPoint: { x: number; y: number };
 
-    if (this.touch?.active) {
-      const a = this.touch.aimVec();
-      if (a) {
-        this.aimX = a.x;
-        this.aimY = a.y;
-      }
-      mv = this.touch.moveVec();
-      attack = this.touch.attackDown();
-      castPoint = { x: me.x + this.aimX * 8, y: me.y + this.aimY * 8 };
-    } else {
-      // FPS-centered aim: heading comes from mouse turn, crosshair is dead
-      // center. The character faces the crosshair; camera trails behind.
-      if (!this.aimInit) {
-        this.controls.setYaw(Math.atan2(me.aimX, me.aimY));
-        this.aimInit = true;
-      }
-      const yaw = this.controls.aimYaw();
-      this.aimX = Math.sin(yaw);
-      this.aimY = Math.cos(yaw);
-      const { fwd, strafe } = this.controls.moveAxes();
-      const rx = -this.aimY; // screen-right when looking along the aim
-      const ry = this.aimX;
-      let dx = this.aimX * fwd + rx * strafe;
-      let dy = this.aimY * fwd + ry * strafe;
-      const l = Math.hypot(dx, dy);
-      if (l > 0) {
-        dx /= l;
-        dy /= l;
-      }
-      mv = { x: dx, y: dy };
-      attack = this.controls.attackDown();
-      castPoint = { x: me.x + this.aimX * 8, y: me.y + this.aimY * 8 };
+    // FPS-centered aim for EVERY input source: heading comes from mouse turn,
+    // pad stick, or the touch look stick; the crosshair is dead center. The
+    // character faces the crosshair; camera trails behind.
+    if (!this.aimInit) {
+      this.controls.setYaw(Math.atan2(me.aimX, me.aimY));
+      this.aimInit = true;
     }
+    if (this.touch?.active) {
+      // the right stick TURNS the view (pad-rate mapping into yaw/pitch)
+      // instead of aiming in screen space — so the camera tracks the aim
+      const look = this.touch.lookVec();
+      if (look) this.controls.applyStickLook(look.x, look.y, dt);
+    }
+    const yaw = this.controls.aimYaw();
+    this.aimX = Math.sin(yaw);
+    this.aimY = Math.cos(yaw);
+    if (this.touch?.active) {
+      const m = this.touch.moveVec(); // stick axes are y-down; up = forward
+      mv = this.rotateToAim(-m.y, m.x); // analog magnitude carries through
+      attack = this.touch.attackDown();
+    } else {
+      const { fwd, strafe } = this.controls.moveAxes();
+      mv = this.rotateToAim(fwd, strafe);
+      const l = Math.hypot(mv.x, mv.y);
+      if (l > 0) {
+        mv.x /= l;
+        mv.y /= l;
+      }
+      attack = this.controls.attackDown();
+    }
+    castPoint = { x: me.x + this.aimX * 8, y: me.y + this.aimY * 8 };
 
     // JUMP ability: while AIRBORNE an LMB-edge casts the leaping strike and
     // suppresses that frame's basic (a grounded click stays a normal attack).


### PR DESCRIPTION
## What

On mobile, the second (right) joystick changed the character's facing but the camera stayed pinned, so it never behaved like the desktop mouse. Touch now uses the exact same FPS camera path as desktop and gamepad:

- **Right stick turns the view**: its deflection folds into yaw/pitch at the same rates as a physical pad's right stick (`applyStickLook` in `input/controls.ts`), so the camera always chases the direction the character faces, with the crosshair dead center. Auto-fire while the stick is held is unchanged.
- **Left stick is camera-relative**: forward/strafe composed against the aim (analog magnitude preserved), so the sticks never flip under the thumbs as the camera rotates.
- **Center reticle now shows on touch** — including on phones, where a CSS rule force-hid it — with the same fire/hit feedback as desktop.
- Audio listener and camera follow are unified across input sources (the pinned-camera special case is removed); touch hint copy updated ("right stick turn").

## Verification

Drove the game headlessly (Vite dev server + Playwright, emulated touch pointers, `?auto` solo boot):

- Right-stick drag right while held: `controls.yaw` −0.628 rad and `view.camYaw` tracked 1:1; no drift after release.
- Right-stick drag up: pitch +0.35 rad, camera pitch followed.
- Left-stick up: hero moved 2.4 units exactly along the aim direction (dot = 1.000).
- Both sticks at once: turning while walking works; reticle visible.
- Shop open (mouse mode): look stick inert, reticle hidden; both restored on close.

`tsc --noEmit`, oxlint, and oxfmt clean for `games/battle-arena`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA2vtdjQbPAT45RpP8nFku

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2vtdjQbPAT45RpP8nFku)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix mobile twin-stick camera by switching touch to the same FPS look as desktop/gamepad: the right stick turns the view and the camera follows the aim. Movement is now camera-relative, and the reticle shows on touch.

- **Bug Fixes**
  - Right stick on touch maps to yaw/pitch at gamepad rates via `applyStickLook`; removed pinned-camera path.
  - Left stick movement is composed relative to the aim; no stick flipping; analog preserved.
  - Center reticle is visible on touch (incl. phones) with fire/hit feedback; hint text updated to “right stick turn.”
  - Unified camera follow and audio listener across input sources.

<sup>Written for commit 8dc8055f042b995c76de68a175a46d86074ef616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

