### PR TITLE
fix(party): make room state survive hibernation

### DIFF
--- a/apps/party/src/server.ts
+++ b/apps/party/src/server.ts
@@ -15,25 +15,24 @@ type Env = {
   DB: D1Database;
 };
 
-type RoomState = {
-  sharedState: Record<string, unknown>;
-  players: PlayerMap;
-  hostId: string | null;
-  /**
-   * The room's player cap, established by the first connection that advertises
-   * one and sticky thereafter, so a later join that omits the query param
-   * can't bypass it. `null` means no cap was ever advertised (unlimited).
-   */
-  cap: number | null;
-  /** Last time (ms) we heard anything *except a pong* from each connection —
-   *  drives host-liveness migration when a host vanishes ungracefully
-   *  (sleep/crash/network drop) or is merely backgrounded. Pongs are excluded on
-   *  purpose: a hidden tab still pongs, and must still lose the host role. */
-  lastSeen: Record<string, number>;
-  /** Last time (ms) we heard *anything at all*, pongs included — drives eviction.
-   *  A hidden tab keeps this fresh, so backgrounding never removes a player. */
-  lastAlive: Record<string, number>;
-};
+/**
+ * The player as stored on its connection. The two liveness clocks live here,
+ * on the socket's attachment, rather than in an instance-level map — see the
+ * class comment for why that matters under hibernation.
+ *
+ * - `lastAlive`: last time we heard *anything at all*, pongs included — drives
+ *   eviction. A hidden tab keeps this fresh, so backgrounding never removes a
+ *   player.
+ * - `lastSeen`: last time we heard anything *except a pong* — drives
+ *   host-liveness migration when a host vanishes ungracefully or is merely
+ *   backgrounded. Pongs are excluded on purpose: a hidden tab still pongs, and
+ *   must still lose the host role.
+ */
+type StoredPlayer = Player & { lastSeen: number; lastAlive: number };
+
+/** Durable, low-frequency room fields, persisted so they survive hibernation. */
+const HOST_ID_KEY = "hostId";
+const CAP_KEY = "cap";
 
 /**
  * Upper bound on a single room's player cap, regardless of what a client
@@ -71,36 +70,108 @@ const readRoomCap = (ctx: ConnectionContext): number | null => {
 };
 
 export class VgServer extends Server {
-  private room: RoomState = {
-    sharedState: {},
-    players: {},
-    hostId: null,
-    cap: null,
-    lastSeen: {},
-    lastAlive: {},
-  };
+  /**
+   * Room state is split by how it must behave under Cloudflare's WebSocket
+   * Hibernation API, which partyserver uses: an idle Durable Object is evicted
+   * and its instance destroyed, but the open sockets — and their serialized
+   * attachments — survive.
+   *
+   * - Players and their liveness clocks live on each connection's attachment
+   *   (see `StoredPlayer`), NOT in an instance map. A parallel `players` map
+   *   was emptied on every hibernation, after which `onMessage` dropped every
+   *   surviving connection's messages (they were no longer "admitted"), freezing
+   *   those players into ghosts that could never move or be evicted. Deriving
+   *   players from the live sockets makes that unrepresentable.
+   * - `hostId` and `cap` change rarely but MUST persist: a wiped `hostId` makes
+   *   the real host's `state_patch` get rejected as non-host after a wake; a
+   *   wiped `cap` lets a post-wake join exceed it. They're mirrored in memory
+   *   and written through to storage, and rehydrated in `onStart()`.
+   * - `sharedState` is host-authoritative game state streamed ~30×/s. It is
+   *   intentionally NOT persisted: the room only hibernates when idle (nobody
+   *   streaming), and the host re-establishes it within a tick on resume — and
+   *   clients re-send on reconnect. Persisting it would be pure write
+   *   amplification.
+   */
+  private sharedState: Record<string, unknown> = {};
+  private hostId: string | null = null;
+  private cap: number | null = null;
+
+  /** Rehydrate durable fields before any handler runs (partyserver awaits this). */
+  async onStart() {
+    this.hostId = (await this.ctx.storage.get<string | null>(HOST_ID_KEY)) ?? null;
+    this.cap = (await this.ctx.storage.get<number | null>(CAP_KEY)) ?? null;
+  }
+
+  private async setHostId(id: string | null): Promise<void> {
+    this.hostId = id;
+    await this.ctx.storage.put(HOST_ID_KEY, id);
+  }
+
+  private async setCap(cap: number | null): Promise<void> {
+    this.cap = cap;
+    await this.ctx.storage.put(CAP_KEY, cap);
+  }
+
+  /** The stored player for a connection id, or undefined if not admitted. */
+  private storedPlayer(id: string): StoredPlayer | undefined {
+    for (const connection of this.getConnections<StoredPlayer>()) {
+      if (connection.id === id) return connection.state ?? undefined;
+    }
+    return undefined;
+  }
+
+  /** Public player map (no liveness fields) derived from the live sockets. */
+  private players(): PlayerMap {
+    const players: PlayerMap = {};
+    for (const connection of this.getConnections<StoredPlayer>()) {
+      const stored = connection.state;
+      if (stored) players[connection.id] = this.toPlayer(stored);
+    }
+    return players;
+  }
+
+  private toPlayer(stored: StoredPlayer): Player {
+    return { id: stored.id, color: stored.color, hue: stored.hue, state: stored.state };
+  }
+
+  /** Count of admitted players (connections carrying state), optionally minus one. */
+  private playerCount(excludeId?: string): number {
+    let count = 0;
+    for (const connection of this.getConnections<StoredPlayer>()) {
+      if (connection.id === excludeId) continue;
+      if (connection.state) count++;
+    }
+    return count;
+  }
 
   /** Migrate host off a connection we haven't heard from within the liveness
    *  window (it vanished without a clean close). Picks the lowest-id live peer
    *  for determinism. No-op while the host is responsive or no live peer exists. */
-  private checkHostLiveness(): void {
-    const host = this.room.hostId;
+  private async checkHostLiveness(): Promise<void> {
+    const host = this.hostId;
     if (!host) return;
     const now = Date.now();
-    if (now - (this.room.lastSeen[host] ?? 0) <= HOST_LIVENESS_TIMEOUT_MS) return;
-    const next = Object.keys(this.room.players)
-      .filter(
-        (id) => id !== host && now - (this.room.lastSeen[id] ?? 0) <= HOST_LIVENESS_TIMEOUT_MS,
-      )
-      .sort()[0];
+    const hostStored = this.storedPlayer(host);
+    if (hostStored && now - hostStored.lastSeen <= HOST_LIVENESS_TIMEOUT_MS) return;
+
+    let next: Connection<StoredPlayer> | null = null;
+    for (const connection of this.getConnections<StoredPlayer>()) {
+      const stored = connection.state;
+      if (!stored || connection.id === host) continue;
+      if (now - stored.lastSeen > HOST_LIVENESS_TIMEOUT_MS) continue;
+      if (!next || connection.id < next.id) next = connection;
+    }
     if (!next) return; // nobody healthier to hand off to — keep the current host
-    this.room.hostId = next;
-    this.room.lastSeen[next] = now; // grace, so we don't immediately re-migrate
-    const hostMessage: ServerMessage = { type: "host", data: { id: next } };
+
+    // Grace on the new host so we don't immediately re-migrate.
+    const stored = next.state;
+    if (stored) next.setState({ ...stored, lastSeen: now });
+    await this.setHostId(next.id);
+    const hostMessage: ServerMessage = { type: "host", data: { id: next.id } };
     this.broadcast(JSON.stringify(hostMessage), []);
   }
 
-  onConnect(connection: Connection<Player>, ctx: ConnectionContext) {
+  async onConnect(connection: Connection<StoredPlayer>, ctx: ConnectionContext) {
     // The room's effective cap for this admission decision: the sticky cap an
     // earlier admitted client established, or — if none yet — the cap this
     // client advertises. We don't persist the requested cap until we've
@@ -108,11 +179,11 @@ export class VgServer extends Server {
     // cap a room that never accepted it — which would otherwise also bounce
     // later, even uncapped, joins to overflow.
     const requestedCap = readRoomCap(ctx);
-    const cap = this.room.cap ?? requestedCap;
+    const cap = this.cap ?? requestedCap;
 
     // Enforce the room cap before admitting the player. If full, point the
     // client at the overflow sibling and close — the SDK reconnects there.
-    if (cap !== null && Object.keys(this.room.players).length >= cap) {
+    if (cap !== null && this.playerCount(connection.id) >= cap) {
       const fullMessage: ServerMessage = {
         type: "room_full",
         data: { room: nextOverflowRoom(this.name), capacity: cap },
@@ -125,86 +196,89 @@ export class VgServer extends Server {
     // Admitted: establish the room's cap stickily from the first admitted
     // client that advertises one, so a later join that omits `_maxPlayers` (a
     // rogue or stale client) can't bypass the cap legit clients set.
-    if (this.room.cap === null && requestedCap !== null) {
-      this.room.cap = requestedCap;
+    if (this.cap === null && requestedCap !== null) {
+      await this.setCap(requestedCap);
     }
 
+    const now = Date.now();
     const { color, hue } = getColorById(connection.id);
-    const player: Player = {
+    const stored: StoredPlayer = {
       id: connection.id,
       color,
       hue,
       state: {},
+      lastSeen: now,
+      lastAlive: now,
     };
-
-    this.room.players[connection.id] = player;
-    this.room.lastSeen[connection.id] = Date.now();
-    this.room.lastAlive[connection.id] = Date.now();
+    connection.setState(stored);
     void this.scheduleSweep();
-    if (!this.room.hostId) {
-      this.room.hostId = connection.id;
+    if (!this.hostId) {
+      await this.setHostId(connection.id);
     }
     // a fresh join is a good moment to evict a host that vanished while the room
     // was idle — so the newcomer lands in a live game, not a frozen one
-    this.checkHostLiveness();
+    await this.checkHostLiveness();
 
     const syncMessage: ServerMessage = {
       type: "sync",
       data: {
-        players: this.room.players,
-        state: this.room.sharedState,
-        hostId: this.room.hostId!,
+        players: this.players(),
+        state: this.sharedState,
+        hostId: this.hostId ?? connection.id,
       },
     };
     connection.send(JSON.stringify(syncMessage));
 
     const joinedMessage: ServerMessage = {
       type: "player_joined",
-      data: player,
+      data: this.toPlayer(stored),
     };
     this.broadcast(JSON.stringify(joinedMessage), [connection.id]);
   }
 
-  onMessage(sender: Connection<Player>, rawMessage: string): void | Promise<void> {
+  async onMessage(sender: Connection<StoredPlayer>, rawMessage: string): Promise<void> {
     try {
       // Ignore messages from connections that were never admitted — e.g. a
       // capacity-refused connection that sends in the window before its close
-      // settles. Such a connection isn't in `players`, so it must not be able
-      // to broadcast state or events into the room.
-      if (!this.room.players[sender.id]) return;
+      // settles. Such a connection carries no state, so it must not be able to
+      // broadcast into the room. (A connection that survived hibernation keeps
+      // its attachment, so it stays admitted — no false drop.)
+      const stored = sender.state;
+      if (!stored) return;
 
       const message = JSON.parse(rawMessage) as ClientMessage;
+      const now = Date.now();
 
       // Any message at all proves the peer is reachable, so it defers eviction.
-      this.room.lastAlive[sender.id] = Date.now();
-      // But only a non-pong message proves the tab is actually *running*. A
+      // But only a non-pong message proves the tab is actually *running*: a
       // hidden tab still answers pings from its message handler while its rAF
-      // heartbeat is paused, so counting pongs here would keep a backgrounded
-      // host in the host seat forever — the exact thing host-liveness prevents.
-      if (message.type !== "pong") {
-        this.room.lastSeen[sender.id] = Date.now();
-      }
+      // heartbeat is paused, so counting pongs as `lastSeen` would keep a
+      // backgrounded host in the seat forever — the thing host-liveness prevents.
+      // Fold both bumps into a single state write (below), including the state
+      // patch when this is a player_state_patch.
+      const nextSeen = message.type === "pong" ? stored.lastSeen : now;
 
       switch (message.type) {
         case "heartbeat":
         case "pong":
-          // liveness only — the timestamp bumps above are the whole point
+          // liveness only — the timestamp bumps are the whole point
+          sender.setState({ ...stored, lastSeen: nextSeen, lastAlive: now });
           break;
         case "state_patch": {
-          // Shared state is host-authoritative: only the elected host
-          // can write. Non-host writes get a `state` echo back so the
-          // client can rewind its local mirror, and we drop the patch
-          // instead of relaying it.
-          if (sender.id !== this.room.hostId) {
+          sender.setState({ ...stored, lastSeen: nextSeen, lastAlive: now });
+          // Shared state is host-authoritative: only the elected host can
+          // write. Non-host writes get a `state` echo back so the client can
+          // rewind its local mirror, and we drop the patch instead of relaying.
+          if (sender.id !== this.hostId) {
             const echo: ServerMessage = {
               type: "state_patch",
-              data: this.room.sharedState,
+              data: this.sharedState,
             };
             sender.send(JSON.stringify(echo));
             break;
           }
-          this.room.sharedState = {
-            ...this.room.sharedState,
+          this.sharedState = {
+            ...this.sharedState,
             ...message.data,
           };
           const broadcastMessage: ServerMessage = {
@@ -215,20 +289,21 @@ export class VgServer extends Server {
           break;
         }
         case "player_state_patch": {
-          const player = this.room.players[sender.id];
-          if (!player) return;
-
-          player.state = { ...player.state, ...message.data };
-          this.room.players[sender.id] = player;
-
+          sender.setState({
+            ...stored,
+            state: { ...stored.state, ...message.data },
+            lastSeen: nextSeen,
+            lastAlive: now,
+          });
           const updateMessage: ServerMessage = {
             type: "player_state",
-            data: { id: sender.id, state: player.state ?? {} },
+            data: { id: sender.id, state: { ...stored.state, ...message.data } },
           };
           this.broadcast(JSON.stringify(updateMessage), [sender.id]);
           break;
         }
         case "emit": {
+          sender.setState({ ...stored, lastSeen: nextSeen, lastAlive: now });
           const eventMessage: ServerMessage = {
             type: "event",
             data: {
@@ -241,19 +316,20 @@ export class VgServer extends Server {
           break;
         }
         default:
+          sender.setState({ ...stored, lastSeen: nextSeen, lastAlive: now });
           break;
       }
 
       // every inbound message is a chance to notice the host went silent and
       // hand off — guests heartbeat every ~2s, so this fires often enough.
-      this.checkHostLiveness();
+      await this.checkHostLiveness();
     } catch (error) {
       console.error("Error handling message", error);
     }
   }
 
-  onClose(connection: Connection<Player>) {
-    this.removePlayer(connection.id);
+  onClose(connection: Connection<StoredPlayer>) {
+    return this.removePlayer(connection);
   }
 
   /**
@@ -262,80 +338,100 @@ export class VgServer extends Server {
    * Both tear the connection down, so both must reap the player — otherwise the
    * error path leaks a ghost that keeps occupying a slot against the room cap.
    */
-  onError(connection: Connection<Player>) {
-    this.removePlayer(connection.id);
+  onError(connection: Connection<StoredPlayer>) {
+    return this.removePlayer(connection);
   }
 
   /**
    * Pings live connections and evicts the ones that have gone silent past the
-   * eviction window, then reconciles `players` against the connections that
-   * actually exist. Reschedules itself until the room empties, at which point
-   * the alarm stops and the Durable Object is free to shut down.
+   * eviction window. Players are the connections themselves now, so there is no
+   * separate map to reconcile — a ghost with no socket cannot exist. Reschedules
+   * itself until the room empties, at which point the alarm stops and the
+   * Durable Object is free to shut down.
    */
   async onAlarm() {
     const now = Date.now();
-    const pingMessage: ServerMessage = { type: "ping" };
-    const liveIds = new Set<string>();
-    const stale: Connection<Player>[] = [];
+    const pingMessage = JSON.stringify({ type: "ping" } satisfies ServerMessage);
+    const stale: Connection<StoredPlayer>[] = [];
 
-    for (const connection of this.getConnections<Player>()) {
-      liveIds.add(connection.id);
+    for (const connection of this.getConnections<StoredPlayer>()) {
+      const stored = connection.state;
       // Not-yet-admitted connections (room_full, closing) aren't players; leave them.
-      if (!this.room.players[connection.id]) continue;
+      if (!stored) continue;
 
-      const aliveAt = this.room.lastAlive[connection.id] ?? now;
-      if (now - aliveAt > EVICTION_TIMEOUT_MS) stale.push(connection);
-      else connection.send(JSON.stringify(pingMessage));
+      if (now - stored.lastAlive > EVICTION_TIMEOUT_MS) {
+        stale.push(connection);
+        continue;
+      }
+      try {
+        connection.send(pingMessage);
+      } catch {
+        // A send to a socket whose peer is already gone throws — reap it, and
+        // don't let one dead connection abort the sweep (and its reschedule).
+        stale.push(connection);
+      }
     }
 
     // Evict unreachable peers. Closing may not fire `onClose` for a peer that is
     // already gone, so reap explicitly; `removePlayer` is idempotent if it does.
     for (const connection of stale) {
-      connection.close(1001, "idle");
-      this.removePlayer(connection.id);
-    }
-
-    // Belt and braces: a player with no live connection behind it can only be a
-    // ghost, whatever teardown path we missed. This makes the leak unrecoverable
-    // by construction rather than relying on every hook firing.
-    for (const id of Object.keys(this.room.players)) {
-      if (!liveIds.has(id)) this.removePlayer(id);
+      try {
+        connection.close(1001, "idle");
+      } catch {
+        /* already gone */
+      }
+      await this.removePlayer(connection);
     }
 
     await this.scheduleSweep();
   }
 
-  private async scheduleSweep() {
-    if (Object.keys(this.room.players).length === 0) return;
+  private async scheduleSweep(): Promise<void> {
+    // Reschedule while any connection is still open. Read that from the socket
+    // set (restored across hibernation) rather than an in-memory count, so the
+    // ping loop can never stall and starve live idle clients of their pings.
+    let hasConnections = false;
+    for (const _connection of this.getConnections()) {
+      hasConnections = true;
+      break;
+    }
+    if (!hasConnections) return;
+
     const pending = await this.ctx.storage.getAlarm();
     if (pending !== null) return;
     await this.ctx.storage.setAlarm(Date.now() + PING_INTERVAL_MS);
   }
 
-  private removePlayer(id: string) {
+  private async removePlayer(connection: Connection<StoredPlayer>): Promise<void> {
     // A connection refused at capacity (room_full) is closed before being
-    // admitted, so it was never in `players` and no client saw it join. Skip the
-    // cleanup/announce so we don't broadcast a spurious player_left. Doubles as
-    // the idempotency guard for a connection the sweep already evicted.
-    if (!this.room.players[id]) return;
-
-    delete this.room.players[id];
-    delete this.room.lastSeen[id];
-    delete this.room.lastAlive[id];
-    const remainingIds = Object.keys(this.room.players);
+    // admitted, so it carries no state and no client saw it join. Skip the
+    // announce so we don't broadcast a spurious player_left. `player_left` is
+    // idempotent on the client anyway, so a trailing onClose after a sweep is
+    // harmless.
+    if (!connection.state) return;
+    const id = connection.id;
 
     const leftMessage: ServerMessage = {
       type: "player_left",
       data: { id },
     };
-    this.broadcast(JSON.stringify(leftMessage), []);
+    this.broadcast(JSON.stringify(leftMessage), [id]);
 
-    if (this.room.hostId === id) {
-      this.room.hostId = remainingIds[0] ?? null;
-      if (this.room.hostId) {
+    // Remaining admitted players, now that this connection is torn down.
+    let firstRemaining: string | null = null;
+    let remainingCount = 0;
+    for (const other of this.getConnections<StoredPlayer>()) {
+      if (other.id === id || !other.state) continue;
+      remainingCount++;
+      if (firstRemaining === null || other.id < firstRemaining) firstRemaining = other.id;
+    }
+
+    if (this.hostId === id) {
+      await this.setHostId(firstRemaining);
+      if (firstRemaining) {
         const hostMessage: ServerMessage = {
           type: "host",
-          data: { id: this.room.hostId },
+          data: { id: firstRemaining },
         };
         this.broadcast(JSON.stringify(hostMessage), []);
       }
@@ -343,15 +439,13 @@ export class VgServer extends Server {
 
     // Reset the sticky cap AND the shared state once the room empties so the
     // next session starts fresh. Otherwise state set by an earlier session
-    // outlives it on the (still-warm) Durable Object: a wrong cap for a
-    // session that wants the unlimited default, and ghost world state (eaten
-    // pellets, scores, farm tiles) that the next session's clients adopt
-    // before their new host's first broadcast.
-    if (remainingIds.length === 0) {
-      this.room.cap = null;
-      this.room.lastSeen = {};
-      this.room.lastAlive = {};
-      this.room.sharedState = {};
+    // outlives it on the (still-warm) Durable Object: a wrong cap for a session
+    // that wants the unlimited default, and ghost world state (eaten pellets,
+    // scores, farm tiles) that the next session's clients adopt before their new
+    // host's first broadcast.
+    if (remainingCount === 0) {
+      await this.setCap(null);
+      this.sharedState = {};
     }
   }
 }


### PR DESCRIPTION
## Problem
Same root cause as kyh.io's phantom-visitor bug, bigger blast radius. partyserver runs on Cloudflare's WebSocket Hibernation API — an idle Durable Object is evicted and its instance destroyed while sockets survive. The entire room lived in an in-memory \`this.room\`, so every hibernation wiped it:

- players map emptied → \`onMessage\` dropped every surviving connection's messages ("not admitted"), freezing those players into unmovable, un-evictable ghosts
- \`hostId\` wiped → the real host's \`state_patch\` got rejected as non-host on wake
- \`cap\` wiped → a post-wake join could exceed it
- \`lastSeen\`/\`lastAlive\` wiped → eviction + host-liveness timing broke (the churn that surfaced as ghosts on kyh.io)

## Fix — split state by how it must behave under hibernation
- players + both liveness clocks → connection **attachment** (\`StoredPlayer\`), derived from \`getConnections()\`; a ghost with no socket is now unrepresentable
- \`hostId\` + \`cap\` → \`ctx.storage\`, hydrated in \`onStart()\`, written through on change
- \`sharedState\` → stays in-memory: streamed ~30×/s and self-heals on host resume / client reconnect, so a hibernation reset is harmless (persisting would be write amplification)
- reschedule the sweep off the live socket set, not an in-memory count

## Verification
Local behavioral test 10/10: host election, host-authoritative state gating, host migration (~6s), cap/overflow. Eviction is the same path verified on kyh.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ghost players and host/cap desync after Cloudflare WebSocket hibernation by splitting room state across connection attachments and durable storage. Prevents dropped messages, wrong host rejections, and cap overflow when a room wakes.

- **Bug Fixes**
  - Move players and liveness to each connection’s attachment (`StoredPlayer`), derived from `getConnections()`.
  - Persist `hostId` and `cap` in `ctx.storage`; hydrate in `onStart()`.
  - Keep `sharedState` in memory; host re-syncs on resume and clients on reconnect.
  - Sweep/ping reads the live socket set, evicts stale peers safely, and performs deterministic host handoff.

<sup>Written for commit db5dcec0110cafa33b5ba74660f10c956cbcff9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

