### PR TITLE
test(party): cover grace, targeting, coalescing, deltas, validation in integration harness

### DIFF
--- a/apps/party/test/integration.test.ts
+++ b/apps/party/test/integration.test.ts
@@ -161,6 +161,307 @@ test("per-player state propagates to other clients", async () => {
   }
 });
 
+// -- Wire-level helpers -------------------------------------------------------
+//
+// Some behaviors are only observable at the wire (per-recipient delta vs full
+// snapshots) or require a client the SDK deliberately doesn't expose (legacy
+// pre-delta clients, abrupt non-1000 closes, a chosen reconnect token). A
+// minimal raw-WebSocket client covers those; everything else uses the real SDK.
+
+/** Structural record view of an unknown value; throws when it isn't one. */
+const toRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`expected a plain object, got: ${JSON.stringify(value)}`);
+  }
+  return Object.fromEntries(Object.entries(value));
+};
+
+type WireMessage = { type: string; data: unknown };
+
+const parseWireMessage = (raw: string): WireMessage => {
+  const record = toRecord(JSON.parse(raw));
+  const { type } = record;
+  if (typeof type !== "string") throw new Error(`message without a type: ${raw}`);
+  return { type, data: record.data };
+};
+
+/**
+ * Raw wire client speaking the party protocol directly. `_pk` is partyserver's
+ * connection-id query param (PartySocket sends one too), so tests can pick
+ * stable player ids for it. Auto-answers server pings so a long test never
+ * gets a raw client evicted.
+ */
+class RawClient {
+  readonly messages: WireMessage[] = [];
+  readonly id: string;
+  closed = false;
+  private ws: WebSocket;
+
+  constructor(room: string, params: Record<string, string>) {
+    const id = params._pk;
+    if (!id) throw new Error("RawClient requires an explicit _pk connection id");
+    this.id = id;
+    const query = new URLSearchParams(params).toString();
+    this.ws = new WebSocket(
+      `ws://${worker.address}:${worker.port}/parties/vg-server/${room}?${query}`,
+    );
+    this.ws.addEventListener("close", () => {
+      this.closed = true;
+    });
+    this.ws.addEventListener("message", (event) => {
+      if (typeof event.data !== "string") return;
+      const message = parseWireMessage(event.data);
+      if (message.type === "ping") {
+        this.ws.send(JSON.stringify({ type: "pong" }));
+        return;
+      }
+      this.messages.push(message);
+    });
+  }
+
+  send(message: Record<string, unknown>): void {
+    this.ws.send(JSON.stringify(message));
+  }
+
+  close(code?: number): void {
+    this.ws.close(code);
+  }
+
+  synced(): boolean {
+    return this.messages.some((message) => message.type === "sync");
+  }
+
+  /** All received messages of one type, data coerced to a record. */
+  received(type: string): Record<string, unknown>[] {
+    return this.messages
+      .filter((message) => message.type === type)
+      .map((message) => toRecord(message.data));
+  }
+}
+
+test("targeted events reach exactly their audience", async () => {
+  const room = uniqueRoom("targeting");
+  const eventsA: string[] = [];
+  const eventsB: string[] = [];
+  const eventsC: string[] = [];
+  const clientA = connect(room, { onEvent: (event) => eventsA.push(event) });
+  const clientB = connect(room, { onEvent: (event) => eventsB.push(event) });
+  const clientC = connect(room, { onEvent: (event) => eventsC.push(event) });
+  try {
+    await waitFor(
+      () => admitted(clientA) && admitted(clientB) && admitted(clientC),
+      "all three admitted",
+    );
+    const bId = clientB.playerId;
+    const cId = clientC.playerId;
+    assert.ok(bId !== null && cId !== null);
+
+    // Per-connection delivery is FIFO, so once the untargeted fence lands
+    // everywhere, any earlier event addressed to that recipient landed too.
+    clientA.sendEvent("secret", null, { to: [bId] });
+    clientA.sendEvent("fence-to", null);
+    await waitFor(
+      () =>
+        eventsA.includes("fence-to") &&
+        eventsB.includes("fence-to") &&
+        eventsC.includes("fence-to"),
+      "fence after to-targeted event reached everyone",
+    );
+    assert.ok(eventsB.includes("secret"), "targeted recipient got the event");
+    assert.ok(!eventsA.includes("secret"), "sender not in `to` list is excluded");
+    assert.ok(!eventsC.includes("secret"), "bystander is excluded");
+
+    clientA.sendEvent("boom", null, { except: [cId] });
+    clientA.sendEvent("fence-except", null);
+    await waitFor(
+      () =>
+        eventsA.includes("fence-except") &&
+        eventsB.includes("fence-except") &&
+        eventsC.includes("fence-except"),
+      "fence after except-targeted event reached everyone",
+    );
+    assert.ok(eventsA.includes("boom"), "sender receives its own except-broadcast");
+    assert.ok(eventsB.includes("boom"), "unexcluded peer receives it");
+    assert.ok(!eventsC.includes("boom"), "excepted peer is excluded");
+  } finally {
+    clientA.destroy();
+    clientB.destroy();
+    clientC.destroy();
+  }
+});
+
+test("coalesced events collapse to the latest payload and never trail the state they precede", async () => {
+  const room = uniqueRoom("coalesce");
+  const clientA = connect(room);
+  try {
+    // A joins alone first so it is deterministically the host (and may write
+    // shared state below).
+    await waitFor(() => admitted(clientA), "A admitted");
+    assert.equal(clientA.isHost, true);
+
+    const arrivals: string[] = [];
+    const clientB = connect(room, {
+      onEvent: (event, payload) => arrivals.push(`event:${event}:${JSON.stringify(payload)}`),
+    });
+    const unsubscribe = clientB.subscribe(() => {
+      if (clientB.sharedState.round === 1 && !arrivals.includes("state:round")) {
+        arrivals.push("state:round");
+      }
+    });
+    try {
+      await waitFor(() => admitted(clientB), "B admitted");
+      await waitFor(() => Object.keys(clientA.players).length === 2, "A sees B");
+
+      // Burst five coalesced events, then a state write in the same tick. The
+      // burst must collapse to ONE wire message carrying the last payload, and
+      // it must arrive before the state patch it precedes.
+      for (let i = 1; i <= 5; i++) {
+        clientA.sendEvent("tick", { i }, { coalesce: true });
+      }
+      clientA.updateSharedState({ round: 1 });
+
+      await waitFor(() => arrivals.includes("state:round"), "B saw the state write");
+      const ticks = arrivals.filter((entry) => entry.startsWith("event:tick:"));
+      assert.equal(ticks.length, 1, `burst collapsed to one event (got: ${ticks.join(", ")})`);
+      assert.equal(ticks[0], 'event:tick:{"i":5}', "latest payload won");
+      assert.ok(
+        arrivals.indexOf(ticks[0]) < arrivals.indexOf("state:round"),
+        "coalesced event arrived before the state patch sent after it",
+      );
+    } finally {
+      unsubscribe();
+      clientB.destroy();
+    }
+  } finally {
+    clientA.destroy();
+  }
+});
+
+test("a dropped player is held in grace, reclaimed by token, and a 1000-close leaves immediately", async () => {
+  const room = uniqueRoom("grace");
+  const clientB = connect(room);
+  const rawId = `raw-grace-${process.pid}`;
+  const token = `tok-grace-${process.pid}`;
+  let rawA: RawClient | null = null;
+  try {
+    await waitFor(() => admitted(clientB), "B admitted");
+
+    rawA = new RawClient(room, { _pk: rawId, _reconnectToken: token });
+    await waitFor(() => rawA?.synced() === true, "raw A synced");
+    rawA.send({ type: "player_state_patch", data: { hp: 5 } });
+    await waitFor(() => clientB.players[rawId]?.state?.hp === 5, "B sees A's state");
+
+    // Abrupt close (≠1000): the seat must be HELD, flagged disconnected.
+    rawA.close(4001);
+    await waitFor(
+      () => clientB.players[rawId]?.connected === false,
+      "B sees A flagged disconnected during grace",
+    );
+    assert.ok(rawId in clientB.players, "A still occupies its seat mid-grace");
+    assert.equal(clientB.players[rawId]?.state?.hp, 5, "held seat keeps its state");
+
+    // Same token returns: seat + state come back, no longer flagged.
+    rawA = new RawClient(room, { _pk: rawId, _reconnectToken: token });
+    await waitFor(() => rawA?.synced() === true, "raw A reclaimed and synced");
+    await waitFor(
+      () => clientB.players[rawId] !== undefined && clientB.players[rawId]?.connected !== false,
+      "B sees A connected again after reclaim",
+    );
+    assert.equal(clientB.players[rawId]?.state?.hp, 5, "reclaimed seat kept its state");
+
+    // Deliberate leave (1000): removed well within the 30s grace window —
+    // waitFor's 10s default timeout is itself the proof of immediacy.
+    rawA.close(1000);
+    await waitFor(() => !(rawId in clientB.players), "1000-close removes the player immediately");
+  } finally {
+    rawA?.close(1000);
+    clientB.destroy();
+  }
+});
+
+test("delta-capable clients get keyed deltas; legacy clients get full snapshots and can still write", async () => {
+  const room = uniqueRoom("deltas");
+  const legacy = new RawClient(room, { _pk: `leg-${process.pid}` });
+  const modern = new RawClient(room, {
+    _pk: `mod-${process.pid}`,
+    _delta: "1",
+    _reconnectToken: `tok-mod-${process.pid}`,
+  });
+  const sdk = connect(room);
+  try {
+    await waitFor(
+      () => legacy.synced() && modern.synced() && admitted(sdk),
+      "all three clients in the room",
+    );
+    const sdkId = sdk.playerId;
+    assert.ok(sdkId !== null);
+
+    sdk.updateMyState({ x: 1, y: 2 });
+    sdk.updateMyState({ y: 3 });
+
+    const statesFor = (client: RawClient): Record<string, unknown>[] =>
+      client
+        .received("player_state")
+        .filter((data) => data.id === sdkId)
+        .map((data) => toRecord(data.state));
+    await waitFor(
+      () => statesFor(legacy).length === 2 && statesFor(modern).length === 2,
+      "both observers saw two player_state messages",
+    );
+
+    // Second update changed only `y`. A legacy observer must still get the
+    // full merged snapshot; a delta-capable one gets just the changed key.
+    assert.deepEqual(statesFor(legacy)[1], { x: 1, y: 3 }, "legacy got the full merged snapshot");
+    assert.deepEqual(statesFor(modern)[1], { y: 3 }, "delta client got only the changed key");
+
+    // A legacy client's full-state write still round-trips.
+    legacy.send({ type: "player_state_patch", data: { a: 1, b: 2 } });
+    await waitFor(() => {
+      const seen = sdk.players[legacy.id]?.state;
+      return seen !== undefined && seen.a === 1 && seen.b === 2;
+    }, "SDK client sees the legacy client's state");
+  } finally {
+    legacy.close(1000);
+    modern.close(1000);
+    sdk.destroy();
+  }
+});
+
+test("malformed and oversized state patches are dropped without harming the room", async () => {
+  const room = uniqueRoom("validation");
+  // Raw host joins first: only the host may write shared state, and only a raw
+  // client can put malformed payloads on the wire.
+  const rawHost = new RawClient(room, { _pk: `val-host-${process.pid}` });
+  const guest = connect(room);
+  try {
+    await waitFor(() => rawHost.synced() && admitted(guest), "host and guest in the room");
+
+    rawHost.send({ type: "state_patch", data: { ["__proto__"]: { polluted: true } } });
+    rawHost.send({ type: "state_patch", data: "not-an-object" });
+    rawHost.send({ type: "state_patch", data: { blob: "x".repeat(1_100_000) } });
+    // Fence: same sender, so the server processed (and dropped) all three
+    // rejects before this valid patch.
+    rawHost.send({ type: "state_patch", data: { ok: 1 } });
+
+    await waitFor(() => guest.sharedState.ok === 1, "valid patch after rejects still lands");
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(guest.sharedState, "__proto__"),
+      false,
+      "prototype-polluting key never reached the guest",
+    );
+    assert.equal(guest.sharedState.blob, undefined, "oversized frame was refused");
+    assert.equal(
+      Object.keys(guest.sharedState).some((key) => /^\d+$/.test(key)),
+      false,
+      "non-object root never scattered index keys into shared state",
+    );
+    assert.equal(rawHost.closed, false, "rejects did not kill the host's connection");
+  } finally {
+    rawHost.close(1000);
+    guest.destroy();
+  }
+});
+
 test("when the host leaves, a remaining guest is promoted", async () => {
   const room = uniqueRoom("promotion");
   const clientA = connect(room);


### PR DESCRIPTION
Extends the integration harness (real workerd Durable Object via `unstable_dev`) from base-protocol coverage to the five features shipped in the multiplayer batch (PRs #258–#266). Suite is now 10 tests; ran 4× consecutively, 10/10 each.

## New coverage

- **Targeting (#262)** — three clients; `{to}` reaches only the listed recipient, `{except}` excludes exactly the excepted peer, untargeted reaches everyone including the sender. Determinism via FIFO fence events.
- **Coalescing (#248/#261)** — a 5-event coalesced burst collapses to ONE wire message carrying the latest payload, and arrives before the `updateSharedState` patch sent after it (the ordering guarantee the feature exists for).
- **Reconnection grace (#238/#244/#266)** — abrupt close (code 4001) holds the seat with `connected: false` and state intact; a new socket presenting the same `_reconnectToken` reclaims id + state; a deliberate 1000-close removes the player immediately (asserted well inside the 30s window).
- **Keyed deltas + legacy compat (#243/#264)** — a raw observer without `_delta` receives full merged `player_state` snapshots while a delta-capable observer receives only the changed key for the same update; a legacy client's full-state writes still round-trip to SDK clients.
- **Validation (#245/#263)** — `__proto__` payloads, non-object roots, and >1 MiB frames are all dropped; a valid patch from the same sender still lands afterwards and the sender's connection survives.

## How

Adds a minimal `RawClient` (raw WebSocket, hand-built `_pk`/`_reconnectToken`/`_delta` query params, structural no-`as` message parsing) for the behaviors the SDK deliberately cannot produce: legacy pre-delta clients, abrupt non-1000 closes, chosen reconnect tokens, and wire-payload inspection. Everything else drives the real `MultiplayerClient`.

Every wait is a predicate poll or an ordering fence; no fixed sleeps anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the integration harness to cover multiplayer features against the real `workerd` Durable Object via `unstable_dev`. Adds five end-to-end tests to validate targeting, coalescing, reconnection grace, keyed deltas/legacy compat, and payload validation.

- **New Features**
  - Targeting: verifies `to` and `except` delivery with FIFO fence for determinism.
  - Coalescing: 5-event burst collapses to one latest-payload message, delivered before the following state patch.
  - Reconnection grace: 4001 close holds seat with `connected: false` and state; same `_reconnectToken` reclaims id/state; 1000 close removes immediately.
  - Keyed deltas & legacy: delta clients receive per-key deltas; legacy observers get full snapshots; legacy full-state writes round-trip to SDK clients.
  - Validation: drops `__proto__`, non-object roots, and >1 MiB frames; valid patch after rejects still lands; sender connection remains open.

- **Refactors**
  - Introduces a minimal RawClient (raw WebSocket) to exercise legacy behavior, abrupt closes, chosen reconnect tokens, and wire-level inspection not available via the SDK.

<sup>Written for commit c409020f10a8f445b191fa12dfae52678fb17efe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

