### PR TITLE
fix(party): duplicate-id-safe connection lookup

### DIFF
--- a/apps/party/src/server.ts
+++ b/apps/party/src/server.ts
@@ -197,10 +197,21 @@ export class VgServer extends Server {
     };
   }
 
-  /** The presence for a connection id, or undefined if not admitted. */
+  /**
+   * The presence for a connection id, or undefined if not admitted. Iterated
+   * rather than getConnection(id): partyserver's hibernating lookup THROWS
+   * when two live sockets share an id — exactly the fast-reconnect race where
+   * a client re-dials before the server sees the old transport die. Returning
+   * the first socket that still has presence attached picks the live one; a
+   * superseded socket has had its presence detached.
+   */
   private presenceOf(id: string): Presence | undefined {
-    const connection = this.getConnection<Presence>(id);
-    return connection?.state ?? undefined;
+    for (const connection of this.getConnections<Presence>()) {
+      if (connection.id !== id) continue;
+      const presence = connection.state;
+      if (presence) return presence;
+    }
+    return undefined;
   }
 
   /** The grace entry holding a seat for this player id, if any. */
@@ -248,16 +259,20 @@ export class VgServer extends Server {
    * that's what "keeping the slot" means.
    */
   private playerCount(excludeId?: string): number {
-    let count = 0;
+    // Seats are counted by player id, not per connection: during a fast
+    // reconnect the re-dial and the not-yet-closed old socket briefly coexist
+    // under one id, and counting both would spuriously bounce a joiner at
+    // cap. The set also collapses a held seat with a live connection of the
+    // same id, matching how players() presents the room.
+    const seated = new Set<string>();
     for (const connection of this.getConnections<Presence>()) {
-      if (connection.id === excludeId) continue;
-      if (connection.state) count++;
+      if (connection.state) seated.add(connection.id);
     }
     for (const entry of this.grace.values()) {
-      if (entry.id === excludeId) continue;
-      count++;
+      seated.add(entry.id);
     }
-    return count;
+    if (excludeId !== undefined) seated.delete(excludeId);
+    return seated.size;
   }
 
   /**


### PR DESCRIPTION
partyserver 0.5.8's `HibernatingConnectionManager.getConnection(id)` throws `More than one connection found for id` when two live sockets share an id (verified against the installed source in node_modules). That's exactly the fast-reconnect race where a client re-dials before the server sees the old transport die — partysocket reuses its client-generated id, so both sockets briefly coexist.

Two call-site fixes in `apps/party/src/server.ts`:

- **`presenceOf()`** — iterates `getConnections()` and returns the first presence-attached match instead of calling the throwing lookup. A superseded socket has had its presence detached, so this picks the live one. Same approach `departPlayer()` already uses (no shared helper: the two loops have different match semantics — `departPlayer` looks for a *different* connection under the same id).
- **`playerCount()`** — counts unique seated player ids (live presence ids plus grace-held ids) instead of raw connections, closing the transient window where one reconnecting player counted twice and a third joiner could be spuriously bounced at the room cap. Also collapses a held seat with a live same-id connection, matching `players()` semantics.

`pnpm verify` green, including the party integration tests (5/5 against real workerd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the fast-reconnect race that caused `partyserver` to throw on duplicate connection ids and could double-count seats. Connection lookup now prefers the live presence, and player count uses unique ids to prevent spurious room-cap rejections.

- **Bug Fixes**
  - `presenceOf()`: iterates `getConnections()` and returns the first presence-attached match, avoiding `HibernatingConnectionManager.getConnection(id)` throwing when two sockets briefly share an id (e.g., `partysocket` reuse).
  - `playerCount()`: counts unique seated player ids (live presence + grace) and applies `excludeId`, preventing reconnects from double-counting and bouncing valid joiners at the cap.

<sup>Written for commit 92ca8f56462ae01a37cc0cc43b26867012a05d82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

