### PR TITLE
fix(multiplayer): don't re-seed initialState on host promotion mid-round

### DIFF
--- a/packages/multiplayer/src/client.ts
+++ b/packages/multiplayer/src/client.ts
@@ -11,6 +11,14 @@ import type {
 import { HEARTBEAT_INTERVAL_MS, ROOM_CAP_QUERY_PARAM } from "./types.js";
 
 export type MultiplayerClientOptions = MultiplayerOptions & {
+  /**
+   * Shared state to seed the room with, applied exactly once per room by the
+   * FIRST host of a still-empty room. It is never re-applied on host
+   * promotion: when the host leaves mid-round and another client is promoted,
+   * the room's live state wins — the new host must not reset it. Rooms that
+   * already have shared state (observed via `sync` or any `state_patch`) are
+   * never re-seeded.
+   */
   initialState?: Record<string, unknown>;
 };
 
@@ -49,6 +57,13 @@ export class MultiplayerClient {
   private socket: PartySocket;
   private listeners = new Set<Listener>();
   private initialStateApplied = false;
+  /** True once authoritative shared state has been observed from the server —
+   *  a non-empty `sync` snapshot or any `state_patch`. Local `_sharedState`
+   *  can't serve as this signal: the constructor pre-seeds it with
+   *  `initialState`, so it is non-empty even before the room has any state.
+   *  Guards `initialState` so a client promoted to host mid-round never
+   *  re-seeds a room that already has live state (issue #240). */
+  private remoteStateSeen = false;
   private options: MultiplayerClientOptions;
   /** True while we reconnect to an overflow room, to mask the interim close. */
   private redirecting = false;
@@ -146,6 +161,7 @@ export class MultiplayerClient {
     this.cap = capacity > 0 ? capacity : this.cap;
     this._connectionStatus = "connecting";
     this.initialStateApplied = false;
+    this.remoteStateSeen = false;
     this._players = {};
     this._hostId = null;
     this._playerId = null;
@@ -323,14 +339,19 @@ export class MultiplayerClient {
           this._playerId = this.socket.id ?? null;
           this._hostId = message.data.hostId;
           this._players = message.data.players;
+          if (Object.keys(message.data.state).length > 0) this.remoteStateSeen = true;
           this._sharedState =
             Object.keys(this._sharedState).length === 0
               ? message.data.state
               : { ...this._sharedState, ...message.data.state };
 
+          // Seed only a genuinely empty room (per remoteStateSeen, the
+          // server's view — not the locally pre-seeded _sharedState). A room
+          // with live state must never be reset by a (re)joining host.
           if (
             message.data.hostId === this.socket.id &&
             !this.initialStateApplied &&
+            !this.remoteStateSeen &&
             this.options.initialState
           ) {
             this.initialStateApplied = true;
@@ -366,10 +387,16 @@ export class MultiplayerClient {
         }
         case "host": {
           this._hostId = message.data.id;
+          // Promotion mid-round must NOT re-seed: a guest promoted after the
+          // host left has never tripped initialStateApplied, so that flag
+          // alone let it wipe the live board (issue #240). Only seed here if
+          // no shared state has ever been observed — i.e. the original host
+          // vanished before seeding an empty room.
           if (
             message.data.id === this.socket.id &&
             this.options.initialState &&
-            !this.initialStateApplied
+            !this.initialStateApplied &&
+            !this.remoteStateSeen
           ) {
             this.initialStateApplied = true;
             this.send({ type: "state_patch", data: this.options.initialState });
@@ -377,6 +404,7 @@ export class MultiplayerClient {
           break;
         }
         case "state_patch": {
+          this.remoteStateSeen = true;
           this._sharedState = { ...this._sharedState, ...message.data };
           break;
         }

--- a/packages/multiplayer/src/client.ts
+++ b/packages/multiplayer/src/client.ts
@@ -320,6 +320,25 @@ export class MultiplayerClient {
     this.notify();
   };
 
+  /**
+   * Seed `options.initialState` iff we are the host of a genuinely empty room.
+   * Emptiness is judged by `remoteStateSeen` (the server's view), not the
+   * locally pre-seeded `_sharedState`: a guest promoted mid-round has never
+   * tripped `initialStateApplied`, and seeding then would wipe the live board
+   * for everyone (issue #240). Called from both `sync` and `host` handlers.
+   */
+  private maybeSeedInitialState(hostId: string): void {
+    if (
+      hostId === this.socket.id &&
+      this.options.initialState &&
+      !this.initialStateApplied &&
+      !this.remoteStateSeen
+    ) {
+      this.initialStateApplied = true;
+      this.send({ type: "state_patch", data: this.options.initialState });
+    }
+  }
+
   private handleMessage = (event: MessageEvent): void => {
     try {
       const message = JSON.parse(event.data) as ServerMessage;
@@ -345,18 +364,7 @@ export class MultiplayerClient {
               ? message.data.state
               : { ...this._sharedState, ...message.data.state };
 
-          // Seed only a genuinely empty room (per remoteStateSeen, the
-          // server's view — not the locally pre-seeded _sharedState). A room
-          // with live state must never be reset by a (re)joining host.
-          if (
-            message.data.hostId === this.socket.id &&
-            !this.initialStateApplied &&
-            !this.remoteStateSeen &&
-            this.options.initialState
-          ) {
-            this.initialStateApplied = true;
-            this.send({ type: "state_patch", data: this.options.initialState });
-          }
+          this.maybeSeedInitialState(message.data.hostId);
 
           // Every reconnect is a brand-new connection server-side, with an empty
           // player state — and `sync` is the one signal that fires on each of
@@ -387,20 +395,7 @@ export class MultiplayerClient {
         }
         case "host": {
           this._hostId = message.data.id;
-          // Promotion mid-round must NOT re-seed: a guest promoted after the
-          // host left has never tripped initialStateApplied, so that flag
-          // alone let it wipe the live board (issue #240). Only seed here if
-          // no shared state has ever been observed — i.e. the original host
-          // vanished before seeding an empty room.
-          if (
-            message.data.id === this.socket.id &&
-            this.options.initialState &&
-            !this.initialStateApplied &&
-            !this.remoteStateSeen
-          ) {
-            this.initialStateApplied = true;
-            this.send({ type: "state_patch", data: this.options.initialState });
-          }
+          this.maybeSeedInitialState(message.data.id);
           break;
         }
         case "state_patch": {


### PR DESCRIPTION
## Problem

`initialStateApplied` is a per-client once-flag. A guest promoted to host mid-round (original host left) never tripped it, so the `host` handler in `packages/multiplayer/src/client.ts` re-sent `options.initialState` — resetting the board/scores for everyone. The `sync` handler had the same hole for a (re)joining host.

## Fix

Track `remoteStateSeen` — set when a `sync` snapshot arrives non-empty or any `state_patch` is received — and require it to be false before seeding in both handlers. Local `_sharedState` can't serve as the guard: the constructor pre-seeds it with `initialState`, so it's non-empty even before the room has state.

Behavior matrix:
- First host of an empty room → still seeds ✅
- Guest promoted mid-round → no longer wipes live state ✅
- Guest promoted in a never-seeded room (host vanished before seeding) → seeds ✅
- Overflow redirect (`room_full`) → flag resets with `initialStateApplied`; fresh shard seeds normally ✅

The React `useMultiplayerState` path was already safe (prev-wins merge); the host-side `isHost && !seeded` seeding pattern documented in the multiplayer skill is unaffected.

`pnpm verify` green (23/23 tasks).

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop re-seeding `initialState` when a guest is promoted to host mid-round to prevent wiping live game state. Seed only when the room is truly empty (fixes #240).

- **Bug Fixes**
  - Added `remoteStateSeen` (set on non-empty `sync` or any `state_patch`) as the server-observed guard instead of local `_sharedState`.
  - Gate seeding via `maybeSeedInitialState()` in `sync` and `host` with `!initialStateApplied && !remoteStateSeen`.
  - Reset `remoteStateSeen` on reconnect/overflow redirects so fresh shards seed correctly.
  - Behavior preserved: first host of an empty room seeds; mid-round promotion does not; promotion in a never-seeded room seeds.

- **Refactors**
  - Extracted `maybeSeedInitialState()` shared by `sync` and `host` handlers.

<sup>Written for commit a7e5dff1dbd7f9de6f300e16ca6e1409c4a79f4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

