### PR TITLE
feat(multiplayer): targeted events (to/except) on sendEvent

### DIFF
--- a/apps/party/src/server.ts
+++ b/apps/party/src/server.ts
@@ -93,6 +93,16 @@ const nextOverflowRoom = (room: string): string => {
   return `${room}${OVERFLOW_SEP}2`;
 };
 
+/**
+ * Read a `to`/`except` id list off an untrusted client message: only a real
+ * array counts (null = field absent or malformed), and non-string entries are
+ * dropped rather than failing the whole event.
+ */
+const readIdList = (value: string[] | undefined): string[] | null => {
+  if (!Array.isArray(value)) return null;
+  return value.filter((id) => typeof id === "string");
+};
+
 /** Read the client-requested player cap, clamped to the hard ceiling. */
 const readRoomCap = (ctx: ConnectionContext): number | null => {
   const raw = new URL(ctx.request.url).searchParams.get(ROOM_CAP_QUERY_PARAM);
@@ -447,7 +457,30 @@ export class VgServer extends Server {
               from: sender.id,
             },
           };
-          this.broadcast(JSON.stringify(eventMessage), []);
+          const raw = JSON.stringify(eventMessage);
+          // Targeting is additive to the wire protocol: absent fields mean the
+          // historical broadcast-to-all (sender included). Ids come from an
+          // untrusted client, so re-validate the shape instead of trusting the
+          // parsed type.
+          const to = readIdList(message.data.to);
+          const except = readIdList(message.data.except);
+          if (to === null && except === null) {
+            this.broadcast(raw, []);
+            break;
+          }
+          if (to === null) {
+            this.broadcast(raw, except ?? []);
+            break;
+          }
+          // `to` wins, minus `except`; deliver only to admitted players so a
+          // capacity-refused connection can never be reached by id.
+          const targets = new Set(to);
+          const excluded = new Set(except ?? []);
+          for (const connection of this.getConnections<Presence>()) {
+            if (!connection.state) continue;
+            if (!targets.has(connection.id) || excluded.has(connection.id)) continue;
+            connection.send(raw);
+          }
           break;
         }
         default:

--- a/apps/party/src/server.ts
+++ b/apps/party/src/server.ts
@@ -464,10 +464,6 @@ export class VgServer extends Server {
           // parsed type.
           const to = readIdList(message.data.to);
           const except = readIdList(message.data.except);
-          if (to === null && except === null) {
-            this.broadcast(raw, []);
-            break;
-          }
           if (to === null) {
             this.broadcast(raw, except ?? []);
             break;

--- a/packages/multiplayer/src/client.ts
+++ b/packages/multiplayer/src/client.ts
@@ -6,6 +6,7 @@ import type {
   MultiplayerOptions,
   Player,
   PlayerMap,
+  SendEventOptions,
   ServerMessage,
 } from "./types.js";
 import {
@@ -13,6 +14,13 @@ import {
   RECONNECT_TOKEN_QUERY_PARAM,
   ROOM_CAP_QUERY_PARAM,
 } from "./types.js";
+
+/** Accept a single id or a list; undefined stays undefined so the field can be
+ *  omitted from the wire message entirely. */
+const normalizeIds = (ids: string | string[] | undefined): string[] | undefined => {
+  if (ids === undefined) return undefined;
+  return Array.isArray(ids) ? ids : [ids];
+};
 
 export type MultiplayerClientOptions = MultiplayerOptions & {
   /**
@@ -286,9 +294,26 @@ export class MultiplayerClient {
     this.notify();
   }
 
-  /** Send a custom event to all players. */
-  sendEvent(event: string, payload: unknown): void {
-    this.send({ type: "emit", data: { event, payload } });
+  /**
+   * Send a custom event. By default it is broadcast to all players (including
+   * this one); pass `to`/`except` to target specific player ids instead — e.g.
+   * `sendEvent("you_died", { by }, { to: victimId })` or
+   * `sendEvent("explosion", at, { except: myId })`.
+   */
+  sendEvent(event: string, payload: unknown, options?: SendEventOptions): void {
+    const to = normalizeIds(options?.to);
+    const except = normalizeIds(options?.except);
+    this.send({
+      type: "emit",
+      data: {
+        event,
+        payload,
+        // Omitted (not undefined) when untargeted, so the wire message stays
+        // byte-identical to the pre-targeting protocol for plain broadcasts.
+        ...(to ? { to } : {}),
+        ...(except ? { except } : {}),
+      },
+    });
   }
 
   /** Set the onEvent callback. */

--- a/packages/multiplayer/src/index.ts
+++ b/packages/multiplayer/src/index.ts
@@ -7,6 +7,7 @@ export type {
   Player,
   PlayerMap,
   ClientMessage,
+  SendEventOptions,
   ServerMessage,
 } from "./types.js";
 export {

--- a/packages/multiplayer/src/react.ts
+++ b/packages/multiplayer/src/react.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 
-import type { MultiplayerOptions, PlayerMap } from "./types.js";
+import type { MultiplayerOptions, PlayerMap, SendEventOptions } from "./types.js";
 import { MultiplayerClient } from "./client.js";
 import type { MultiplayerClientOptions, MultiplayerSnapshot } from "./client.js";
 
@@ -21,7 +21,7 @@ export type MultiplayerRoom<TShared = Record<string, unknown>> = MultiplayerSnap
       | Record<string, unknown>
       | ((previous: Record<string, unknown>) => Record<string, unknown>),
   ) => void;
-  sendEvent: (event: string, payload: unknown) => void;
+  sendEvent: (event: string, payload: unknown, options?: SendEventOptions) => void;
 };
 
 export type UseMultiplayerRoomConfig<TShared> = MultiplayerOptions & {
@@ -102,7 +102,8 @@ export function useMultiplayerRoom<
   );
 
   const sendEvent = useCallback(
-    (event: string, payload: unknown) => client.sendEvent(event, payload),
+    (event: string, payload: unknown, options?: SendEventOptions) =>
+      client.sendEvent(event, payload, options),
     [client],
   );
 

--- a/packages/multiplayer/src/types.ts
+++ b/packages/multiplayer/src/types.ts
@@ -59,10 +59,28 @@ export type Player = {
 
 export type PlayerMap = Record<string, Player>;
 
+/**
+ * Delivery targeting for `sendEvent`. Omit for the default broadcast to every
+ * player in the room (including the sender).
+ *
+ * - `to`: deliver only to these player ids. The sender is included only if its
+ *   own id is listed.
+ * - `except`: exclude these player ids (applied after `to`, if both given).
+ *
+ * Targeting is enforced by the party server; a server predating it ignores
+ * these fields and falls back to broadcasting to everyone.
+ */
+export type SendEventOptions = {
+  to?: string | string[];
+  except?: string | string[];
+};
+
 export type ClientMessage =
   | { type: "state_patch"; data: Record<string, unknown> }
   | { type: "player_state_patch"; data: Record<string, unknown> }
-  | { type: "emit"; data: { event: string; payload: unknown } }
+  // `to`/`except` are additive so servers and clients on either side of the
+  // targeting feature interoperate: absent fields mean broadcast-to-all.
+  | { type: "emit"; data: { event: string; payload: unknown; to?: string[]; except?: string[] } }
   // Liveness ping sent on an interval so the server can detect a host that has
   // gone away ungracefully (laptop sleep, crashed tab, dropped network) without
   // waiting for the WebSocket's much-longer TCP timeout, and migrate host.

--- a/plugins/game-features/skills/multiplayer/SKILL.md
+++ b/plugins/game-features/skills/multiplayer/SKILL.md
@@ -197,6 +197,11 @@ const onPointerMove = (e: PointerEvent) => {
 ```tsx
 room.sendEvent("explosion", { x: 100, y: 200 });
 
+// Target specific players instead of broadcasting: `to` delivers only to those
+// ids (sender included only if listed), `except` excludes ids.
+room.sendEvent("you_died", { by: killerId }, { to: victimId });
+room.sendEvent("taunt", { line }, { except: room.playerId ?? [] });
+
 // Receive via onEvent config:
 const room = useMultiplayerRoom({
   host,


### PR DESCRIPTION
Closes #242

The relay only had a broadcast-only `emit`/`event` pair — there was no way to send "you died" to one player without every client receiving and filtering it. This adds Colyseus-style targeting.

## API

```ts
client.sendEvent("you_died", { by }, { to: victimId });          // one player
client.sendEvent("round_start", data, { to: [a, b] });           // several
client.sendEvent("explosion", at, { except: client.playerId ?? [] }); // everyone else
```

`to`/`except` take a single id or a list. Recipients = (`to` ?? all players) minus `except`; sender is included only when it matches. Available on `MultiplayerClient.sendEvent` and the React `room.sendEvent`; `SendEventOptions` is exported.

## Wire protocol & compatibility

- `to`/`except` are **additive optional fields** on the existing `emit` message. Untargeted sends omit them, so plain broadcasts stay byte-identical to the pre-targeting protocol.
- **Old client → new server:** no fields → broadcast to all, exactly as before.
- **New client → old server:** the old server reads only `event`/`payload`, so targeting degrades to broadcast (documented on `SendEventOptions`).
- Server re-validates the id lists at the boundary (untrusted client input) and only delivers `to` events to admitted connections.

## Notes

- Skill docs: added a 4-line targeting example to the Events section of the multiplayer skill.
- `pnpm verify` green (typecheck 23/23, lint, format, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add targeted multiplayer events via `sendEvent(event, payload, { to, except })` so games can message specific players without broadcasting. Backward compatible across client/server versions; untargeted sends remain byte-identical and old servers ignore targeting.

- **New Features**
  - `sendEvent("you_died", data, { to: id | [ids] })` and `sendEvent("explosion", data, { except: id | [ids] })`.
  - `to` delivers only to listed ids; `except` excludes after `to`. Sender is included only if listed.
  - Server (`apps/party`) validates id lists and delivers only to admitted connections.
  - React `room.sendEvent` passes options through; `SendEventOptions` exported from `packages/multiplayer`.
  - Docs: added targeting examples in the multiplayer skill.

- **Refactors**
  - Simplified `emit` handler in `apps/party` by collapsing the redundant untargeted-broadcast branch.

<sup>Written for commit bdf29cb61806f0c0637e0b49f4e10c5bbd958845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

