### PR TITLE
feat(invites): unrevoke codes and edit max uses

### DIFF
--- a/apps/web/src/components/admin/invite-admin.tsx
+++ b/apps/web/src/components/admin/invite-admin.tsx
@@ -5,7 +5,7 @@ import { Input } from "@repo/ui/components/input";
 import { Skeleton } from "@repo/ui/components/skeleton";
 import { toast } from "@repo/ui/components/sonner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CheckIcon, CopyIcon } from "lucide-react";
+import { CheckIcon, CopyIcon, PencilIcon } from "lucide-react";
 
 import { SkeletonReveal } from "@/components/ui/skeleton-reveal";
 import { useTRPC } from "@/lib/trpc";
@@ -54,11 +54,18 @@ export const InviteAdmin = () => {
       onError: (err) => toast.error(err.message),
     }),
   );
-  const revoke = useMutation(
-    trpc.auth.revokeInvite.mutationOptions({
-      onSuccess: () => {
+  const update = useMutation(
+    trpc.auth.updateInvite.mutationOptions({
+      onSuccess: (_data, variables) => {
         qc.invalidateQueries({ queryKey: trpc.auth.listInvites.queryKey() });
-        toast.success("Code revoked");
+        toast.success(
+          variables.revoked === true
+            ? "Code revoked"
+            : variables.revoked === false
+              ? "Code restored"
+              : "Code updated",
+        );
+        setEditing(null);
       },
       onError: (err) => toast.error(err.message),
     }),
@@ -69,6 +76,8 @@ export const InviteAdmin = () => {
   const [note, setNote] = useState("");
   const [customCode, setCustomCode] = useState("");
   const [copied, setCopied] = useState<string | null>(null);
+  // Row currently having its max-uses edited inline; "" = unlimited.
+  const [editing, setEditing] = useState<{ id: string; maxUses: number | "" } | null>(null);
 
   const trimmedCustomCode = customCode.trim();
 
@@ -199,9 +208,64 @@ export const InviteAdmin = () => {
                     >
                       {status}
                     </span>
-                    <span className="text-muted-foreground shrink-0">
-                      {row.usedCount}/{row.maxUses ?? "∞"} uses
-                    </span>
+                    {editing?.id === row.id ? (
+                      <form
+                        className="flex shrink-0 items-center gap-1"
+                        onSubmit={(e) => {
+                          e.preventDefault();
+                          update.mutate({
+                            id: row.id,
+                            maxUses: editing.maxUses === "" ? null : editing.maxUses,
+                          });
+                        }}
+                      >
+                        <span className="text-muted-foreground">{row.usedCount}/</span>
+                        <Input
+                          type="number"
+                          min={1}
+                          autoFocus
+                          placeholder="∞"
+                          className="h-7 w-16"
+                          value={editing.maxUses}
+                          onChange={(e) =>
+                            setEditing({
+                              id: row.id,
+                              maxUses: e.target.value === "" ? "" : Number(e.target.value) || 1,
+                            })
+                          }
+                        />
+                        <Button
+                          type="submit"
+                          variant="ghost"
+                          size="sm"
+                          loading={
+                            update.isPending &&
+                            update.variables?.id === row.id &&
+                            update.variables?.maxUses !== undefined
+                          }
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setEditing(null)}
+                        >
+                          Cancel
+                        </Button>
+                      </form>
+                    ) : (
+                      <button
+                        type="button"
+                        title="Edit max uses"
+                        className="text-muted-foreground hover:text-foreground inline-flex shrink-0 items-center gap-1"
+                        onClick={() => setEditing({ id: row.id, maxUses: row.maxUses ?? "" })}
+                      >
+                        {row.usedCount}/{row.maxUses ?? "∞"} uses
+                        <PencilIcon className="size-3" />
+                      </button>
+                    )}
                     {row.note && (
                       <span className="text-muted-foreground min-w-0 truncate italic">
                         {row.note}
@@ -226,10 +290,29 @@ export const InviteAdmin = () => {
                           type="button"
                           variant="ghost"
                           size="sm"
-                          loading={revoke.isPending && revoke.variables?.id === row.id}
-                          onClick={() => revoke.mutate({ id: row.id })}
+                          loading={
+                            update.isPending &&
+                            update.variables?.id === row.id &&
+                            update.variables?.revoked === true
+                          }
+                          onClick={() => update.mutate({ id: row.id, revoked: true })}
                         >
                           Revoke
+                        </Button>
+                      )}
+                      {status === "revoked" && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          loading={
+                            update.isPending &&
+                            update.variables?.id === row.id &&
+                            update.variables?.revoked === false
+                          }
+                          onClick={() => update.mutate({ id: row.id, revoked: false })}
+                        >
+                          Unrevoke
                         </Button>
                       )}
                     </span>

--- a/packages/api/src/auth/auth-router.ts
+++ b/packages/api/src/auth/auth-router.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull } from "@repo/db";
+import { and, desc, eq } from "@repo/db";
 import { inviteCode } from "@repo/db/drizzle-schema";
 import { user, verification } from "@repo/db/drizzle-schema-auth";
 import { TRPCError } from "@trpc/server";
@@ -203,19 +203,38 @@ export const authRouter = createTRPCRouter({
       }
     }),
 
-  revokeInvite: adminProcedure
-    .input(z.object({ id: z.string() }))
+  // Revoke, unrevoke, or change the use limit of an existing code. Omitted
+  // fields are left untouched. Lowering `maxUses` below `usedCount` is allowed
+  // and simply exhausts the code; raising it re-opens an exhausted code.
+  updateInvite: adminProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        // `null` = unlimited uses; omit to leave unchanged.
+        maxUses: z.number().int().min(1).nullable().optional(),
+        // `true` revokes now, `false` clears an existing revocation.
+        revoked: z.boolean().optional(),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
-      const [revoked] = await ctx.db
-        .update(inviteCode)
-        .set({ revokedAt: new Date() })
-        .where(and(eq(inviteCode.id, input.id), isNull(inviteCode.revokedAt)))
-        .returning();
+      const patch: Partial<typeof inviteCode.$inferInsert> = {};
+      if (input.maxUses !== undefined) patch.maxUses = input.maxUses;
+      if (input.revoked !== undefined) patch.revokedAt = input.revoked ? new Date() : null;
 
-      if (!revoked) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Code not found or already revoked" });
+      if (Object.keys(patch).length === 0) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Nothing to update" });
       }
 
-      return { code: revoked };
+      const [updated] = await ctx.db
+        .update(inviteCode)
+        .set(patch)
+        .where(eq(inviteCode.id, input.id))
+        .returning();
+
+      if (!updated) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Code not found" });
+      }
+
+      return { code: updated };
     }),
 });


### PR DESCRIPTION
Admins can now unrevoke a revoked invite code and change how many uses a code allows.

## API (`packages/api/src/auth/auth-router.ts`)

- Replaced the single-purpose `revokeInvite` mutation with `updateInvite`, an admin mutation taking `{ id, maxUses?, revoked? }`:
  - `revoked: true` revokes now; `revoked: false` clears the revocation.
  - `maxUses` sets the use limit (`null` = unlimited); raising it re-opens an exhausted code, lowering it below `usedCount` exhausts the code.
  - Omitted fields are untouched; an empty patch is `BAD_REQUEST`, unknown id is `NOT_FOUND`.
- `revokeInvite` had a single caller (the admin UI), so no compat shim is kept.

## Admin UI (`apps/web/src/components/admin/invite-admin.tsx`)

- Revoked codes get an **Unrevoke** button next to the existing Revoke.
- The `used/max uses` counter is now clickable, opening an inline editor (number input, blank = unlimited) with Save/Cancel.
- Per-action loading states discriminate on the mutation variables so only the button that was clicked spins.

## Verification

Exercised end-to-end against the local Miniflare stack (`pnpm dev:web` + seeded D1) via tRPC over HTTP: revoke → edit maxUses while revoked → unrevoke → code validates as redeemable again; empty patch returns 400 and unknown id returns 404. `pnpm typecheck` passes for the changed packages (pre-existing route-tree errors in `@repo/web` are unrelated); lint and format are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8ZYKAWqyEntvQ2Jp2MzZ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8ZYKAWqyEntvQ2Jp2MzZ5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ability for admins to unrevoke invite codes and edit their max uses, with a new flexible API and small UI improvements. Replaces the single-purpose revoke API with `updateInvite`.

- **New Features**
  - Added `trpc.auth.updateInvite` taking `{ id, maxUses?, revoked? }`.
    - `revoked: true` revokes; `false` clears revocation.
    - `maxUses: null` = unlimited. Raising can reopen an exhausted code; lowering below `usedCount` exhausts it.
  - Admin UI: Unrevoke button on revoked codes; inline max-uses editor with Save/Cancel.
  - Scoped loading states so only the triggered action shows a spinner.

- **Migration**
  - Replace calls to `trpc.auth.revokeInvite` with `trpc.auth.updateInvite`.
  - Send only fields to change; empty patches return 400. Unknown `id` returns 404.

<sup>Written for commit 524d8bd3cba0597f9a2e1c276b8e63a4cffd4f14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

