### PR TITLE
feat(party): /health and room inspection endpoints

### DIFF
--- a/apps/party/README.md
+++ b/apps/party/README.md
@@ -16,6 +16,19 @@ Clients connect via WebSocket. The server handles:
 - **Player state** — `player_state_patch` per-player, broadcast to others
 - **Events** — `emit` pass-through for custom game events
 
+## HTTP endpoints
+
+- `GET /health` — liveness probe, answered at the Worker layer (never wakes a
+  Durable Object). Returns `{ ok: true, service: "vibedgames-party" }`.
+- `GET /parties/vg-server/:room` — per-room inspection. Returns aggregate stats
+  only (`{ room, playerCount, capacity, hasHost }`) — never player ids or game
+  state, since room slugs are guessable and games are untrusted code. Wakes the
+  room's Durable Object; with no open connections it sleeps again right after.
+
+There is no global room-listing endpoint: Durable Objects have no "list all
+instances" primitive, and maintaining a registry (KV or a directory DO) isn't
+warranted yet. Inspect rooms by id.
+
 ## Design rationale
 
 Multiplayer is **host-authoritative, last-write-wins**. The elected host (a browser)

--- a/apps/party/src/server.ts
+++ b/apps/party/src/server.ts
@@ -407,6 +407,25 @@ export class VgServer extends Server {
     await this.ctx.storage.setAlarm(Date.now() + PING_INTERVAL_MS);
   }
 
+  /**
+   * HTTP room inspection: `GET /parties/vg-server/:room` returns aggregate
+   * stats for that room. Rooms are addressed by guessable slugs and games are
+   * untrusted code, so this exposes counts only — never player ids, colors, or
+   * game state. Inspecting a room wakes its Durable Object; with no open
+   * connections it goes right back to sleep.
+   */
+  onRequest(request: Request): Response {
+    if (request.method !== "GET") {
+      return Response.json({ error: "method_not_allowed" }, { status: 405 });
+    }
+    return Response.json({
+      room: this.name,
+      playerCount: this.playerCount(),
+      capacity: this.cap,
+      hasHost: this.hostId !== null,
+    });
+  }
+
   private async removePlayer(connection: Connection<Presence>): Promise<void> {
     // A connection refused at capacity (room_full) is closed before being
     // admitted, so it carries no presence and no client saw it join. Skip the
@@ -458,6 +477,12 @@ export class VgServer extends Server {
 
 export default {
   async fetch(request: Request, env: Env) {
+    // Liveness probe. Answered at the Worker layer so it never wakes a
+    // Durable Object — cheap enough for an uptime monitor to hammer.
+    const url = new URL(request.url);
+    if (url.pathname === "/health") {
+      return Response.json({ ok: true, service: "vibedgames-party" });
+    }
     return (await routePartykitRequest(request, env)) || new Response("Not Found", { status: 404 });
   },
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
## What

- `GET /health` — liveness probe answered at the Worker layer, before `routePartykitRequest`, so it never wakes a Durable Object. Cheap enough for an uptime monitor to hammer.
- `GET /parties/vg-server/:room` — per-room inspection via `onRequest` on `VgServer`. Returns `{ room, playerCount, capacity, hasHost }`. Non-GET → 405.

## Why counts only, and why no global listing

- **Security:** room slugs are guessable and games are untrusted code, so the inspection endpoint exposes aggregates only — never player ids, colors, or game state. No auth gate needed for data this coarse.
- **Scope:** Durable Objects have no "list all instances" primitive. A real listing needs a registry (KV or a directory DO) — extra infra that isn't warranted yet. This is the smallest honest version: liveness + per-room stats by id. If a lobby/browse feature ever needs a true room list, that's the moment to add a registry.

Caveat: inspecting a room wakes its DO; with no open connections it sleeps again immediately (no alarm is scheduled without connections).

## Verified

- Live against `wrangler dev`: `/health` → `{"ok":true,"service":"vibedgames-party"}`, `/parties/vg-server/test-room` → `{"room":"test-room","playerCount":0,"capacity":null,"hasHost":false}`, POST → 405, unknown path → 404.
- `@repo/party` typecheck, oxlint, oxfmt, and `pnpm test` all pass. (Full `pnpm verify` hits a pre-existing `@repo/web` typecheck failure in a fresh worktree — stale `routeTree.gen.ts`, unrelated to this change; it fails identically on the base commit.)

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two HTTP endpoints to the party service: a cheap `GET /health` liveness probe and a counts-only room inspection at `GET /parties/vg-server/:room`. Implements the liveness probe and room stats requested in #246.

- **New Features**
  - `GET /health`: answered at the Worker layer; never wakes a Durable Object. Returns `{ ok: true, service: "vibedgames-party" }`.
  - `GET /parties/vg-server/:room`: returns `{ room, playerCount, capacity, hasHost }`. GET only; non-GET returns 405. Wakes the room’s Durable Object briefly if idle.
  - Security: exposes aggregate counts only; no player IDs or game state. No global room listing (requires a registry; out of scope).

<sup>Written for commit 47b97866c0c6eeb845636dbad3f09f1f2edbf790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

