### PR TITLE
test(party): integration harness with real VgServer + two simulated clients

### DIFF
--- a/apps/party/package.json
+++ b/apps/party/package.json
@@ -7,7 +7,8 @@
     "clean": "rm -rf .cache .turbo .wrangler dist node_modules",
     "deploy": "wrangler deploy --name vibedgames-party",
     "dev": "pnpm with-env wrangler dev",
-    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test test/integration.test.ts",
+    "typecheck": "tsc --noEmit && tsc -p test --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
     "@kyh/tsconfig": "catalog:",
+    "@types/node": "catalog:",
     "partyserver": "^0.5.8",
     "typescript": "catalog:",
     "wrangler": "catalog:"

--- a/apps/party/test/integration.test.ts
+++ b/apps/party/test/integration.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import type { Unstable_DevWorker } from "wrangler";
+import { unstable_dev } from "wrangler";
+
+import type { MultiplayerClientOptions } from "@vibedgames/multiplayer";
+import { MultiplayerClient } from "@vibedgames/multiplayer";
+
+/**
+ * Integration tests that drive the real VgServer — Durable Object, partyserver
+ * routing, wire protocol and all — through wrangler's local runtime
+ * (`unstable_dev` → workerd), with `MultiplayerClient` instances as the
+ * clients. Node 22+ provides the global WebSocket that PartySocket picks up,
+ * and the client's heartbeat falls back to setInterval off-browser, so the SDK
+ * runs here unmodified.
+ */
+
+let worker: Unstable_DevWorker;
+
+before(async () => {
+  worker = await unstable_dev("src/server.ts", {
+    config: "wrangler.jsonc",
+    logLevel: "error",
+    experimental: { disableExperimentalWarning: true },
+  });
+});
+
+after(async () => {
+  await worker.stop();
+});
+
+/** Each test gets its own room, i.e. its own Durable Object instance. */
+let roomCounter = 0;
+const uniqueRoom = (label: string): string => `it-${process.pid}-${roomCounter++}-${label}`;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Poll until `predicate` holds. Deterministic waiting — no fixed sleeps. */
+const waitFor = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out after ${timeoutMs}ms waiting for: ${label}`);
+    }
+    await delay(25);
+  }
+};
+
+const connect = (
+  room: string,
+  options?: Pick<MultiplayerClientOptions, "onEvent">,
+): MultiplayerClient =>
+  new MultiplayerClient({
+    host: `http://${worker.address}:${worker.port}`,
+    party: "vg-server",
+    room,
+    ...options,
+  });
+
+/** Connected + admitted: the server's `sync` sets both status and player id. */
+const admitted = (client: MultiplayerClient): boolean =>
+  client.connectionStatus === "connected" && client.playerId !== null;
+
+test("two clients join the same room and both see each other", async () => {
+  const room = uniqueRoom("join");
+  const clientA = connect(room);
+  const clientB = connect(room);
+  try {
+    await waitFor(() => admitted(clientA) && admitted(clientB), "both clients admitted");
+    await waitFor(
+      () => Object.keys(clientA.players).length === 2 && Object.keys(clientB.players).length === 2,
+      "both clients see 2 players",
+    );
+
+    const aId = clientA.playerId;
+    const bId = clientB.playerId;
+    assert.ok(aId !== null && bId !== null);
+    assert.notEqual(aId, bId);
+    assert.ok(bId !== null && bId in clientA.players, "A sees B");
+    assert.ok(aId !== null && aId in clientB.players, "B sees A");
+  } finally {
+    clientA.destroy();
+    clientB.destroy();
+  }
+});
+
+test("first client to join becomes host, and both clients agree", async () => {
+  const room = uniqueRoom("host");
+  const clientA = connect(room);
+  try {
+    await waitFor(() => admitted(clientA), "first client admitted");
+    assert.equal(clientA.hostId, clientA.playerId, "solo joiner is host");
+    assert.equal(clientA.isHost, true);
+
+    const clientB = connect(room);
+    try {
+      await waitFor(() => admitted(clientB), "second client admitted");
+      assert.equal(clientB.hostId, clientA.playerId, "guest agrees on host");
+      assert.equal(clientB.isHost, false);
+    } finally {
+      clientB.destroy();
+    }
+  } finally {
+    clientA.destroy();
+  }
+});
+
+test("host state_patch propagates to guests; non-host writes are dropped", async () => {
+  const room = uniqueRoom("shared-state");
+  const eventsA: string[] = [];
+  const eventsB: string[] = [];
+  const clientA = connect(room, { onEvent: (event) => eventsA.push(event) });
+  const clientB = connect(room);
+  try {
+    await waitFor(() => admitted(clientA) && admitted(clientB), "both clients admitted");
+    // Which client wins the host election depends on connect order — don't
+    // assume construction order decided it.
+    await waitFor(() => clientA.isHost || clientB.isHost, "a host is elected");
+    const host = clientA.isHost ? clientA : clientB;
+    const guest = clientA.isHost ? clientB : clientA;
+    const hostEvents = clientA.isHost ? eventsA : eventsB;
+
+    host.updateSharedState({ score: 42 });
+    await waitFor(() => guest.sharedState.score === 42, "guest received host patch");
+
+    // Non-host write: the server must drop it. Ordering fence: the server
+    // handles the guest's messages in order, so once its follow-up event
+    // reaches the host, the rogue patch was already processed (and dropped).
+    guest.updateSharedState({ cheat: true });
+    guest.sendEvent("fence", null);
+    await waitFor(() => hostEvents.includes("fence"), "fence event reached host");
+    assert.equal(host.sharedState.cheat, undefined, "host never saw the non-host patch");
+  } finally {
+    clientA.destroy();
+    clientB.destroy();
+  }
+});
+
+test("per-player state propagates to other clients", async () => {
+  const room = uniqueRoom("player-state");
+  const clientA = connect(room);
+  const clientB = connect(room);
+  try {
+    await waitFor(() => admitted(clientA) && admitted(clientB), "both clients admitted");
+
+    clientA.updateMyState({ x: 7, y: 11 });
+    const aId = clientA.playerId;
+    assert.ok(aId !== null);
+    await waitFor(() => {
+      const seen = clientB.players[aId]?.state;
+      return seen !== undefined && seen.x === 7 && seen.y === 11;
+    }, "B sees A's player state");
+  } finally {
+    clientA.destroy();
+    clientB.destroy();
+  }
+});
+
+test("when the host leaves, a remaining guest is promoted", async () => {
+  const room = uniqueRoom("promotion");
+  const clientA = connect(room);
+  const clientB = connect(room);
+  try {
+    await waitFor(() => admitted(clientA) && admitted(clientB), "both clients admitted");
+    await waitFor(() => clientA.isHost || clientB.isHost, "a host is elected");
+    const host = clientA.isHost ? clientA : clientB;
+    const guest = clientA.isHost ? clientB : clientA;
+    const hostPlayerId = host.playerId;
+    assert.ok(hostPlayerId !== null);
+
+    host.destroy();
+
+    await waitFor(() => guest.isHost, "guest promoted to host after host left");
+    await waitFor(
+      () => hostPlayerId !== null && !(hostPlayerId in guest.players),
+      "departed host removed from player map",
+    );
+  } finally {
+    clientA.destroy();
+    clientB.destroy();
+  }
+});

--- a/apps/party/test/tsconfig.json
+++ b/apps/party/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@kyh/tsconfig/base.json",
+  "compilerOptions": {
+    // Tests run under Node (node:test + tsx), not workerd — so Node ambient
+    // types here, while src/ keeps @cloudflare/workers-types. The two globals
+    // conflict, hence the separate project.
+    "types": ["node"]
+  },
+  "include": ["."]
+}

--- a/apps/party/tsconfig.json
+++ b/apps/party/tsconfig.json
@@ -7,5 +7,5 @@
     "types": ["@cloudflare/workers-types"]
   },
   "include": ["."],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "test"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ catalogs:
       version: 4.110.0
     zod:
       specifier: ^4.4.3
-      version: 3.25.76
+      version: 4.4.3
 
 overrides:
   react-hook-form: ^7.72.1
@@ -222,6 +222,9 @@ importers:
       '@kyh/tsconfig':
         specifier: 'catalog:'
         version: 1.1.14
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.1
       partyserver:
         specifier: ^0.5.8
         version: 0.5.8(@cloudflare/workers-types@5.20260708.1)
@@ -272,7 +275,7 @@ importers:
         version: 11.18.0(@tanstack/react-query@5.101.2(react@19.2.7))(@trpc/client@11.18.0(@trpc/server@11.18.0(typescript@7.0.2))(typescript@7.0.2))(@trpc/server@11.18.0(typescript@7.0.2))(react@19.2.7)(typescript@7.0.2)
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(478363b50960934426661c20f40f6199)
+        version: 1.6.23(95fb2c648e722677cc2b3a3bc3f005f4)
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
@@ -728,7 +731,7 @@ importers:
         version: 1.0.20
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(478363b50960934426661c20f40f6199)
+        version: 1.6.23(95fb2c648e722677cc2b3a3bc3f005f4)
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
@@ -8329,7 +8332,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(478363b50960934426661c20f40f6199)
+      better-auth: 1.6.23(95fb2c648e722677cc2b3a3bc3f005f4)
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -8359,7 +8362,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.23(478363b50960934426661c20f40f6199)
+      better-auth: 1.6.23(95fb2c648e722677cc2b3a3bc3f005f4)
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -11010,7 +11013,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
-  better-auth@1.6.23(478363b50960934426661c20f40f6199):
+  better-auth@1.6.23(95fb2c648e722677cc2b3a3bc3f005f4):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260708.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260708.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2))(typescript@7.0.2))(kysely@0.29.3)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2))(sql.js@1.14.1))


### PR DESCRIPTION
Closes #247

## What

Integration-test harness for the multiplayer server: boots the real `VgServer` (Durable Object, partyserver routing, wire protocol) through wrangler's `unstable_dev` → local workerd, and drives it with two real `MultiplayerClient` instances from `node:test`.

## Harness choice

- **`unstable_dev` (wrangler 4.110)** — verified empirically: WebSocket upgrade to `/parties/vg-server/{room}` works against the local workerd, DO + D1 bindings simulated. Chosen over `@cloudflare/vitest-pool-workers` (repo has no vitest; the repo convention is `node --import tsx --test`, per `apps/cli`) and over spawning `wrangler dev` (port/readiness parsing).
- **`@vibedgames/multiplayer` runs in Node unmodified** — Node ≥22 provides the global WebSocket PartySocket picks up, and the client's heartbeat falls back to `setInterval` off-browser. No raw-socket protocol duplication in tests.

## Tests (each in its own room = own DO instance)

- two clients join → both see each other
- first joiner becomes host, both agree
- host `state_patch` propagates; **non-host write dropped** (asserted with an event fence — per-connection ordering, no sleeps)
- per-player state propagates
- host leaves → guest promoted, departed host removed

Deterministic: all waits are predicate-polls with timeouts; tests don't assume which client wins the host election (that raced under turbo's parallel load and was fixed).

## Wiring

- `apps/party` `test` script → picked up by root `pnpm test` / `pnpm verify` (turbo `test` task), fully headless.
- Tests get their own tsconfig project (`test/tsconfig.json`, `types: ["node"]`) because Node ambient types conflict with `@cloudflare/workers-types` used by `src/`; `typecheck` now checks both projects.
- New devDep: `@types/node` (catalog).

## Notes

- workerd prints `Uncaught Error: Network connection lost.` lines when tests tear down client sockets abruptly — cosmetic, from the runtime's socket-error path; exit code is 0 and all assertions pass.
- `pnpm verify` passes; `pnpm test` ran 4× consecutively (turbo parallel load) with zero flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an integration test harness that boots the real `VgServer` via `wrangler` `unstable_dev` and drives it with two `@vibedgames/multiplayer` clients to validate host election and state sync end-to-end. Closes #247.

- **New Features**
  - Boots the Worker locally (workerd; DO + D1 simulated) and connects two real `MultiplayerClient` instances via Node 22’s global WebSocket.
  - Tests: mutual presence, host election, host `state_patch` propagation with non-host writes rejected, per-player state sync, and host-leave promotion. Each test uses its own room/DO.
  - Deterministic waits using predicate polls (no sleeps).
  - Wiring: new `test` script (`node --import tsx --test test/integration.test.ts`), dedicated `test/tsconfig.json` with Node types, app tsconfig excludes `test`, and `typecheck` runs both projects.

- **Dependencies**
  - Added dev dependency `@types/node`.

<sup>Written for commit abb9eb42a925a9e22008dccf5e08bbe64a21b233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

