### PR TITLE
chore(cli): move tsbuildinfo out of dist to .cache, matching sibling packages

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,7 +15,7 @@ Cut a new npm version of one or more publishable packages in this repo.
   - `vibedgames` → `apps/cli` → tag prefix `vibedgames@`
   - `@vibedgames/multiplayer` → `packages/multiplayer` → tag prefix `@vibedgames/multiplayer@`
   - `@vibedgames/gamepad` → `packages/gamepad` → tag prefix `@vibedgames/gamepad@`
-- All ship `dist/` built by `tsc`. `tsBuildInfoFile` placement VARIES: `apps/cli` keeps it in `dist/.tsbuildinfo` (cleaning dist invalidates it), but `packages/multiplayer` and `packages/gamepad` keep it in `.cache/tsbuildinfo.json` — there, `rm -rf dist` alone makes `tsc` silently emit NOTHING (cache says up-to-date). Always remove both `dist` and `.cache`.
+- All ship `dist/` built by `tsc`. All three keep `tsBuildInfoFile` at `.cache/tsbuildinfo.json` — NEVER inside `dist/` (it would ship in the tarball; vibedgames ≤0.3.0 did exactly that). Consequence: `rm -rf dist` alone makes `tsc` silently emit NOTHING (cache says up-to-date). Always remove both `dist` and `.cache`.
 - `vibedgames` and `@vibedgames/multiplayer` have no internal workspace consumers. `@vibedgames/gamepad` IS consumed in-repo by the example games via `workspace:^`, but `pnpm publish` rewrites that to the published version automatically — no manual downstream sync needed.
 - Current branch: !`git -C /Users/kyh/Documents/Projects/vibedgames rev-parse --abbrev-ref HEAD`
 - Working tree: !`git -C /Users/kyh/Documents/Projects/vibedgames status --short`

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
-    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+    "tsBuildInfoFile": "./.cache/tsbuildinfo.json"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Unifies `tsBuildInfoFile` at `.cache/tsbuildinfo.json` for all three publishable packages. Side-effect fix: `dist/.tsbuildinfo` was shipping in the published `vibedgames` tarball (confirmed in 0.3.0's file list). Clean-build verified — buildinfo lands in `.cache/`, dist stays clean. Release skill doc updated to the unified convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the CLI’s `tsBuildInfoFile` from `dist/.tsbuildinfo` to `.cache/tsbuildinfo.json`, matching other packages. This prevents the file from being published in the `vibedgames` tarball and keeps `dist/` clean.

- **Bug Fixes**
  - Updated `apps/cli/tsconfig.json` to write build info to `.cache/tsbuildinfo.json`.
  - Updated the release skill doc to reflect the unified convention and note that clean builds should remove both `dist` and `.cache`.

<sup>Written for commit 102f9136e921c4efba120d098abad574b249134a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

