### PR TITLE
feat(multiplayer): payload validation (server hardening + client schema hook)

### DIFF
--- a/apps/party/src/server.ts
+++ b/apps/party/src/server.ts
@@ -4,7 +4,9 @@ import { routePartykitRequest, Server } from "partyserver";
 import type { ClientMessage, Player, PlayerMap, ServerMessage } from "@vibedgames/multiplayer";
 import {
   EVICTION_TIMEOUT_MS,
+  findStructuralIssue,
   HOST_LIVENESS_TIMEOUT_MS,
+  MAX_MESSAGE_BYTES,
   PING_INTERVAL_MS,
   RECONNECT_GRACE_MS,
   RECONNECT_TOKEN_QUERY_PARAM,
@@ -245,6 +247,18 @@ export class VgServer extends Server {
   }
 
   /**
+   * Structural guard for an untrusted patch payload; true means drop the
+   * message. Shared by both patch handlers so the check and its logging can't
+   * drift apart.
+   */
+  private rejectMalformed(sender: Connection<Presence>, data: unknown, label: string): boolean {
+    const issue = findStructuralIssue(data);
+    if (issue === null) return false;
+    console.warn(`Dropping ${label} from ${sender.id}: ${issue}`);
+    return true;
+  }
+
+  /**
    * Mark a connection heard-from on the keepalive channel. `seen` is true for a
    * non-pong keepalive (heartbeat) — the signal a backgrounded tab stops sending.
    */
@@ -397,12 +411,20 @@ export class VgServer extends Server {
       const presence = sender.state;
       if (!presence) return;
 
+      // Refuse oversized frames before parsing: the platform would drop a
+      // >1 MiB frame anyway, and parsing near-limit garbage burns DO CPU.
+      if (rawMessage.length > MAX_MESSAGE_BYTES) {
+        console.warn(`Dropping oversized message (${rawMessage.length} units) from ${sender.id}`);
+        return;
+      }
+
       const message = JSON.parse(rawMessage) as ClientMessage;
 
       switch (message.type) {
         case "player_state_patch": {
           // Hot path: snapshot + broadcast only. Liveness rides the heartbeat/
           // pong keepalive channel, so a per-tick stream costs no attachment write.
+          if (this.rejectMalformed(sender, message.data, "player_state_patch")) break;
           const next = { ...(this.snapshots.get(sender.id) ?? {}), ...message.data };
           this.snapshots.set(sender.id, next);
           const updateMessage: ServerMessage = {
@@ -425,6 +447,10 @@ export class VgServer extends Server {
             sender.send(JSON.stringify(echo));
             break;
           }
+          // The merge below spreads `data` into shared state, so a non-object
+          // root (string/array) would scatter index keys into every room's
+          // state; depth/forbidden-key checks bound what untrusted games store.
+          if (this.rejectMalformed(sender, message.data, "state_patch")) break;
           this.shared = {
             ...this.shared,
             ...message.data,

--- a/packages/multiplayer/src/client.ts
+++ b/packages/multiplayer/src/client.ts
@@ -14,6 +14,7 @@ import {
   RECONNECT_TOKEN_QUERY_PARAM,
   ROOM_CAP_QUERY_PARAM,
 } from "./types.js";
+import type { MultiplayerSchemas, SchemaViolation } from "./validation.js";
 
 /** Accept a single id or a list; undefined stays undefined so the field can be
  *  omitted from the wire message entirely. */
@@ -55,6 +56,12 @@ export type MultiplayerClientOptions = MultiplayerOptions & {
    * never re-seeded.
    */
   initialState?: Record<string, unknown>;
+  /**
+   * Optional state schemas (Standard Schema — zod v3.24+, valibot, arktype…).
+   * Outgoing updates that fail validation are blocked before send; incoming
+   * ones are dropped before merge. See `MultiplayerSchemas` for semantics.
+   */
+  schemas?: MultiplayerSchemas;
 };
 
 export type MultiplayerSnapshot = {
@@ -138,6 +145,8 @@ export class MultiplayerClient {
    *  patches. */
   private pendingCoalesced = new Map<string, PendingEvent>();
   private coalesceFlushScheduled = false;
+  /** One warning per client for async schemas — validation must stay sync. */
+  private warnedAsyncSchema = false;
 
   private _connectionStatus: MultiplayerConnectionStatus = "connecting";
   private _playerId: string | null = null;
@@ -157,6 +166,13 @@ export class MultiplayerClient {
     this._onEvent = options.onEvent;
     this._room = options.room;
     this.cap = options.maxPlayers && options.maxPlayers > 0 ? Math.floor(options.maxPlayers) : null;
+
+    // Surface an invalid initialState immediately, at construction, where the
+    // author is looking. Report-only: blocking the seed would leave the room
+    // permanently empty, which bricks a game harder than imperfect data.
+    if (options.initialState) {
+      this.passesSchema("sharedState", "outgoing", options.initialState);
+    }
 
     this.socket = new PartySocket({
       host: options.host,
@@ -301,6 +317,7 @@ export class MultiplayerClient {
       typeof updater === "function"
         ? updater(this._sharedState)
         : { ...this._sharedState, ...updater };
+    if (!this.passesSchema("sharedState", "outgoing", next)) return;
     this._sharedState = next;
     this.flushCoalescedEvents();
     this.send({ type: "state_patch", data: next });
@@ -314,6 +331,7 @@ export class MultiplayerClient {
     if (!this._playerId) return;
     const current = (this._players[this._playerId]?.state as Record<string, unknown>) ?? {};
     const next = typeof updater === "function" ? updater(current) : { ...current, ...updater };
+    if (!this.passesSchema("playerState", "outgoing", next)) return;
 
     const existing = this._players[this._playerId] ?? { id: this._playerId };
     this._players = {
@@ -402,6 +420,52 @@ export class MultiplayerClient {
     this.pendingCoalesced.clear();
   }
 
+  /**
+   * Run the registered schema (if any) for a channel against a candidate FULL
+   * state. Returns whether the state may be used; a failure is reported via
+   * `schemas.onViolation` (default: console.warn). Empty states bypass
+   * validation — rooms and players start empty by protocol, before any seed
+   * or first update arrives. Async schemas can't gate a synchronous game
+   * loop, so they warn once and pass.
+   */
+  private passesSchema(
+    channel: SchemaViolation["channel"],
+    direction: SchemaViolation["direction"],
+    state: Record<string, unknown>,
+    from?: string,
+  ): boolean {
+    const schemas = this.options.schemas;
+    const schema = channel === "sharedState" ? schemas?.sharedState : schemas?.playerState;
+    if (!schema) return true;
+    if (Object.keys(state).length === 0) return true;
+
+    const result = schema["~standard"].validate(state);
+    if (result instanceof Promise) {
+      if (!this.warnedAsyncSchema) {
+        this.warnedAsyncSchema = true;
+        console.warn(
+          "[multiplayer] async schemas are not supported — validation skipped. Use a synchronous schema.",
+        );
+      }
+      return true;
+    }
+    if (!result.issues) return true;
+
+    const violation: SchemaViolation = {
+      channel,
+      direction,
+      issues: result.issues,
+      data: state,
+      ...(from !== undefined ? { from } : {}),
+    };
+    if (schemas?.onViolation) {
+      schemas.onViolation(violation);
+    } else {
+      console.warn(`[multiplayer] ${direction} ${channel} failed schema validation`, result.issues);
+    }
+    return false;
+  }
+
   private notify(): void {
     for (const listener of this.listeners) listener();
   }
@@ -469,11 +533,21 @@ export class MultiplayerClient {
           this._playerId = this.socket.id ?? null;
           this._hostId = message.data.hostId;
           this._players = message.data.players;
+          // remoteStateSeen tracks the SERVER's view, so it is set even when
+          // the local schema rejects the payload — the room has live state
+          // either way, and a promoted host must never re-seed over it.
           if (Object.keys(message.data.state).length > 0) this.remoteStateSeen = true;
-          this._sharedState =
-            Object.keys(this._sharedState).length === 0
-              ? message.data.state
-              : { ...this._sharedState, ...message.data.state };
+          {
+            const merged =
+              Object.keys(this._sharedState).length === 0
+                ? message.data.state
+                : { ...this._sharedState, ...message.data.state };
+            // On violation keep the previous local state — refusing admission
+            // over bad room data would strand the player on "connecting".
+            if (this.passesSchema("sharedState", "incoming", merged)) {
+              this._sharedState = merged;
+            }
+          }
 
           this.maybeSeedInitialState(message.data.hostId);
 
@@ -511,10 +585,15 @@ export class MultiplayerClient {
         }
         case "state_patch": {
           this.remoteStateSeen = true;
-          this._sharedState = { ...this._sharedState, ...message.data };
+          const merged = { ...this._sharedState, ...message.data };
+          if (!this.passesSchema("sharedState", "incoming", merged)) break;
+          this._sharedState = merged;
           break;
         }
         case "player_state": {
+          if (!this.passesSchema("playerState", "incoming", message.data.state, message.data.id)) {
+            break;
+          }
           const existing = this._players[message.data.id] ?? { id: message.data.id };
           this._players = {
             ...this._players,

--- a/packages/multiplayer/src/index.ts
+++ b/packages/multiplayer/src/index.ts
@@ -19,3 +19,12 @@ export {
   PING_INTERVAL_MS,
   EVICTION_TIMEOUT_MS,
 } from "./types.js";
+
+export type {
+  MultiplayerSchemas,
+  SchemaViolation,
+  StandardSchemaV1,
+  StandardSchemaIssue,
+  StandardSchemaResult,
+} from "./validation.js";
+export { findStructuralIssue, MAX_MESSAGE_BYTES, MAX_STATE_DEPTH } from "./validation.js";

--- a/packages/multiplayer/src/validation.ts
+++ b/packages/multiplayer/src/validation.ts
@@ -1,0 +1,126 @@
+/**
+ * Two validation layers, split by where they can actually run:
+ *
+ * 1. STRUCTURAL (server + client): the party server is one shared deployment
+ *    serving every game's rooms, so it can never run per-game schemas — it
+ *    enforces game-agnostic shape limits instead (`findStructuralIssue`,
+ *    `MAX_MESSAGE_BYTES`). These constants live here so the server and SDK
+ *    agree on the same limits.
+ *
+ * 2. GAME SCHEMAS (client only): game authors know their state's shape, so
+ *    they register schemas on `MultiplayerClient` via `schemas` — validated
+ *    before send (fail fast on your own bugs) and on receive (drop other
+ *    clients' malformed data). Schemas use the Standard Schema interface
+ *    (https://standardschema.dev), so zod v3.24+, valibot, arktype, or any
+ *    compliant validator plugs in without this package depending on one.
+ */
+
+/**
+ * Minimal vendored Standard Schema v1 interface (the spec is designed to be
+ * copied, not depended on). Any library exposing `~standard` satisfies it.
+ */
+export type StandardSchemaV1<Input = unknown, Output = Input> = {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (
+      value: unknown,
+    ) => StandardSchemaResult<Output> | Promise<StandardSchemaResult<Output>>;
+  };
+};
+
+export type StandardSchemaIssue = {
+  readonly message: string;
+  readonly path?: ReadonlyArray<PropertyKey | { readonly key: PropertyKey }> | undefined;
+};
+
+export type StandardSchemaResult<Output> =
+  | { readonly value: Output; readonly issues?: undefined }
+  | { readonly issues: ReadonlyArray<StandardSchemaIssue> };
+
+/**
+ * Ceiling on a single websocket message, in UTF-16 code units (≈ bytes for
+ * ASCII-heavy JSON). Matches Cloudflare's 1 MiB websocket frame limit — a
+ * message this large would be dropped by the platform anyway, so the server
+ * refuses it explicitly instead of half-processing it.
+ */
+export const MAX_MESSAGE_BYTES = 1_048_576;
+
+/**
+ * Maximum nesting depth for shared/player state patches. Real game state is
+ * a few levels deep; hundreds signal either a cycle escaping into JSON or a
+ * deliberately pathological payload built to stack-overflow naive walkers.
+ */
+export const MAX_STATE_DEPTH = 32;
+
+/** Keys that could poison prototypes when patches are merged downstream. */
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// This runs on every state/player patch (the server's per-tick hot path), so
+// it iterates keys without the tuple-array allocations of Object.entries and
+// never recurses into primitives — a big array of numbers costs one typeof
+// per element, keeping the walk proportional to container count, not payload
+// size. The 1 MiB message cap bounds total work.
+const walk = (value: unknown, depth: number): string | null => {
+  if (depth > MAX_STATE_DEPTH) return `nesting exceeds ${MAX_STATE_DEPTH} levels`;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item !== "object" || item === null) continue;
+      const issue = walk(item, depth + 1);
+      if (issue) return issue;
+    }
+    return null;
+  }
+  if (isRecord(value)) {
+    for (const key in value) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+      if (FORBIDDEN_KEYS.has(key)) return `forbidden key "${key}"`;
+      const child = value[key];
+      if (typeof child !== "object" || child === null) continue;
+      const issue = walk(child, depth + 1);
+      if (issue) return issue;
+    }
+  }
+  return null;
+};
+
+/**
+ * Game-agnostic structural check for a state patch: must be a plain object
+ * (a string/array root would spread index keys into room state), bounded in
+ * depth, and free of prototype-polluting keys. Returns a human-readable issue
+ * or null when the patch is acceptable. The party server runs this on every
+ * `state_patch` / `player_state_patch` before merging.
+ */
+export const findStructuralIssue = (data: unknown): string | null => {
+  if (!isRecord(data)) return "patch must be a plain object";
+  return walk(data, 1);
+};
+
+export type SchemaViolation = {
+  /** Which registered schema flagged the data. */
+  channel: "sharedState" | "playerState";
+  /** `outgoing` = blocked before send (local bug); `incoming` = dropped on receive. */
+  direction: "outgoing" | "incoming";
+  /** Player id the data came from, when known (incoming player state). */
+  from?: string;
+  issues: ReadonlyArray<StandardSchemaIssue>;
+  /** The full candidate state that failed (post-merge, not the raw patch). */
+  data: Record<string, unknown>;
+};
+
+export type MultiplayerSchemas = {
+  /**
+   * Validated against the FULL shared state after a patch merges (never a
+   * partial patch), so write it to describe the whole object. States start
+   * empty, so empty objects bypass validation — model required fields
+   * accordingly or seed them via `initialState`.
+   */
+  sharedState?: StandardSchemaV1<unknown, Record<string, unknown>>;
+  /** Validated against a single player's full state. Same empty-object bypass. */
+  playerState?: StandardSchemaV1<unknown, Record<string, unknown>>;
+  /** Observe violations (metrics, dev overlays). Default logs a console.warn. */
+  onViolation?: (violation: SchemaViolation) => void;
+};


### PR DESCRIPTION
Closes #245

## Design

The issue asked for "game authors register Zod schemas, validated server-side". That can't be taken literally: `VgServer` is **one shared deployment serving every game's rooms** — there is no per-game server code, so arbitrary author schemas can never run there. Split accordingly:

**1. Server: structural hardening (game-agnostic, protects every room)** — `apps/party/src/server.ts`
- `state_patch` / `player_state_patch` payloads must pass `findStructuralIssue` before merge/broadcast: plain-object root, depth ≤ 32, no `__proto__`/`constructor`/`prototype` keys. The root check fixes a real bug: the server spread `message.data` unchecked, so a string/array payload scattered index keys (`"0"`, `"1"`, …) into shared state.
- Frames over 1 MiB (Cloudflare's websocket limit) are refused before `JSON.parse`, so near-limit garbage doesn't burn DO CPU.
- Limits sized against real usage: `updateSharedState` streams the whole shared state ~30×/s (pacman's 775-pellet map, starfall's 32-player rooms all sit far under both caps).

**2. Client: bring-your-own-validator schema hook** — `packages/multiplayer`
- New `schemas` option on `MultiplayerClient`: `{ sharedState?, playerState?, onViolation? }`.
- Schemas use the [Standard Schema](https://standardschema.dev) interface (type vendored, ~30 lines) — zod v3.24+, valibot, arktype all satisfy it. **No zod dependency added**; the package's dep list is unchanged.
- Semantics: **outgoing** updates failing validation are blocked before send (fail fast on your own bug); **incoming** ones are dropped before merge (protects against other clients' malformed data). Violations go to `onViolation` (default `console.warn`).
- Validation always runs against the full post-merge state, never a partial patch. Empty states bypass validation (rooms/players start empty by protocol). Async schemas warn once and pass — they can't gate a sync game loop.
- `initialState` is validated at construction, report-only.

Shared constants (`MAX_MESSAGE_BYTES`, `MAX_STATE_DEPTH`) and the structural guard live in `@vibedgames/multiplayer` so server and SDK agree on limits.

## Compatibility
No wire-format change. Old clients keep working; games not passing `schemas` see zero behavior change.

## Verification
`pnpm verify` passes (typecheck, lint, format, tests).

Skill-doc coverage for the new option is left to #250 (docs backlog PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds payload validation to multiplayer: a server-side structural guard and an opt‑in client schema hook to block malformed state. Hardens rooms and lets games validate shared/player state; closes #245.

- **New Features**
  - Client: new `schemas` option on `MultiplayerClient` (Standard Schema v1). Outgoing updates that fail are blocked; incoming ones are dropped. Supports `onViolation` (defaults to console.warn), validates `initialState` at construction (report-only), and warns once for async schemas. Opt-in; no wire-format changes.
  - Shared: export `findStructuralIssue`, `MAX_MESSAGE_BYTES`, and `MAX_STATE_DEPTH` from `@vibedgames/multiplayer` so server and SDK share limits. No new deps; Zod v3.24+, Valibot, or ArkType plug in.

- **Bug Fixes**
  - Server: validate `state_patch`/`player_state_patch` before merge. Require a plain-object root, cap depth at 32, and ban `__proto__`/`constructor`/`prototype` keys. Fixes index-key pollution from non-object patches.
  - Server: drop frames over 1 MiB before parsing to avoid wasted CPU on oversized messages.

<sup>Written for commit f7295669a033f39a950f11cc35782d97ccca3bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

