### PR TITLE
chore(multiplayer): oxfmt fix in SKILL.md

### DIFF
--- a/plugins/game-features/skills/multiplayer/SKILL.md
+++ b/plugins/game-features/skills/multiplayer/SKILL.md
@@ -530,7 +530,7 @@ A disconnected game looks identical to a frozen one. Render the status.
 
 ❌ **Treating broadcast and send-to-one as interchangeable.**
 `sendEvent("secret_role", …)` + filtering in `onEvent` means every client
-still *receives* the payload — anyone can read it in DevTools. Deliver
+still _receives_ the payload — anyone can read it in DevTools. Deliver
 private data with `{ to: playerId }`; the server never sends it elsewhere.
 
 ❌ **Treating a working local room as proof production works.**


### PR DESCRIPTION
One-line whitespace fix the docs PR missed; unbreaks `pnpm verify` format check on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix markdown emphasis in `plugins/game-features/skills/multiplayer/SKILL.md` to match `oxfmt` rules, restoring a passing `pnpm verify` format check on main.

<sup>Written for commit db175afe8161b0eef862d8e5f1c0ac5600c86fee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

