### PR TITLE
Dock the account nav to the bottom center on mobile

### DIFF
--- a/apps/web/src/components/account/account-shell.tsx
+++ b/apps/web/src/components/account/account-shell.tsx
@@ -20,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@repo/ui/components/tooltip";
+import { useIsMobile } from "@repo/ui/hooks/use-mobile";
 
 import { authClient } from "@/auth/client";
 
@@ -49,12 +50,14 @@ function RailLink({
   icon: Icon,
   hovered,
   onHover,
+  tooltipSide,
 }: {
   to: string;
   label: string;
   icon: typeof Gamepad2Icon;
   hovered: string | null;
   onHover: (to: string) => void;
+  tooltipSide: "top" | "right";
 }) {
   const matchRoute = useMatchRoute();
   const isActive = matchRoute({ to, fuzzy: true }) !== false;
@@ -69,7 +72,7 @@ function RailLink({
             aria-label={label}
             onMouseEnter={() => onHover(to)}
             onFocus={() => onHover(to)}
-            className={`relative rounded-full p-2 outline-none transition-colors duration-100 ${
+            className={`relative rounded-full p-3.5 outline-none transition-colors duration-100 md:p-2 ${
               showDisc ? "text-foreground" : "text-muted-foreground"
             }`}
           />
@@ -84,7 +87,7 @@ function RailLink({
         )}
         <Icon className="relative size-4" />
       </TooltipTrigger>
-      <TooltipContent side="right">{label}</TooltipContent>
+      <TooltipContent side={tooltipSide}>{label}</TooltipContent>
     </Tooltip>
   );
 }
@@ -103,14 +106,20 @@ const initials = (user: ShellUser): string => {
  * full-height gutter cells — logo top-left, rail viewport-centered on the
  * logo's axis, avatar top-right — so the document scrolls normally and the
  * chrome stays pinned without `position: fixed`. Below `sm` the content
- * spans the full grid and the rail floats over it, as before. Deliberately
- * no page-entrance animation: loading states are the skeletons' job. Do NOT
+ * spans the full grid. Below `md` the rail becomes a bottom-centered dock:
+ * it drops out of the gutter flow into `position: fixed`, turns horizontal,
+ * and grows to 44px touch targets — so it must clear the main content's
+ * bottom padding and the iOS home-bar safe area. That `md` boundary is the
+ * same one `useIsMobile` uses, which is what keeps the tooltip side (`top`
+ * docked, `right` railed) in step with the layout. Deliberately no
+ * page-entrance animation: loading states are the skeletons' job. Do NOT
  * wrap any of this in FadeInBlur (its lingering inline `filter` would break
  * the rail's backdrop-blur).
  */
 export function AccountShell({ user, children }: { user: ShellUser; children: React.ReactNode }) {
   const navigate = useNavigate();
   const [hoveredRail, setHoveredRail] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   const signOut = async () => {
     await authClient.signOut();
@@ -127,14 +136,14 @@ export function AccountShell({ user, children }: { user: ShellUser; children: Re
             </Link>
           </div>
 
-          <div className="pointer-events-auto sticky top-1/2 -translate-y-1/2">
+          <div className="pointer-events-auto fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 -translate-x-1/2 md:sticky md:bottom-auto md:left-auto md:top-1/2 md:translate-x-0 md:-translate-y-1/2">
             <nav
               aria-label="Account"
               onMouseLeave={() => setHoveredRail(null)}
               onBlur={(e) => {
                 if (!e.currentTarget.contains(e.relatedTarget)) setHoveredRail(null);
               }}
-              className="bg-input/40 flex w-11 flex-col items-center gap-1 rounded-full p-1.5 shadow-[0_8px_24px_rgb(0_0_0/0.4),0_2px_6px_rgb(0_0_0/0.3)] backdrop-blur-sm"
+              className="bg-input/40 flex items-center gap-1 rounded-full p-1.5 shadow-[0_8px_24px_rgb(0_0_0/0.4),0_2px_6px_rgb(0_0_0/0.3)] backdrop-blur-sm md:w-11 md:flex-col"
             >
               {railItems
                 .filter((item) => !item.adminOnly || user.isAdmin)
@@ -146,6 +155,7 @@ export function AccountShell({ user, children }: { user: ShellUser; children: Re
                     icon={item.icon}
                     hovered={hoveredRail}
                     onHover={setHoveredRail}
+                    tooltipSide={isMobile ? "top" : "right"}
                   />
                 ))}
             </nav>
@@ -177,7 +187,7 @@ export function AccountShell({ user, children }: { user: ShellUser; children: Re
           </div>
         </div>
 
-        <main className="col-span-full row-start-1 px-2 pt-28 pb-16 sm:col-span-1 sm:col-start-2 sm:px-4">
+        <main className="col-span-full row-start-1 px-2 pt-28 pb-[calc(6rem+env(safe-area-inset-bottom))] sm:col-span-1 sm:col-start-2 sm:px-4 md:pb-16">
           <div className="mx-auto max-w-3xl space-y-16">{children}</div>
         </main>
       </div>


### PR DESCRIPTION
The main nav on the logged-in pages (`/home`, `/settings`, `/admin/*`) was a vertical rail pinned to the left gutter at every width. Below `md` it now becomes a bottom-centered dock.

## What changed

`apps/web/src/components/account/account-shell.tsx`:

- **Position** — below `md` the rail wrapper drops out of the gutter flow into `fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 -translate-x-1/2`; `md:` restores the original `sticky top-1/2 -translate-y-1/2` in column 1.
- **Orientation** — the `nav` is horizontal and auto-width by default, `md:w-11 md:flex-col` above.
- **Touch targets** — rail links go `p-3.5` (44px) while docked, `md:p-2` (32px) on the rail.
- **Clearance** — `main` gets `pb-[calc(6rem+env(safe-area-inset-bottom))]`, dropping back to `pb-16` at `md`, so the last row of content is never under the dock.
- **Tooltips** — `side="top"` while docked, `side="right"` on the rail, via `useIsMobile`. Its 768px breakpoint *is* the `md` boundary, so the JS and CSS switch at the same width.

Untouched: the shared `rail-disc` highlight (same surface, same `layoutId` spring), the logo, the avatar menu, and the whole `md`-and-up layout.

## Verification

`pnpm verify` green (typecheck · lint · format · test).

Driven in a real browser against `pnpm dev:web`, signed in as the seeded admin:

| Width | `nav` box | Center offset | Bottom gap | Link size |
| --- | --- | --- | --- | --- |
| 390 | 152×56 | 0.0px | 16px | 44×44 |
| 768 | 44×116 | left gutter | — | 32×32 |
| 1280 | 44×116 | left gutter | — | 32×32 |

At 390px: `/settings` scrolled to the bottom leaves 24.5px of clearance between the last content element and the dock; tapping the dock's Settings link navigates and the active disc springs across. Screenshots at all three widths look right — dock centered and floating over content on mobile, rail unchanged at 768 and 1280.

---
_Generated by [Claude Code](https://claude.ai/code/session_013FEfzu4gPDTqEXaTQbjX52)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docked the account nav to a bottom-centered dock on mobile for better reachability and safe-area handling, while keeping the desktop rail unchanged. Applies to logged-in pages (`/home`, `/settings`, `/admin/*`).

- New Features
  - Below `md`, the left rail becomes a fixed, bottom-centered dock with a horizontal layout and 44px touch targets.
  - At `md` and up, the vertical, viewport-centered rail remains unchanged with 32px targets.
  - Tooltips switch between top (dock) and right (rail) via `useIsMobile` from `@repo/ui/hooks/use-mobile`, aligned to the `md` breakpoint.
  - Added safe-area-aware bottom padding to `main` and the dock (`env(safe-area-inset-bottom)`) so content is never covered. Existing highlight disc, logo, and avatar menu are unchanged.

<sup>Written for commit 7976de04554aa98f3c353773a15c03175251b477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

