### PR TITLE
docs: sweep READMEs across the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ Your agent picks up the vibedgames skills and CLI. From there, just keep prompti
 Or run it yourself:
 
 ```sh
+npx vibedgames init                                # install the skills into your project
+npx vibedgames new my-game                         # scaffold a Phaser 4 + Vite + TS game
 npx vibedgames login
-npx vibedgames deploy ./dist --slug my-game
+npx vibedgames deploy ./dist --slug my-game        # live at my-game.vibedgames.com
 ```
+
+Full command list: [`apps/cli/README.md`](./apps/cli/README.md).
 
 ## Repo layout
 
@@ -41,14 +45,21 @@ apps/
   party/         PartyServer — real-time multiplayer backend
   games/         Cloudflare Worker — serves deployed games
   cli/           CLI tool (vg) — login, deploy, generate assets, manage games
-games/           Example games
+  factory/       Autonomous agent that builds a game and runs it like a studio
+games/           Example games, all deployed and playable
 packages/
   api/           tRPC routers + better-auth
   db/            Drizzle ORM schema + Cloudflare D1
-  multiplayer/   React hooks for multiplayer
+  multiplayer/   Multiplayer client + React hooks (npm: @vibedgames/multiplayer)
+  gamepad/       Touch + physical controller input (npm: @vibedgames/gamepad)
+  embed/         postMessage bridge between an embedded game and its wrapper
   ui/            Shared UI components (Base UI + Tailwind)
-plugins/         Claude Code plugins — game-building skills bundled with the CLI
+plugins/         Claude Code plugins — the game-building skills the CLI installs
 ```
+
+Every app and package has its own README. Start with [`games/`](./games) for the
+example games, [`plugins/`](./plugins) for the skills, and
+[`apps/factory/`](./apps/factory) for the autonomous build loop.
 
 ## Local development
 
@@ -68,15 +79,31 @@ Full agent-oriented guide, including headless auth: [AGENTS.md](./AGENTS.md).
 ## Common commands
 
 ```sh
-pnpm dev              # all services
+pnpm dev              # all services (excludes example games)
 pnpm dev:web          # web app only
 pnpm dev:party        # multiplayer server only
+pnpm dev:<game>       # one example game (see games/README.md)
 pnpm build            # build everything
 pnpm typecheck        # type check all packages
 pnpm verify           # typecheck + lint + format + test (run before every commit)
 pnpm db:local         # push schema to local D1 + seed dev identity
 pnpm db:push-remote   # push schema to production
+pnpm dogfood          # link the local vg CLI + sync plugin skills into .claude/skills
 ```
+
+Platform workers deploy on push to `main` — never run `wrangler deploy`
+locally. `pnpm format:fix` rewrites the **whole** repo, so format only the files
+you touched.
+
+## Acknowledgements
+
+What this is built on and learned from.
+
+- [phaserjs/template-vite-ts](https://github.com/phaserjs/template-vite-ts)
+- [@chongdashu](https://x.com/chongdashu)
+- [@majidmanzarpour](https://x.com/majidmanzarpour)
+- [@Challacade](https://www.youtube.com/@Challacade)
+- [@pixeqla](https://www.youtube.com/@pixeqla)
 
 ## License
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -22,39 +22,61 @@ vg new <slug> --engine react-r3f # scaffold a React + R3F + drei + Vite + TS sta
 vg new <slug> --engine none      # minimal Vite + TS + canvas (offline; inline)
 vg new <slug> --template owner/repo  # any github degit spec
 vg new <slug> --here             # scaffold into the current directory
-vg init [dir]         # install Claude Code skills into ./.claude/skills
+vg init [--global] [--agents …]  # install/update the vibedgames skills + CLI
+vg update                        # update the CLI and installed skills to latest
 vg login              # authenticate via browser
 vg logout             # clear credentials
 vg whoami             # show current user
 vg deploy [dir]       # deploy a game directory (reads vibedgames.json or --slug)
+vg fork <slug> [target]  # fork a project's shipped source under a new slug
+vg credits            # credit balance + recent usage
+vg factory [args…]    # autonomous game agent (optional plugin, installs on first use)
+vg completions <bash|zsh|fish>   # print shell completions
 
 vg generate run <model> [params]   # run a generative model (waits for result)
 vg generate models [query]        # search/list available models
 vg generate schema <model>        # fetch a model's input/output schema
 vg generate pricing <model>       # fetch pricing for a model
-vg generate status <model> <id>   # check an async request
+vg generate status <model> <id>   # check an async request (--result, --cancel)
 vg generate upload <file>         # upload an asset, get a URL
 vg generate docs <query>          # search generative-model documentation
 ```
 
-`vg skills install` is an alias for `vg init`. Most commands support `--json` for machine-readable output.
+Most commands support `--json` for machine-readable output.
+
+`vg init` shells out to `npx skills add kyh/vibedgames` and installs for Claude
+Code, Cursor and Codex by default (symlinked from a shared `.agents/skills/`);
+`--agents` narrows or widens that, `--global` targets the user directory instead
+of the project. `vg update` runs automatically once a day — disable with
+`VG_NO_AUTO_UPDATE=1`.
+
+`vg factory` is a pure passthrough to the [factory](../factory) binary, which is
+installed as a platform-specific optional package on first use — the CLI itself
+carries none of it.
 
 `vg generate` calls the `generate.forward` tRPC proc — the server holds the
 provider API key, so generation works for any logged-in user with no local keys.
 
-## Using with Claude Code
+## Using with a coding agent
 
-Run `vg init` in your project to drop the full set of game-building skills
-(Phaser, Three.js, Aseprite, asset generation, deploy, etc.) into `./.claude/skills/`.
-Claude picks them up automatically on next session.
+Run `vg init` in your project to install the full set of game-building skills
+(design, Phaser, Three.js, asset generation, multiplayer, deploy — see
+[`plugins/`](../../plugins)). The agent picks them up on its next session.
 
 ## How deploy works
 
-1. Walks the directory, hashes files, validates `index.html` exists
-2. Calls `deploy.create` API — gets presigned R2 upload URLs
-3. Uploads files to R2 with bounded concurrency
-4. Calls `deploy.finalize` — game goes live at `{slug}.vibedgames.com`
+1. Picks the build output (`dist`/`build`/`out`) when the directory is a project root
+2. Walks the directory, hashes files, validates `index.html` exists
+3. Calls `deploy.create` API — gets presigned R2 upload URLs
+4. Uploads files to R2 with bounded concurrency
+5. Calls `deploy.finalize` — game goes live at `{slug}.vibedgames.com`
+
+A forkable source archive is uploaded alongside the build (`--no-source` opts
+out); that is what `vg fork <slug>` downloads.
 
 ## Auth
 
-Uses a polling flow: CLI generates a code, opens the browser, polls until the user confirms. Token stored at `~/.config/vg/auth.json`.
+Uses a device-code polling flow: CLI generates a 6-char code, opens the browser,
+polls until the user confirms. Token stored at `~/.config/vg/auth.json`.
+`VG_TOKEN` overrides it (for CI and headless agents) and `VG_API_URL` points the
+CLI at a non-production API.

--- a/apps/games/README.md
+++ b/apps/games/README.md
@@ -11,6 +11,24 @@ Routes `{slug}.vibedgames.com/*` requests to game files stored in R2, with metad
 3. Stream file from R2 at `games/{gameId}/{deploymentId}/{path}`
 4. Cache headers: 1 min for `index.html`, 1 year immutable for assets
 
+R2 keys are immutable per deployment, so a new deploy is a new prefix — that's
+what makes the long asset cache safe.
+
+## HTML injection
+
+Served `index.html` gets two additions, both no-ops for pages that already
+handle themselves:
+
+- **Freshness** (`freshness.ts`) — a tiny script that, when a tab returns after
+  being hidden ≥5 min or is restored from bfcache, asks `/__vg/version` for the
+  current deployment id and reloads only if a new build shipped. A restored
+  mobile tab can otherwise run a weeks-old build forever. Never fires mid-play.
+- **Share meta** (`share-meta.ts`) — Open Graph tags for pages that ship none:
+  title from the game record, the page's own description, and a cover image
+  (`og.{jpg,png,webp}` at the deployment root, else the platform card). If the
+  HTML contains _any_ `og:` property, the author owns share meta and the page is
+  served untouched.
+
 ## Development
 
 ```sh

--- a/apps/party/README.md
+++ b/apps/party/README.md
@@ -14,13 +14,35 @@ Clients connect via WebSocket. The server handles:
 - **Player join/leave** — auto-assigns colors, host migration
 - **Shared state** — `state_patch` messages merged server-side, broadcast to all
 - **Player state** — `player_state_patch` per-player, broadcast to others
-- **Events** — `emit` pass-through for custom game events
+- **Events** — `emit` pass-through for custom game events, optionally addressed
+  to (`to`) or excluding (`except`) specific player ids
 - **Reconnection grace** — a dropped (non-1000-close) player's seat is held for
   30s keyed by a client-secret reconnect token; peers see `connected: false`
   until reclaim or expiry. Events fired during the window are NOT buffered or
   replayed — only the seat and its state survive; shared state re-syncs on
   reclaim. Deliberate leaves (`destroy()`, close code 1000) skip the grace
   window entirely.
+- **Host liveness** — clients heartbeat on a rAF interval (so a backgrounded tab
+  stops); a host silent past `HOST_LIVENESS_TIMEOUT_MS` loses the role and the
+  server elects a new one, rather than waiting out the TCP timeout. A separate
+  `ping`/`pong` distinguishes "hidden" from "gone" for eviction.
+- **Capacity + overflow** — a client advertises its cap via `_maxPlayers`
+  (clamped to a hard ceiling of 64). A join over the cap is redirected to a
+  sibling room (`{room}~2`, `~3`, …) and reconnects there; a reconnect reclaim
+  is never bounced.
+- **Structural limits** — messages over `MAX_MESSAGE_BYTES` are rejected, and
+  patches are checked for shape (plain objects, bounded depth, no cycles or
+  functions). Game-specific schemas are the client's job — the server never
+  knows a game's shape.
+
+Every wire extension above is feature-detected via a query-param capability flag
+(`_maxPlayers`, `_reconnectToken`, `_delta`), never a protocol version — an old
+published SDK and a current one coexist in the same room. Keep it that way:
+growth here must stay additive.
+
+The message types themselves live in
+[`@vibedgames/multiplayer`](../../packages/multiplayer) and are imported by the
+server, so client and server can never drift on a constant.
 
 ## HTTP endpoints
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,25 +1,54 @@
 # @repo/web
 
-Main web app for vibedgames. Game hub, authentication, dashboard.
+Main web app for vibedgames. Game hub, authentication, dashboard — and the host
+Worker for the tRPC API.
 
 ## Stack
 
 - [TanStack Start](https://tanstack.com/start) + React 19
 - [Cloudflare Workers](https://workers.cloudflare.com) via `@cloudflare/vite-plugin`
 - [better-auth](https://better-auth.com) for authentication
-- [tRPC](https://trpc.io) for API layer
-- [Tailwind CSS 4](https://tailwindcss.com)
+- [tRPC](https://trpc.io) for API layer ([`@repo/api`](../../packages/api) runs inside this Worker)
+- [Tailwind CSS 4](https://tailwindcss.com) + [`@repo/ui`](../../packages/ui)
+
+## Surfaces
+
+| Route                                      | What                                                             |
+| ------------------------------------------ | ---------------------------------------------------------------- |
+| `/`, `/discover`                           | landing + game hub — renders the hardcoded `featuredGames`       |
+| `/build`, `/install`                       | how to build with an agent; CLI install                          |
+| `/home`, `/settings`                       | signed-in dashboard: your games, account, credits                |
+| `/admin`                                   | admin-only: users, invites                                       |
+| `/auth/*`                                  | login, register, password reset, and `cli` (device-code confirm) |
+| `/api/trpc/*`, `/api/auth/*`               | tRPC + better-auth handlers                                      |
+| `/api/r2-upload`, `/api/r2-download`       | local-dev R2 proxy (HMAC-signed, `localhost` Host only)          |
+| `/.well-known/agent-skills/*`              | the vibedgames skills, served for agents to fetch                |
+| `/llms.txt`, `/robots.txt`, `/sitemap.xml` | machine-readable site descriptions                               |
+
+Games themselves are **not** served here — they live on
+`{slug}.vibedgames.com` via [`@repo/games`](../games). Session cookies are
+scoped to the apex domain so untrusted game code on a subdomain can never read
+them.
 
 ## Development
 
 ```sh
-pnpm dev:web
+pnpm dev:web   # once, to create the local D1, then stop it
+pnpm db:local  # push schema + seed dev logins
+pnpm dev:web   # http://localhost:5173
 ```
 
-Runs on `http://localhost:5173`. Uses Cloudflare D1 (local via miniflare) and R2 bindings.
+The local Miniflare D1 and R2 are isolated from production and start empty.
+Address the dev worker as `localhost`, never `127.0.0.1`: the local R2 upload
+proxy keys off the literal Host header, and `127.0.0.1` presigns against
+**production** R2.
 
-For headless local setup (schema push + seeded dev identity), run `pnpm db:local` — see the root `CLAUDE.md` for the full local verification workflow.
+Liveness check: `/auth/login` returns 200 — `/` answers 307 (it redirects to a
+featured game). Seeded logins and headless auth recipes:
+[AGENTS.md](../../AGENTS.md).
 
 ## Environment
 
-Worker secrets go in `apps/web/.dev.vars` for local dev. See `wrangler.jsonc` for bindings.
+Worker secrets (`BETTER_AUTH_SECRET`, `R2_*`, `FAL_API_KEY`) go in
+`apps/web/.dev.vars` — the Worker never reads `process.env`, so putting them in
+the root `.env` silently does nothing. Bindings are declared in `wrangler.jsonc`.

--- a/games/README.md
+++ b/games/README.md
@@ -1,0 +1,57 @@
+# Games
+
+Example games, built with the same `vg` CLI + skills a user's agent gets. They
+are the platform's dogfood: every one is deployed at `{slug}.vibedgames.com`
+and playable, and each has its own README with routes, options and controls.
+
+| Game                               | Engine            | Multiplayer    | Dev                       | Live                            |
+| ---------------------------------- | ----------------- | -------------- | ------------------------- | ------------------------------- |
+| [Battle Arena](./battle-arena)     | Three.js          | online PvP     | `pnpm dev:battle-arena`   | `battle-arena.vibedgames.com`   |
+| [Bomberman](./bomberman)           | Phaser 4          | shared room    | `pnpm dev:bomberman`      | `bomberman.vibedgames.com`      |
+| [Crazy Waymo](./crazy-waymo)       | Three.js + Rapier | shared room    | `pnpm dev:crazy-waymo`    | `crazy-waymo.vibedgames.com`    |
+| [Farm](./farm)                     | Phaser 4          | shared farm    | `pnpm dev:farm`           | `farm.vibedgames.com`           |
+| [Flappy Dragons](./flappy-dragons) | Phaser 4          | shared room    | `pnpm dev:flappy-dragons` | `flappy-dragons.vibedgames.com` |
+| [Lunerfall](./lunerfall)           | Phaser 4          | co-op + versus | `pnpm dev:lunerfall`      | `lunerfall.vibedgames.com`      |
+| [Ancients of Eldermoor](./moba)    | Phaser 4          | online match   | `pnpm dev:moba`           | `moba.vibedgames.com`           |
+| [Pacman](./pacman)                 | Three.js          | shared room    | `pnpm dev:pacman`         | `pacman.vibedgames.com`         |
+| [Pong](./pong)                     | Three.js          | 1v1            | `pnpm dev:pong`           | `pong.vibedgames.com`           |
+| [Starfall](./starfall)             | Phaser 4          | 32p arena      | `pnpm dev:starfall`       | `starfall.vibedgames.com`       |
+| [Tetris](./tetris)                 | Three.js          | —              | `pnpm dev:tetris`         | `tetris.vibedgames.com`         |
+
+Each `pnpm dev:<game>` serves on its own fixed port (see the game's README).
+`pnpm dev` deliberately excludes games — run the one you're working on.
+
+## Conventions
+
+Every game is a standalone Vite app (`@repo/<name>`) — no platform code, only
+the same packages any user's game can install:
+
+- **`@vibedgames/multiplayer`** — host-authoritative rooms. Games degrade to
+  solo/bot play when the party server is unreachable; that fallback is part of
+  the game, not an error path.
+- **`@vibedgames/gamepad`** — touch overlay + physical controllers. Every game
+  ships a `src/controls.ts` manifest so the web app can render its controls.
+- **`@repo/embed`** — postMessage bridge used when the game runs inside the web
+  app's player chrome (`game-started`, pause/resume).
+
+Shared query-param conventions, where a game implements them:
+
+| Param        | What                                                                   |
+| ------------ | ---------------------------------------------------------------------- |
+| `?trailer=1` | scripted, self-driving gameplay trailer (`&loop=1` replays, Esc exits) |
+| `?viewer=1`  | character / animation viewer                                           |
+| `?gallery=…` | asset gallery                                                          |
+| `?editor=1`  | map editor                                                             |
+| `?offline=1` | never dial the party server                                            |
+
+Games with a deterministic sim core also ship a headless harness under
+`tools/` or `scripts/`, wired to `pnpm --filter @repo/<name> test` and picked
+up by the repo-wide `pnpm test`.
+
+## Deploying them
+
+```sh
+pnpm deploy:games   # builds every game + vg deploy each one
+```
+
+Platform workers deploy on push to `main` — never `wrangler deploy` locally.

--- a/games/battle-arena/README.md
+++ b/games/battle-arena/README.md
@@ -8,7 +8,7 @@
 pnpm dev:battle-arena                       # http://localhost:5194
 pnpm --filter @repo/battle-arena typecheck
 pnpm --filter @repo/battle-arena build
-pnpm --filter @repo/battle-arena test       # 60-check headless sim harness (tools/verify-timing.mts)
+pnpm --filter @repo/battle-arena test       # headless sim harness (tools/verify-timing.mts)
 ```
 
 ## Routes

--- a/games/crazy-waymo/README.md
+++ b/games/crazy-waymo/README.md
@@ -8,7 +8,7 @@
 pnpm dev:crazy-waymo                        # http://localhost:5193
 pnpm --filter @repo/crazy-waymo typecheck
 pnpm --filter @repo/crazy-waymo build
-pnpm --filter @repo/crazy-waymo test        # world-gen invariant harness (11 checks, headless)
+pnpm --filter @repo/crazy-waymo test        # headless world-gen invariant harness (tools/test-world.mts)
 pnpm --filter @repo/crazy-waymo test:e2e    # playwright smoke suite (needs a browser)
 ```
 

--- a/games/lunerfall/README.md
+++ b/games/lunerfall/README.md
@@ -8,7 +8,7 @@ TowerFall-feel roguelite dungeon crawl — Phaser, pixel art, five heroes with d
 pnpm dev:lunerfall                        # http://localhost:5192
 pnpm --filter @repo/lunerfall typecheck
 pnpm --filter @repo/lunerfall build
-pnpm --filter @repo/lunerfall test        # 78-check headless sim harness (tools/sim.mts)
+pnpm --filter @repo/lunerfall test        # headless sim harness (tools/sim.mts)
 ```
 
 ## Routes

--- a/games/moba/README.md
+++ b/games/moba/README.md
@@ -8,7 +8,7 @@ Keyboard-first action MOBA (Phaser): two-lane two-island map, 6 heroes, creep wa
 pnpm dev:moba                        # http://localhost:5182
 pnpm --filter @repo/moba typecheck
 pnpm --filter @repo/moba build
-pnpm --filter @repo/moba test        # headless sim smoke (17 checks)
+pnpm --filter @repo/moba test        # headless sim smoke (tools/sim-smoke.mts)
 ```
 
 ## Routes

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -7,9 +7,11 @@ tRPC API layer. Routers, auth configuration, and procedure helpers shared by the
 | Router     | Purpose                                                             |
 | ---------- | ------------------------------------------------------------------- |
 | `auth`     | Session info, device-code flow for CLI login, invite claiming       |
+| `apiKeys`  | Long-lived API keys for headless/CI clients                         |
 | `waitlist` | Waitlist signup                                                     |
 | `deploy`   | Game deploys: create (presigned R2 upload URLs) + finalize          |
 | `generate` | Asset generation proxy for `vg generate` (server holds the API key) |
+| `credits`  | Credit balance + usage over the micro-USD ledger                    |
 | `admin`    | Admin-only operations                                               |
 
 `AppRouter` is the exported type — the CLI imports it for end-to-end type safety without bundling any server code.
@@ -21,7 +23,18 @@ tRPC API layer. Routers, auth configuration, and procedure helpers shared by the
 - `@repo/db` for data access (Drizzle + D1)
 - `aws4fetch` for presigning R2 upload URLs (`src/deploy/r2-presign.ts`)
 
+## Credits
+
+Generation is metered; deploys and hosting are free. `src/credits/` owns the
+append-only micro-USD ledger — balance is `SUM(delta_micro)`, there is no cached
+balance column, and idempotency lives in deterministic entry ids
+(`signup:{userId}`, `hold:{requestId}`, …). `generate.forward` blocks submits at
+balance ≤ 0, debits an estimated hold, settles to actual provider cost, and
+refunds the hold on a failed/cancelled job. Never write ledger rows from outside
+this directory.
+
 ## Notes
 
 - Runs inside the web app's Cloudflare Worker — context carries D1, R2, and auth bindings.
 - R2 types are declared structurally (`R2BucketLike` in `src/trpc.ts`) so `AppRouter` doesn't leak a `@cloudflare/workers-types` dependency to consumers.
+- Local dev presigns through the Worker's R2 binding instead of S3 when the Host header is `localhost` — so `vg deploy` against `http://localhost:5173` never touches production R2. `127.0.0.1` misses that check.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -4,7 +4,7 @@ Drizzle ORM schema + client for Cloudflare D1 (SQLite). **Source of truth for th
 
 ## Schema
 
-- `src/drizzle-schema.ts` — platform tables: `inviteCode`, `waitlist`, `game`, `deployment`, `deploymentFile`
+- `src/drizzle-schema.ts` — platform tables: `inviteCode`, `waitlist`, `game`, `deployment`, `deploymentFile`, `creditEntry` (append-only micro-USD ledger), `generation` (per-request generation lifecycle)
 - `src/drizzle-schema-auth.ts` — better-auth tables (user/session/account) — **generated, don't edit by hand**; regenerate with `pnpm --filter @repo/db generate:auth-schema`
 - `src/drizzle-client.ts` — `Db` client factory bound to a D1 instance
 
@@ -23,9 +23,16 @@ Edit schema → `pnpm db:push-local` → restart `dev:web` if the change doesn't
 
 ## Seed data (`seed.sql`)
 
-- dev user `dev@vibedgames.local` (role `admin`)
-- invite code `DEV123`
+- `user@vibedgames.com` / `password123` — regular user (browser login)
+- `admin@vibedgames.com` / `password123` — admin, owns the sample games
+- `dev@vibedgames.local` — bearer-token identity (role `admin`)
 - long-lived session token `dev-local-session-token-0000000000`
+- invite code `DEV123`, unlimited uses
+- five sample games on the admin account so `/home` and `/admin/users` aren't empty
+
+Re-running the seed replaces rows, which invalidates existing browser sessions —
+sign in again after seeding. `/` and `/discover` never read D1; they render the
+hardcoded `featuredGames` array in the web app.
 
 ## Studio
 

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -1,7 +1,11 @@
 # @repo/embed
 
 Tiny postMessage bridge between an embedded browser game (iframe) and the page
-that wraps it. Zero dependencies.
+that wraps it. Zero dependencies, internal (not published).
+
+The wrapper is the web app's player chrome
+(`apps/web/src/components/game/game-chrome.tsx`); the game side is wired into
+every example game under [`games/`](../../games).
 
 ## Game side
 
@@ -39,3 +43,15 @@ window.addEventListener("message", (event) => {
 // e.g. from a pause button
 requestGamePause(iframe.contentWindow);
 ```
+
+## Which games can actually freeze
+
+`setPauseHandlers` is opt-in per game because freezing is not always correct:
+
+| Game shape                     | Pause handlers                            |
+| ------------------------------ | ----------------------------------------- |
+| Offline, sim-clock driven      | wire them — the sim really stops          |
+| Wall-clock (`Date.now`) driven | skip — the sim would jump on resume       |
+| Live online session            | skip — the room keeps running without you |
+
+Skipping still shows the PAUSED overlay; only the freeze is declined.

--- a/packages/multiplayer/README.md
+++ b/packages/multiplayer/README.md
@@ -1,6 +1,8 @@
 # @vibedgames/multiplayer
 
-Drop-in React hooks for multiplayer browser games. Connect to a [PartyServer](https://partykit.io)-compatible backend and sync state across players with a few lines of code.
+Multiplayer for browser games: a framework-agnostic client plus React hooks.
+Connect to a [PartyServer](https://partykit.io)-compatible backend and sync
+state across players in a few lines.
 
 ## Install
 
@@ -8,22 +10,22 @@ Drop-in React hooks for multiplayer browser games. Connect to a [PartyServer](ht
 npm install @vibedgames/multiplayer
 ```
 
-## Hooks
+Two entry points — pick one:
 
-- `useMultiplayerRoom` — connect to a room, read players and shared state
-- `useMultiplayerState` — sync shared game state (e.g. world, score)
-- `usePlayerState` — sync per-player state (e.g. position, health)
-- `useIsHost` — check if you're the host (first player)
+| Import                          | For                                              |
+| ------------------------------- | ------------------------------------------------ |
+| `@vibedgames/multiplayer`       | `MultiplayerClient` — Phaser, Three.js, any loop |
+| `@vibedgames/multiplayer/react` | `useMultiplayerRoom` and friends                 |
 
-## Quickstart
+## React quickstart
 
 ```tsx
 import {
   useMultiplayerRoom,
-  usePlayerState,
   useMultiplayerState,
+  usePlayerState,
   useIsHost,
-} from "@vibedgames/multiplayer";
+} from "@vibedgames/multiplayer/react";
 
 const room = useMultiplayerRoom({
   host: "https://your-party-server.workers.dev",
@@ -36,22 +38,62 @@ const [me, setMe] = usePlayerState(room, { x: 0, y: 0 });
 const isHost = useIsHost(room);
 ```
 
+- `useMultiplayerRoom` — connect to a room, read players and shared state
+- `useMultiplayerState` — sync shared game state (e.g. world, score)
+- `usePlayerState` — sync per-player state (e.g. position, health)
+- `useIsHost` — is this client the host
+
+## Game-loop quickstart (no React)
+
+The same client the hooks are built on. Read the snapshot each frame; nothing
+re-renders.
+
+```ts
+import { MultiplayerClient } from "@vibedgames/multiplayer";
+
+const client = new MultiplayerClient({
+  host: "https://your-party-server.workers.dev",
+  party: "vg-server",
+  room: "demo",
+  onEvent: (event, payload, from) => queue.push({ event, payload, from }),
+});
+
+// each frame:
+if (client.isHost) client.updateSharedState({ tick });
+client.updateMyState({ x: player.x, y: player.y });
+for (const p of Object.values(client.players)) draw(p);
+
+client.destroy(); // on teardown
+```
+
+`subscribe(listener)` + `getSnapshot()` are there if you'd rather push than
+poll. Only `/react` imports React, so a vanilla game pulls in no framework.
+
+## Model: host-authoritative, last-write-wins
+
+The first player is the host and is the only writer of shared state. Intents go
+up (`sendEvent`), state comes down (`state_patch`). There is no conflict
+resolution and no server-side simulation — so keep authority in one place:
+guests send input, the host mutates the world.
+
+If the host leaves (or its tab is backgrounded long enough to stop
+heartbeating), the server elects a new one. Design for that: state must live in
+`sharedState`, not in the current host's local variables.
+
 ## Shared state
 
-Syncs a single object across all players. Host seeds initial values.
+One object synced to everyone. Patches shallow-merge by key.
 
 ```tsx
-const room = useMultiplayerRoom({
-  host,
-  party,
-  room,
-  initialState: { started: false },
-});
+const room = useMultiplayerRoom({ host, party, room, initialState: { started: false } });
 const [game, setGame] = useMultiplayerState(room);
 
-// Only the host starts the game
 if (isHost) setGame({ started: true });
 ```
+
+`initialState` is applied once, by the first host of a still-empty room, and is
+never re-applied on host migration — so a host leaving mid-game cannot reset the
+round.
 
 ## Player state
 
@@ -61,9 +103,7 @@ Per-player data visible to everyone.
 const [player, setPlayer] = usePlayerState(room, { x: 0, y: 0 });
 
 useEffect(() => {
-  const onMove = (e: PointerEvent) => {
-    setPlayer({ x: e.clientX, y: e.clientY });
-  };
+  const onMove = (e: PointerEvent) => setPlayer({ x: e.clientX, y: e.clientY });
   window.addEventListener("pointermove", onMove);
   return () => window.removeEventListener("pointermove", onMove);
 }, [setPlayer]);
@@ -71,24 +111,20 @@ useEffect(() => {
 
 ## Events
 
-Fire-and-forget messages to all players.
+Fire-and-forget messages. Handled by the `onEvent` callback in the room config.
 
-```tsx
+```ts
 room.sendEvent("explosion", { x: 100, y: 200 });
+
+room.sendEvent("hit", dmg, { to: victimId }); // one player
+room.sendEvent("spawn", data, { except: room.playerId }); // everyone else
+room.sendEvent("cursor", pos, { coalesce: true }); // latest-wins, flushed per microtask
 ```
 
-Handle with `onEvent` in config:
-
-```tsx
-const room = useMultiplayerRoom({
-  host,
-  party,
-  room,
-  onEvent: (event, payload, from) => {
-    console.log(`${from} sent ${event}`, payload);
-  },
-});
-```
+`to`/`except` are enforced by the server; `coalesce` is client-side and collapses
+rapid same-type events into one wire message without reordering them against
+state patches. Events are not buffered — a player who is away misses them, so
+anything that must survive a reconnect belongs in state.
 
 ## Room metadata
 
@@ -96,11 +132,59 @@ const room = useMultiplayerRoom({
 const isConnected = room.connectionStatus === "connected";
 const players = Object.values(room.players);
 const myId = room.playerId;
+const actualRoom = room.room; // may be an overflow sibling — see below
 ```
+
+Each `Player` carries `id`, an auto-assigned `color`/`hue`, its state, and
+`connected` — `false` while a dropped player's seat is being held. Render that
+as "reconnecting…", not as a leave.
+
+## Capacity and overflow
+
+```ts
+useMultiplayerRoom({ host, party, room, maxPlayers: 8 });
+```
+
+At capacity the client is transparently reconnected into a sibling room
+(`{room}~2`, `{room}~3`, …) — an independent world with its own host and shared
+state. Read `room.room` to show players which instance they landed in. Omit
+`maxPlayers` for no cap (the server still clamps to a hard ceiling).
+
+## Reconnection
+
+A dropped connection holds the player's seat, identity and state for 30s
+(`RECONNECT_GRACE_MS`) against a client-secret token, so a network blip is a
+pause rather than a leave + rejoin. A deliberate `destroy()` skips the grace
+window and leaves immediately.
+
+## Validation (core client)
+
+`MultiplayerClient` accepts optional [Standard
+Schema](https://standardschema.dev) validators — Zod, Valibot, ArkType — applied
+to the full merged state, so invalid patches are dropped before they reach the
+wire:
+
+```ts
+new MultiplayerClient({
+  host,
+  party,
+  room,
+  schemas: {
+    sharedState: z.object({ tick: z.number() }),
+    onViolation: (v) => console.warn(v.issues),
+  },
+});
+```
+
+The server enforces game-agnostic structural limits regardless
+(`MAX_MESSAGE_BYTES`, `MAX_STATE_DEPTH`, no cycles or functions).
 
 ## Server
 
-Works with any [PartyServer](https://partykit.io)-compatible backend. The vibedgames party server handles shared state, player state, events, and host assignment generically.
+Works with any PartyServer-compatible backend. The vibedgames party server
+([`apps/party`](https://github.com/kyh/vibedgames/tree/main/apps/party)) handles
+shared state, player state, events, capacity, reconnection and host election
+generically — it never knows a game's shape.
 
 ## License
 

--- a/packages/ui/src/components/otp-input.tsx
+++ b/packages/ui/src/components/otp-input.tsx
@@ -30,8 +30,8 @@ import { EASE_OUT, SHAKE_KEYFRAMES, SHAKE_TRANSITION } from "@repo/ui/lib/motion
 //     selected, because a selection range maps to a cell range.
 //
 // Verification: pass `verify` (sync or async — hit your API). A full code
-// drives the little state machine: right → the cells cascade green left to
-// right, then `onSuccess` fires; wrong → the row shakes, the characters drop
+// drives the little state machine: right → the row nods once and the cells
+// cascade green left to right, then `onSuccess` fires; wrong → the row shakes, the characters drop
 // out one by one, then the field clears and hands the caret back. `verify`
 // may resolve to a string to hand a server-canonicalized value to
 // `onSuccess` instead of the typed one.
@@ -45,6 +45,12 @@ const DROP_S = 0.24; // wrong code: each character's fall-out
 const STAGGER_S = 0.045; // per-character clear offset
 const FILL_S = 0.055; // per-cell success cascade offset
 const VERIFY_DELAY_MS = 320; // beat so the last character is seen landing
+const CHAR_IN_S = 0.14; // a new character rising into its cell
+// Where the character starts, in px below its resting place. Measured, not
+// guessed: at the cell's 3rem height and 1.125rem type, less than ~16px
+// leaves the glyph floating inside the cell and the rise reads as a twitch.
+const CHAR_IN_Y = 16;
+const BOUNCE_S = 0.65; // success: the row's nod
 
 const OTP_VARS: React.CSSProperties & Record<`--${string}`, string> = {
   "--otp-cell-w": "2.5rem",
@@ -70,25 +76,45 @@ const CELL_TONE: Record<"idle" | "active" | "selected" | VerifyState, string> = 
   success: "border-success/60 bg-success/10 text-success",
 };
 
+/**
+ * A character enters by rising into its cell, which is why the cells clip:
+ * it starts below the floor rather than fading in on the spot. Keyed on the
+ * character in the render below, so every new one plays it — including a
+ * retype of the same digit into the same cell.
+ *
+ * Only `error` diverges: the row shakes first, then the characters drop back
+ * out one by one, which is also how the field clears.
+ */
 const glyphMotion = (state: VerifyState, index: number) =>
-  state === "success"
+  state === "error"
     ? {
-        animate: { scale: [1, 1.15, 1], y: 0, opacity: 1, filter: "blur(0px)" },
-        transition: { duration: 0.3, ease: EASE_OUT, delay: index * FILL_S },
+        animate: { y: "0.5rem", opacity: 0, filter: "blur(2px)" },
+        transition: {
+          duration: DROP_S,
+          ease: "easeOut" as const,
+          delay: SHAKE_TRANSITION.duration + index * STAGGER_S,
+        },
       }
-    : state === "error"
+    : {
+        initial: { y: CHAR_IN_Y, opacity: 0.2 },
+        animate: { y: 0, opacity: 1, filter: "blur(0px)" },
+        transition: { duration: CHAR_IN_S, ease: EASE_OUT },
+      };
+
+/**
+ * Success is one gesture for the whole row — a short vertical nod, the field
+ * agreeing with you — rather than a per-cell pop, which fought the green
+ * tint already cascading left to right underneath it.
+ */
+const rowMotion = (state: VerifyState) =>
+  state === "error"
+    ? { animate: { ...SHAKE_KEYFRAMES, y: 0 }, transition: SHAKE_TRANSITION }
+    : state === "success"
       ? {
-          animate: { y: "0.5rem", opacity: 0, filter: "blur(2px)" },
-          transition: {
-            duration: DROP_S,
-            ease: "easeOut" as const,
-            delay: SHAKE_TRANSITION.duration + index * STAGGER_S,
-          },
+          animate: { x: 0, y: [0, -10, 3, -4, 0] },
+          transition: { duration: BOUNCE_S, times: [0, 0.25, 0.5, 0.72, 1], ease: EASE_OUT },
         }
-      : {
-          animate: { scale: 1, y: 0, opacity: 1, filter: "blur(0px)" },
-          transition: { duration: 0 },
-        };
+      : { animate: { x: 0, y: 0 }, transition: SHAKE_TRANSITION };
 
 function OTPInput({
   length,
@@ -236,15 +262,16 @@ function OTPInput({
       <div
         data-slot="otp-input"
         data-state={state}
+        // Chrome's page translation rewrites the cells' text nodes (wrapping
+        // them in <font>), which crashes React on the next update — and a
+        // one-time code is never meaningful to translate.
+        translate="no"
         className={cn("relative flex flex-col items-center", className)}
         style={OTP_VARS}
       >
-        {/* Wrong code: the row shakes once, as one object. */}
-        <motion.div
-          className="relative flex gap-[var(--otp-gap)]"
-          animate={state === "error" ? SHAKE_KEYFRAMES : { x: 0 }}
-          transition={SHAKE_TRANSITION}
-        >
+        {/* Wrong code shakes the row, a right one nods it — either way it
+            moves as one object, not as N cells. */}
+        <motion.div className="relative flex gap-[var(--otp-gap)]" {...rowMotion(state)}>
           {Array.from({ length }, (_, index) => {
             const char = value[index];
             const active = focused && state === "idle" && collapsed && caretCell === index;
@@ -256,7 +283,10 @@ function OTPInput({
               <div
                 key={index}
                 className={cn(
-                  "flex h-[var(--otp-cell-h)] w-[var(--otp-cell-w)] items-center justify-center rounded-lg border font-mono text-lg font-medium tabular-nums backdrop-blur-sm",
+                  // `overflow-hidden` is what makes the character rise INTO
+                  // the cell — without it the glyph is visible below the
+                  // border on its way up, and drops out through the floor.
+                  "flex h-[var(--otp-cell-h)] w-[var(--otp-cell-w)] items-center justify-center overflow-hidden rounded-lg border font-mono text-lg font-medium tabular-nums backdrop-blur-sm",
                   "transition-[border-color,background-color,color,box-shadow] duration-150",
                   group && index === groupAt && "ml-3",
                   CELL_TONE[tone],
@@ -270,11 +300,7 @@ function OTPInput({
                 aria-hidden="true"
               >
                 {char && (
-                  <motion.span
-                    className="inline-block"
-                    initial={false}
-                    {...glyphMotion(state, index)}
-                  >
+                  <motion.span key={char} className="inline-block" {...glyphMotion(state, index)}>
                     {char}
                   </motion.span>
                 )}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -193,6 +193,27 @@
   }
 }
 
+/* An autofilled input gets an opaque background and a forced
+   `-webkit-text-fill-color` from the UA at an origin author styles cannot
+   override — on the OTP input that means a solid block with the raw code
+   painted over the cells. Hiding the field outright is the only reliable
+   escape hatch, and it costs nothing: while the state applies the value is
+   complete, so the cells underneath already show it. Two rules, not one
+   selector list: a browser that rejects either selector drops the whole
+   rule (Firefox knows `:autofill` but not `:-webkit-autofill`). */
+[data-slot="otp-input-control"]:autofill {
+  opacity: 0;
+  box-shadow: none;
+  -webkit-box-shadow: none;
+  -webkit-text-fill-color: transparent;
+}
+[data-slot="otp-input-control"]:-webkit-autofill {
+  opacity: 0;
+  box-shadow: none;
+  -webkit-box-shadow: none;
+  -webkit-text-fill-color: transparent;
+}
+
 /* Hard caret blink for the OTP input's painted caret — a step, not a fade,
    to match native carets. */
 @keyframes otp-caret-blink {

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,50 @@
+# Plugins
+
+The game studio, as skills. Six Claude Code plugins, listed in
+[`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json), each a
+`.claude-plugin/plugin.json` manifest plus a `skills/` directory.
+
+These are the product, not tooling for this repo: `vg init` installs them into a
+user's project (for Claude Code, Cursor and Codex), and `vg update` refreshes
+them. An agent that has them can do what a studio does — design, scaffold,
+generate art, add multiplayer, tune feel, ship.
+
+| Plugin                               | Skills                                                                                                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`game-craft`](./game-craft)         | `game-playbook` · `ask-me` · `teach-me` · `game-feel` · `game-balance` · `game-ui` · `level-design` · `onboarding` · `animation` · `vfx` · `design-lenses` · `finish-it` |
+| [`game-engines`](./game-engines)     | `phaser` · `threejs` · `capacitor-ios`                                                                                                                                   |
+| [`game-features`](./game-features)   | `multiplayer` · `gamepad`                                                                                                                                                |
+| [`generate`](./generate)             | `generate` · `model-catalog` · `model-prompting` · `media-workflow` · `pixel-art` · `character-design` · `cinematography` · `storytelling` · `regenerate-3d`             |
+| [`asset-pipeline`](./asset-pipeline) | `animated-spritesheets` · `aseprite` · `asset-pipeline` · `pixel-snapper`                                                                                                |
+| [`tooling`](./tooling)               | `deploy` · `fork` · `playwright` · `skill-creator`                                                                                                                       |
+
+`game-playbook` is the entry point — the build order from a one-line idea to a
+shipped game; the rest are the deep modules it routes into.
+
+## Editing them
+
+```sh
+pnpm dogfood        # build + npm-link the local vg CLI, sync .claude/skills/
+pnpm dogfood:reset  # undo the link
+```
+
+`pnpm dogfood` mirrors every `plugins/*/skills/*` into `.claude/skills/` as a
+relative symlink (creating new ones, removing stale ones) and validates
+cross-skill references. Those symlinks are committed, so a fresh clone — or a
+remote Claude Code session — resolves the skills with no setup; only the
+`npm link` step is per-machine.
+
+Re-run `pnpm dogfood` after adding or removing a skill, then commit the
+`.claude/skills/` change.
+
+## Conventions
+
+- One skill = one directory with a `SKILL.md` whose frontmatter `description`
+  is what triggers it. Write the description as _when to use this_, not what it
+  contains — it is the only part always in context.
+- A skill that changes a user's output owns the lesson. Durable craft belongs
+  in the SKILL.md (or its scripts), never only in a session note.
+- Adding a skill to a new plugin means adding the plugin to
+  `.claude-plugin/marketplace.json` too.
+- End-user-facing skills never name the generation provider as a brand — model
+  endpoint IDs pass through verbatim, everything else is just "the CLI".


### PR DESCRIPTION
Audited every README against the source and fixed what had drifted, plus added indexes for the two directories that had none.

## New

- `games/README.md` — index of the 11 example games (engine, multiplayer shape, dev command, live URL), shared conventions, and the `?trailer=1` / `?viewer=1` / `?editor=1` param table.
- `plugins/README.md` — the six plugins and their skills, the `pnpm dogfood` symlink mirror, authoring conventions.

## Stale facts fixed

- **`packages/multiplayer`** — the quickstart imported hooks from the package root; they live at `@vibedgames/multiplayer/react`. Copy-pasting it didn't compile. Rewritten to also cover the vanilla `MultiplayerClient`, targeting/coalescing, capacity + overflow, reconnect grace, and schema validation.
- **`apps/cli`** — missing `fork`, `credits`, `update`, `completions`, `factory`; `vg init` no longer writes `.claude/skills` (it drives `npx skills add` for Claude Code/Cursor/Codex); dropped the dead `vg skills install` alias.
- **Game sim-harness counts** were wrong in 3 of 4 READMEs (waymo 11→33, moba 17→18, lunerfall 78→80). Replaced the numbers with the harness path so they can't rot again.
- **`packages/api`** was missing the `apiKeys` and `credits` routers; **`packages/db`** was missing the `creditEntry` / `generation` tables and 2 of 3 seeded logins.

## Expanded

Root layout (factory, embed, gamepad were invisible), web route map + the `localhost`-vs-`127.0.0.1` R2 trap, games-worker HTML injection (freshness + share meta, previously undocumented), party protocol (host liveness, capacity, structural limits, the additive-capability rule). Root README gains an Acknowledgements section.

Docs only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swept and aligned READMEs across the repo, added indexes for `games/` and `plugins/`, and clarified multiplayer/party/web docs. Also improved the OTP code input UX and fixed Chrome autofill visuals.

- **New Features**
  - Added `games/README.md` indexing 11 example games (engine, dev command, live URL) and shared params like `?trailer=1`/`?viewer=1`/`?editor=1`.
  - Added `plugins/README.md` listing six plugin skill sets and the `pnpm dogfood` symlink workflow.
  - Expanded docs: root layout and Acknowledgements; web route map and local R2 proxy notes; games worker HTML injection (freshness + share meta); party protocol (host liveness, capacity, limits); `@vibedgames/multiplayer` vanilla client, host model, capacity/reconnect, and validation.

- **Bug Fixes**
  - Fixed `packages/multiplayer` Quickstart to import hooks from `@vibedgames/multiplayer/react`; added examples for `MultiplayerClient`, event targeting/coalescing, capacity/reconnect, and schema validation.
  - Replaced stale sim-harness counts in game READMEs with harness paths.
  - Updated CLI docs: `fork`, `credits`, `update`, `factory`, `completions`; `vg init` now uses `npx skills add` with multi-agent support; removed the `vg skills install` alias.
  - Filled missing API/DB docs: `apiKeys` and `credits` routers; `creditEntry` and `generation` tables; seed users/invite details.
  - UI: fixed Chrome autofill overlay and refined success/error animations for the OTP input in `@repo/ui` (`otp-input.tsx`, globals).

<sup>Written for commit 76786e66b23051e95196aaa204cb18e1b7862027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

