### PR TITLE
feat(multiplayer): opt-in event coalescing on sendEvent

### DIFF
--- a/packages/multiplayer/src/client.ts
+++ b/packages/multiplayer/src/client.ts
@@ -22,6 +22,29 @@ const normalizeIds = (ids: string | string[] | undefined): string[] | undefined 
   return Array.isArray(ids) ? ids : [ids];
 };
 
+/** A coalesced event waiting for the next microtask flush. */
+type PendingEvent = {
+  event: string;
+  payload: unknown;
+  to?: string[];
+  except?: string[];
+};
+
+/** Emit-message data with targeting fields omitted (not undefined) when
+ *  untargeted, so plain broadcasts stay byte-identical to the pre-targeting
+ *  wire protocol. */
+const emitData = (
+  event: string,
+  payload: unknown,
+  to: string[] | undefined,
+  except: string[] | undefined,
+): { event: string; payload: unknown; to?: string[]; except?: string[] } => ({
+  event,
+  payload,
+  ...(to ? { to } : {}),
+  ...(except ? { except } : {}),
+});
+
 export type MultiplayerClientOptions = MultiplayerOptions & {
   /**
    * Shared state to seed the room with, applied exactly once per room by the
@@ -109,6 +132,12 @@ export class MultiplayerClient {
   private heartbeatRaf: number | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private lastHeartbeatAt = 0;
+  /** Coalesced events awaiting the microtask flush — latest payload per
+   *  event + target signature. Flushed before any other outgoing game message
+   *  so coalescing can delay an event but never reorder it relative to state
+   *  patches. */
+  private pendingCoalesced = new Map<string, PendingEvent>();
+  private coalesceFlushScheduled = false;
 
   private _connectionStatus: MultiplayerConnectionStatus = "connecting";
   private _playerId: string | null = null;
@@ -203,6 +232,8 @@ export class MultiplayerClient {
     this._hostId = null;
     this._playerId = null;
     this._sharedState = this.options.initialState ?? {};
+    // Queued for a room that never admitted us — don't leak them into the new one.
+    this.pendingCoalesced.clear();
 
     // Mask only the one synchronous close that reconnect() dispatches for the
     // old connection. The server's async close(4001) never reaches
@@ -271,6 +302,7 @@ export class MultiplayerClient {
         ? updater(this._sharedState)
         : { ...this._sharedState, ...updater };
     this._sharedState = next;
+    this.flushCoalescedEvents();
     this.send({ type: "state_patch", data: next });
     this.notify();
   }
@@ -290,6 +322,7 @@ export class MultiplayerClient {
     };
     this._myState = next;
 
+    this.flushCoalescedEvents();
     this.send({ type: "player_state_patch", data: next });
     this.notify();
   }
@@ -299,21 +332,35 @@ export class MultiplayerClient {
    * this one); pass `to`/`except` to target specific player ids instead — e.g.
    * `sendEvent("you_died", { by }, { to: victimId })` or
    * `sendEvent("explosion", at, { except: myId })`.
+   *
+   * With `{ coalesce: true }`, rapid same-type events collapse into one wire
+   * message carrying the latest payload, sent on the next microtask. Pending
+   * coalesced events are flushed ahead of every other outgoing game message
+   * (state patches, non-coalesced events), so opting in bounds message rate
+   * without ever reordering an event relative to the state it annotates.
+   * Coalescing composes with targeting: same-type events aimed at different
+   * recipients coalesce independently, each keeping its own audience.
    */
   sendEvent(event: string, payload: unknown, options?: SendEventOptions): void {
     const to = normalizeIds(options?.to);
     const except = normalizeIds(options?.except);
-    this.send({
-      type: "emit",
-      data: {
-        event,
-        payload,
-        // Omitted (not undefined) when untargeted, so the wire message stays
-        // byte-identical to the pre-targeting protocol for plain broadcasts.
-        ...(to ? { to } : {}),
-        ...(except ? { except } : {}),
-      },
-    });
+    if (options?.coalesce) {
+      // Keyed by event + target signature: two "damage" events aimed at
+      // different victims must not collapse into one (the survivor's payload
+      // would reach the wrong audience).
+      const key = `${event}\u0000${to?.join(",") ?? ""}\u0000${except?.join(",") ?? ""}`;
+      this.pendingCoalesced.set(key, { event, payload, to, except });
+      if (!this.coalesceFlushScheduled) {
+        this.coalesceFlushScheduled = true;
+        Promise.resolve().then(() => {
+          this.coalesceFlushScheduled = false;
+          this.flushCoalescedEvents();
+        });
+      }
+      return;
+    }
+    this.flushCoalescedEvents();
+    this.send({ type: "emit", data: emitData(event, payload, to, except) });
   }
 
   /** Set the onEvent callback. */
@@ -323,6 +370,7 @@ export class MultiplayerClient {
 
   /** Disconnect and clean up. */
   destroy(): void {
+    this.flushCoalescedEvents();
     if (this.heartbeatRaf !== null) {
       rafHost.cancelAnimationFrame?.(this.heartbeatRaf);
       this.heartbeatRaf = null;
@@ -343,6 +391,15 @@ export class MultiplayerClient {
 
   private send(message: ClientMessage): void {
     this.socket.send(JSON.stringify(message));
+  }
+
+  /** Send pending coalesced events now, latest payload per key, in first-queued order. */
+  private flushCoalescedEvents(): void {
+    if (this.pendingCoalesced.size === 0) return;
+    for (const { event, payload, to, except } of this.pendingCoalesced.values()) {
+      this.send({ type: "emit", data: emitData(event, payload, to, except) });
+    }
+    this.pendingCoalesced.clear();
   }
 
   private notify(): void {

--- a/packages/multiplayer/src/types.ts
+++ b/packages/multiplayer/src/types.ts
@@ -60,19 +60,28 @@ export type Player = {
 export type PlayerMap = Record<string, Player>;
 
 /**
- * Delivery targeting for `sendEvent`. Omit for the default broadcast to every
- * player in the room (including the sender).
+ * Options for `MultiplayerClient.sendEvent`. Omit for the default: an
+ * immediate broadcast to every player in the room (including the sender).
  *
  * - `to`: deliver only to these player ids. The sender is included only if its
  *   own id is listed.
  * - `except`: exclude these player ids (applied after `to`, if both given).
+ * - `coalesce`: collapse rapid events sharing an event type AND target into a
+ *   single wire message carrying the latest payload, flushed on the next
+ *   microtask. Ordering is preserved: pending coalesced events are flushed
+ *   before any outgoing state patch or non-coalesced event, so a coalesced
+ *   event never overtakes — nor lags behind — a state update sent around it.
+ *   Use for high-frequency annotations (damage numbers, cursor pings) where
+ *   only the latest value matters.
  *
  * Targeting is enforced by the party server; a server predating it ignores
- * these fields and falls back to broadcasting to everyone.
+ * those fields and falls back to broadcasting to everyone. Coalescing is
+ * client-side only and works against any server.
  */
 export type SendEventOptions = {
   to?: string | string[];
   except?: string | string[];
+  coalesce?: boolean;
 };
 
 export type ClientMessage =


### PR DESCRIPTION
Closes #248

## What

`sendEvent(type, payload, { coalesce: true })` — opt-in coalescing for high-frequency events (damage numbers, cursor pings) where only the latest value per event type matters.

## Design

The issue's stated race — an event beating (or trailing) the state update it annotates — comes from games throttling their own state sends while events go out immediately. The fix is coalescing **with an ordering guarantee**, both handled client-side:

- Coalesced events land in a `Map<eventType, payload>` (latest payload wins) and flush on the next microtask — a synchronous burst becomes one wire message per event type.
- Pending coalesced events are flushed **ahead of every other outgoing game message** (`state_patch`, `player_state_patch`, non-coalesced `emit`). Coalescing can delay an event, but can never reorder it relative to state patches or other events: program order is preserved on the wire.
- `redirectTo` (room-overflow) clears the pending queue — those events targeted a room that never admitted us. `destroy()` flushes best-effort before closing.

## Compatibility

- Default path (no options) is byte-identical on the wire; the third parameter is optional everywhere (client + React hook).
- Client-only: the server relay is untouched — a coalesced event is an ordinary `emit` by the time it's sent.
- Microtask scheduling uses `Promise.resolve().then(...)` (pure ES) — no DOM/timer globals, so the package still typechecks in the workers context.

## Verification

`pnpm verify` passes (typecheck, lint, format, all tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in event coalescing to collapse rapid same‑type events into one message per microtask while preserving ordering with state patches and other emits. Addresses #248 and reduces wire chatter without changing default behavior.

- **New Features**
  - `sendEvent(event, payload, { coalesce: true })` collapses rapid same‑type events (per target via `to`/`except`) to the latest payload and flushes on the next microtask.
  - Coalesced events flush before any `state_patch`, `player_state_patch`, or non‑coalesced `emit` to preserve program order.

- **Migration**
  - No changes if you don’t use coalescing; existing calls behave the same.
  - To opt in, pass `{ coalesce: true }` to `sendEvent`; the React hook now accepts the same options.

<sup>Written for commit 5ece1d49648bfe42bc799e2dd6da510f7fb178c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

