### PR TITLE
docs(release-skill): tsBuildInfoFile varies by package; clean .cache too

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,7 +15,7 @@ Cut a new npm version of one or more publishable packages in this repo.
   - `vibedgames` → `apps/cli` → tag prefix `vibedgames@`
   - `@vibedgames/multiplayer` → `packages/multiplayer` → tag prefix `@vibedgames/multiplayer@`
   - `@vibedgames/gamepad` → `packages/gamepad` → tag prefix `@vibedgames/gamepad@`
-- All ship `dist/` built by `tsc`. `tsBuildInfoFile` lives in `dist/.tsbuildinfo` so cleaning dist invalidates incremental cache.
+- All ship `dist/` built by `tsc`. `tsBuildInfoFile` placement VARIES: `apps/cli` keeps it in `dist/.tsbuildinfo` (cleaning dist invalidates it), but `packages/multiplayer` and `packages/gamepad` keep it in `.cache/tsbuildinfo.json` — there, `rm -rf dist` alone makes `tsc` silently emit NOTHING (cache says up-to-date). Always remove both `dist` and `.cache`.
 - `vibedgames` and `@vibedgames/multiplayer` have no internal workspace consumers. `@vibedgames/gamepad` IS consumed in-repo by the example games via `workspace:^`, but `pnpm publish` rewrites that to the published version automatically — no manual downstream sync needed.
 - Current branch: !`git -C /Users/kyh/Documents/Projects/vibedgames rev-parse --abbrev-ref HEAD`
 - Working tree: !`git -C /Users/kyh/Documents/Projects/vibedgames status --short`
@@ -69,7 +69,7 @@ Keep bullets terse — sacrifice grammar for concision. Drop noise like "fix typ
 
 - `pnpm install` from repo root — defensive; deps may be unlinked after a pull.
 - For each target, force a clean build:
-  - `rm -rf <pkg-path>/dist`
+  - `rm -rf <pkg-path>/dist <pkg-path>/.cache` (both — see tsBuildInfoFile note above)
   - `pnpm --filter <pkg-name> build`
 - Verify `dist/` exists and is non-empty.
 


### PR DESCRIPTION
Skill claimed tsbuildinfo lives in `dist/` for all three publishable packages. Only true for apps/cli — multiplayer and gamepad use `.cache/tsbuildinfo.json`, so `rm -rf dist` alone makes tsc silently emit nothing (bit the 0.2.0 release). Step 4 now cleans both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update release docs to clean both `dist` and `.cache` before building, preventing `tsc` from silently skipping emits. Clarifies that `tsBuildInfoFile` lives in `dist` for `apps/cli`, but in `.cache/tsbuildinfo.json` for `@vibedgames/multiplayer` and `@vibedgames/gamepad`.

<sup>Written for commit 6c1780be587bb5bf24653617a1900ec342b1e7e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

