### PR TITLE
feat(crazy-waymo): kart-racer visual overhaul — AO, film grade, clearcoat, FX, HUD

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,9 +3,21 @@
   "configurations": [
     {
       "name": "web",
-      "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["dev:web"],
+      "runtimeExecutable": "/bin/zsh",
+      "runtimeArgs": [
+        "-c",
+        "export PATH=\"$HOME/Library/Application Support/fnm/aliases/default/bin:$PATH\"; exec pnpm dev:web"
+      ],
       "port": 5173
+    },
+    {
+      "name": "crazy-waymo",
+      "runtimeExecutable": "/bin/zsh",
+      "runtimeArgs": [
+        "-c",
+        "export PATH=\"$HOME/Library/Application Support/fnm/aliases/default/bin:$PATH\"; cd games/crazy-waymo && exec node node_modules/vite/bin/vite.js"
+      ],
+      "port": 5193
     }
   ]
 }

--- a/games/crazy-waymo/index.html
+++ b/games/crazy-waymo/index.html
@@ -45,26 +45,33 @@
         pointer-events: none;
         z-index: 5;
         font-weight: 700;
+        /* Hard contour on every HUD text so it survives a bright sky. */
+        text-shadow: 0 2px 0 rgba(0, 0, 0, 0.55);
       }
+      /* Chunky kart plate: solid warm-dark body, dark bevel ring outside the
+         gold accent border, hard offset drop. No backdrop blur — the solid
+         panel replaces it (and it cost GPU on phones). */
       .pill {
         position: fixed;
-        background: rgba(18, 16, 26, 0.62);
-        border: 2px solid rgba(255, 209, 71, 0.5);
-        border-radius: 12px;
+        background: rgba(24, 20, 16, 0.92);
+        border: 2px solid rgba(255, 209, 71, 0.75);
+        border-radius: 14px;
         padding: 8px 14px;
         letter-spacing: 1px;
-        backdrop-filter: blur(7px);
-        -webkit-backdrop-filter: blur(7px);
-        box-shadow: 0 4px 0 rgba(0, 0, 0, 0.35);
+        box-shadow:
+          0 0 0 2px rgba(16, 11, 7, 0.9),
+          0 5px 0 rgba(0, 0, 0, 0.45);
       }
       .label {
         font-size: 10px;
+        font-weight: 900;
         letter-spacing: 2px;
         opacity: 0.7;
         display: block;
       }
       .value {
         font-size: 22px;
+        font-weight: 800;
         font-variant-numeric: tabular-nums;
       }
 
@@ -193,10 +200,10 @@
         color: #fff;
       }
       #boost-track {
-        width: 84px;
+        width: 100px;
         height: 8px;
         border-radius: 5px;
-        background: rgba(255, 255, 255, 0.16);
+        background: rgba(0, 0, 0, 0.45);
         overflow: hidden;
         margin-top: 4px;
       }
@@ -221,7 +228,7 @@
         }
       }
 
-      /* Mini dash — speedo dial (digits in the middle) + boost, bottom-left */
+      /* Mini dash — analogue speedo gauge + boost, bottom-left */
       #speed {
         left: calc(14px + env(safe-area-inset-left));
         bottom: calc(14px + env(safe-area-inset-bottom));
@@ -230,8 +237,8 @@
       }
       #dash-dial {
         display: block;
-        width: 88px;
-        height: 52px;
+        width: 120px;
+        height: 84px;
         margin: 0 auto;
       }
       #speed #boost-track {
@@ -244,7 +251,7 @@
         right: calc(14px + env(safe-area-inset-right));
         min-width: 150px;
         text-align: right;
-        border-color: rgba(73, 224, 255, 0.55);
+        border-color: rgba(73, 224, 255, 0.8);
         transition:
           opacity 0.2s,
           transform 0.2s;
@@ -364,18 +371,19 @@
         bottom: calc(14px + env(safe-area-inset-bottom));
         width: 148px;
         height: 148px;
-        border-radius: 12px;
-        border: 2px solid rgba(255, 209, 71, 0.5);
-        background: rgba(18, 16, 26, 0.62);
-        box-shadow: 0 4px 0 rgba(0, 0, 0, 0.35);
+        border-radius: 14px;
+        border: 2px solid rgba(255, 209, 71, 0.75);
+        background: rgba(24, 20, 16, 0.92);
+        box-shadow:
+          0 0 0 2px rgba(16, 11, 7, 0.9),
+          0 5px 0 rgba(0, 0, 0, 0.45);
         display: none;
         z-index: 5;
         pointer-events: none;
-        opacity: 0.92;
       }
       /* Touch: the pedals own the bottom-right, so the map stacks directly on
          top of the speedo in the bottom-left column. `bottom` clears the
-         speedo's ~84px box plus a 10px gutter. */
+         speedo's ~114px box plus a 10px gutter. */
       @media (pointer: coarse) {
         #minimap {
           width: 104px;
@@ -383,7 +391,7 @@
           right: auto;
           top: auto;
           left: calc(14px + env(safe-area-inset-left));
-          bottom: calc(108px + env(safe-area-inset-bottom));
+          bottom: calc(138px + env(safe-area-inset-bottom));
         }
       }
       @media (pointer: coarse) and (max-height: 500px) {

--- a/games/crazy-waymo/package.json
+++ b/games/crazy-waymo/package.json
@@ -21,6 +21,7 @@
     "@repo/embed": "workspace:*",
     "@vibedgames/gamepad": "workspace:^",
     "@vibedgames/multiplayer": "workspace:^",
+    "n8ao": "^2.0.0",
     "polygon-clipping": "^0.15.7",
     "three": "^0.185.1"
   },

--- a/games/crazy-waymo/src/fx/impact-stars.ts
+++ b/games/crazy-waymo/src/fx/impact-stars.ts
@@ -1,0 +1,141 @@
+import * as THREE from "three";
+
+// Mario-Kart cartoon impact stars: on a crash, 3-5 chunky yellow stars fly
+// outward-upward from the impact in a loose ring, spin, arc under gravity and
+// fade. Opaque cartoon icons — NORMAL blending, not additive: a star is a
+// comic-book glyph stamped over the scene, not a light source. Fixed sprite
+// pool, one shared canvas texture, zero allocation per burst.
+
+const POOL = 8;
+const GRAVITY = 14;
+const LIFE = 0.7;
+// Fraction of life spent fully opaque before the fade-out starts.
+const HOLD = 0.45;
+
+/** 5-point star, warm yellow fill + thin white rim, generated at boot. */
+function starTexture(): THREE.CanvasTexture {
+  const size = 128;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    const cx = size / 2;
+    const cy = size / 2;
+    const outer = size * 0.44;
+    const inner = outer * 0.48;
+    ctx.beginPath();
+    for (let i = 0; i < 10; i++) {
+      const r = i % 2 === 0 ? outer : inner;
+      const a = (i / 10) * Math.PI * 2 - Math.PI / 2;
+      const x = cx + Math.cos(a) * r;
+      const y = cy + Math.sin(a) * r;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.fillStyle = "#ffd147";
+    ctx.fill();
+    ctx.lineWidth = size * 0.045;
+    ctx.lineJoin = "round";
+    ctx.strokeStyle = "#ffffff";
+    ctx.stroke();
+  }
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+type Star = {
+  readonly sprite: THREE.Sprite;
+  readonly mat: THREE.SpriteMaterial;
+  vx: number;
+  vy: number;
+  vz: number;
+  spin: number; // rad/s
+  size: number;
+  life: number; // remaining; <= 0 = idle
+  stamp: number; // activation order, for stealing the oldest
+};
+
+export class ImpactStars {
+  readonly group = new THREE.Group();
+  private stars: Star[] = [];
+  private clock = 0;
+
+  constructor() {
+    const tex = starTexture();
+    for (let i = 0; i < POOL; i++) {
+      // Per-sprite material: SpriteMaterial.rotation is what spins the star.
+      const mat = new THREE.SpriteMaterial({
+        map: tex,
+        transparent: true,
+        depthWrite: false,
+        opacity: 0,
+      });
+      const sprite = new THREE.Sprite(mat);
+      sprite.visible = false;
+      sprite.renderOrder = 12; // above the car and the smoke/spark pools
+      this.group.add(sprite);
+      this.stars.push({ sprite, mat, vx: 0, vy: 0, vz: 0, spin: 0, size: 1, life: 0, stamp: 0 });
+    }
+  }
+
+  /** Crash burst at the impact point; `power` is the crash block's 0..1 p. */
+  burst(x: number, y: number, z: number, power: number): void {
+    const count = 3 + Math.round(Math.min(1, Math.max(0, power)) * 2);
+    const base = Math.random() * Math.PI * 2;
+    for (let i = 0; i < count; i++) {
+      const star = this.claim();
+      // Loose ring: even spacing plus jitter, so the burst reads as a shape
+      // (the dustRing lesson: coherent ring beats noisy swarm).
+      const ang = base + (i / count) * Math.PI * 2 + (Math.random() - 0.5) * 0.7;
+      const out = 3.2 + power * 2.2 + Math.random() * 1.4;
+      star.vx = Math.cos(ang) * out;
+      star.vz = Math.sin(ang) * out;
+      star.vy = 4.6 + power * 2.4 + Math.random() * 1.2;
+      star.spin = (Math.random() < 0.5 ? -1 : 1) * (3 + Math.random() * 5);
+      star.size = 0.5 + power * 0.3 + Math.random() * 0.1;
+      star.life = LIFE * (0.85 + Math.random() * 0.3);
+      star.stamp = ++this.clock;
+      star.sprite.position.set(x, y + 0.6, z);
+      star.sprite.scale.setScalar(star.size);
+      star.mat.rotation = Math.random() * Math.PI * 2;
+      star.mat.opacity = 1;
+      star.sprite.visible = true;
+    }
+  }
+
+  update(dt: number): void {
+    for (const star of this.stars) {
+      if (star.life <= 0) continue;
+      star.life -= dt;
+      if (star.life <= 0) {
+        star.sprite.visible = false;
+        star.mat.opacity = 0;
+        continue;
+      }
+      star.vy -= GRAVITY * dt;
+      star.sprite.position.x += star.vx * dt;
+      star.sprite.position.y += star.vy * dt;
+      star.sprite.position.z += star.vz * dt;
+      star.mat.rotation += star.spin * dt;
+      const frac = star.life / LIFE;
+      star.mat.opacity = Math.min(1, frac / HOLD);
+    }
+  }
+
+  private claim(): Star {
+    let best = this.stars[0];
+    let bestStamp = Infinity;
+    for (const star of this.stars) {
+      if (star.life <= 0) return star;
+      if (star.stamp < bestStamp) {
+        bestStamp = star.stamp;
+        best = star;
+      }
+    }
+    if (best) return best;
+    throw new Error("impact-star pool is empty"); // unreachable: POOL > 0
+  }
+}

--- a/games/crazy-waymo/src/fx/particles.ts
+++ b/games/crazy-waymo/src/fx/particles.ts
@@ -13,6 +13,10 @@ type EmitOpts = {
   // Optional directional term: final velocity = radial term + dir * dirSpeed.
   dir?: { x: number; y: number; z: number };
   dirSpeed?: number;
+  // 0..1 scale on the day bloom gain (sparks pool only). Hot FX — drift
+  // sparks, boost flame, crash bursts — glow at 1; inert debris like sand and
+  // grass flecks opts out at 0, or every off-road run reads as a fire.
+  bloomGain?: number;
 };
 
 // vAlpha = remaining life fraction (1 at birth -> 0 at death).
@@ -23,12 +27,15 @@ const VERT = `
   attribute float aMax;
   attribute float aSize;
   attribute vec3 aColor;
+  attribute float aGain;
   uniform float uScale;
   uniform float uGrow;
   varying float vAlpha;
   varying vec3 vColor;
+  varying float vGain;
   void main() {
     vColor = aColor;
+    vGain = aGain;
     vAlpha = clamp(aLife / max(aMax, 0.0001), 0.0, 1.0);
     float shrinkRamp = mix(0.6, 1.4, vAlpha);
     float growRamp = mix(1.5, 0.7, vAlpha);
@@ -40,7 +47,13 @@ const VERT = `
 `;
 // Color cools toward death (hot core early, dark residue late); alpha is
 // fast-in-slow-out (vAlpha^2 spends most of the life dim, popping at birth).
-const FRAG = `
+// Smoke is LIT: the top of each puff catches uSunTint, the underside sits in
+// uAmbient shade — the vertical gradient across the point sprite is what makes
+// a flat point read as a volume, and it's what lets golden-hour smoke go
+// orange instead of staying flat grey.
+const FRAG_SMOKE = `
+  uniform vec3 uSunTint;
+  uniform vec3 uAmbient;
   varying float vAlpha;
   varying vec3 vColor;
   void main() {
@@ -49,6 +62,34 @@ const FRAG = `
     if (r > 0.25) discard;
     float soft = smoothstep(0.25, 0.0, r);
     vec3 color = mix(vColor * 0.35, vColor, pow(vAlpha, 0.6));
+    float topLit = smoothstep(0.78, 0.18, gl_PointCoord.y);
+    // Ceiling keeps a stack of overlapping lit puffs from blowing out to a
+    // single white-yellow mass under the post S-curve.
+    color *= min(uAmbient + uSunTint * topLit, vec3(1.0));
+    gl_FragColor = vec4(color, vAlpha * vAlpha * soft);
+  }
+`;
+// Sparks: uGain boosts the CENTER of the sprite only (skirt stays at 1x, so a
+// gained spark reads white-hot core + colored halo, not a blob). By day the
+// bloom threshold sits at 6.5 pre-tonemap while spark colors peak ~1 — the
+// gain is what lets a day drift spark cross the cut and glow like the night
+// lamp halos do.
+const FRAG_SPARKS = `
+  uniform float uGain;
+  varying float vAlpha;
+  varying vec3 vColor;
+  varying float vGain;
+  void main() {
+    vec2 d = gl_PointCoord - vec2(0.5);
+    float r = dot(d, d);
+    if (r > 0.25) discard;
+    float soft = smoothstep(0.25, 0.0, r);
+    vec3 color = mix(vColor * 0.35, vColor, pow(vAlpha, 0.6));
+    // Hot core confined to the inner ~35% radius — r is SQUARED distance, so
+    // the earlier 1-4r ramp still covered most of the sprite and every gained
+    // spark rendered as a fat additive splat instead of a pinprick.
+    float core = pow(smoothstep(0.03, 0.0, r), 2.0);
+    color *= 1.0 + (uGain - 1.0) * core * vGain;
     gl_FragColor = vec4(color, vAlpha * vAlpha * soft);
   }
 `;
@@ -60,6 +101,7 @@ class ParticleField {
   private size: Float32Array;
   private life: Float32Array;
   private max: Float32Array;
+  private gain: Float32Array;
   private vel: Float32Array;
   private grav: Float32Array;
   private drag: Float32Array;
@@ -72,12 +114,15 @@ class ParticleField {
     private n: number,
     blending: THREE.Blending,
     grow: boolean,
+    frag: string,
+    extraUniforms: Record<string, THREE.IUniform>,
   ) {
     this.pos = new Float32Array(n * 3);
     this.col = new Float32Array(n * 3);
     this.size = new Float32Array(n);
     this.life = new Float32Array(n);
     this.max = new Float32Array(n);
+    this.gain = new Float32Array(n);
     this.vel = new Float32Array(n * 3);
     this.grav = new Float32Array(n);
     this.drag = new Float32Array(n);
@@ -88,12 +133,13 @@ class ParticleField {
     geo.setAttribute("aSize", new THREE.BufferAttribute(this.size, 1));
     geo.setAttribute("aLife", new THREE.BufferAttribute(this.life, 1));
     geo.setAttribute("aMax", new THREE.BufferAttribute(this.max, 1));
+    geo.setAttribute("aGain", new THREE.BufferAttribute(this.gain, 1));
     geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
 
     this.mat = new THREE.ShaderMaterial({
-      uniforms: { uScale: this.scaleUniform, uGrow: { value: grow ? 1 : 0 } },
+      uniforms: { uScale: this.scaleUniform, uGrow: { value: grow ? 1 : 0 }, ...extraUniforms },
       vertexShader: VERT,
-      fragmentShader: FRAG,
+      fragmentShader: frag,
       transparent: true,
       depthWrite: false,
       blending,
@@ -129,6 +175,7 @@ class ParticleField {
       this.size[i] = o.size * (0.7 + Math.random() * 0.6);
       this.life[i] = o.life;
       this.max[i] = o.life;
+      this.gain[i] = o.bloomGain ?? 1;
       this.grav[i] = o.gravity;
       this.drag[i] = o.drag;
     }
@@ -162,13 +209,25 @@ class ParticleField {
     geo.getAttribute("aSize").needsUpdate = true;
     geo.getAttribute("aLife").needsUpdate = true;
     geo.getAttribute("aMax").needsUpdate = true;
+    geo.getAttribute("aGain").needsUpdate = true;
   }
 }
 
+export type FxSurface = "road" | "grass" | "sand" | "concrete";
+
 // High-level effects used by the game.
 export class Fx {
-  readonly smoke = new ParticleField(420, THREE.NormalBlending, true); // grows over life
-  readonly sparks = new ParticleField(500, THREE.AdditiveBlending, false); // shrinks over life
+  // Defaults approximate noon so the first frames before setLighting look sane.
+  private smokeSun = { value: new THREE.Color(0.78, 0.72, 0.6) };
+  private smokeAmbient = { value: new THREE.Color(0.55, 0.6, 0.65) };
+  private sparkGain = { value: 1 };
+  readonly smoke = new ParticleField(420, THREE.NormalBlending, true, FRAG_SMOKE, {
+    uSunTint: this.smokeSun,
+    uAmbient: this.smokeAmbient,
+  }); // grows over life
+  readonly sparks = new ParticleField(500, THREE.AdditiveBlending, false, FRAG_SPARKS, {
+    uGain: this.sparkGain,
+  }); // shrinks over life
   private tmp = new THREE.Color();
   private tmpDir = { x: 0, y: 0, z: 0 };
 
@@ -181,11 +240,47 @@ export class Fx {
     this.sparks.setScale(px);
   }
 
+  // Per-frame lighting feed from the day-night rig. `day` = 1 - lamp factor.
+  // Sun scale 0.26: a golden key (1.9 int) lands the puff's lit top around
+  // parity with its albedo and the shaded base at ~0.5x — volume without the
+  // stack of puffs clipping toward white (the post S-curve + vibrance sit on
+  // top of whatever leaves here; 0.45 read as a fireball).
+  // Ambient floor 0.12 keeps night smoke readable against the dark ground.
+  // Spark gain tops out at x3.5 — deliberately UNDER the 6.5 day bloom cut.
+  // Cores at ~3.4 ACES-clip to a white-hot center on their own; pushing them
+  // past the cut instead (an earlier x7) fed every 20Hz spark trail into the
+  // bloom pyramid and a plain grind drift read as a chain of fireballs. Only
+  // spots where several sparks overlap now cross the cut, which is a glint,
+  // not a flood. At night the cut is 0.85 and gain MUST return to 1.
+  setLighting(
+    sun: THREE.Color,
+    sunIntensity: number,
+    ambient: THREE.Color,
+    ambientIntensity: number,
+    day: number,
+  ): void {
+    this.smokeSun.value.copy(sun).multiplyScalar(sunIntensity * 0.26);
+    this.smokeAmbient.value.copy(ambient).multiplyScalar(ambientIntensity).addScalar(0.12);
+    this.sparkGain.value = 1 + 2.5 * Math.min(1, Math.max(0, day));
+  }
+
   // Tire smoke while drifting. `charged` is the Mario-Kart mini-turbo tell:
-  // sparks turn cyan and the count jumps 2 -> 5.
-  driftPuff(x: number, z: number, boosting: boolean, charged = false): void {
-    this.tmp.setHSL(0, 0, boosting ? 0.85 : 0.72);
-    this.smoke.emit(x, 0.3, z, {
+  // sparks turn cyan and the count jumps 2 -> 5. Smoke is tinted by the
+  // surface being torn up (same colors as kickup, so the two systems agree):
+  // road keeps grey rubber-smoke, off-road throws that surface's dust.
+  driftPuff(
+    x: number,
+    y: number,
+    z: number,
+    boosting: boolean,
+    charged = false,
+    surface: FxSurface = "road",
+  ): void {
+    if (surface === "grass") this.tmp.setRGB(0.42, 0.36, 0.24);
+    else if (surface === "sand") this.tmp.setRGB(0.66, 0.57, 0.41);
+    else if (surface === "concrete") this.tmp.setRGB(0.8, 0.8, 0.78);
+    else this.tmp.setHSL(0, 0, boosting ? 0.85 : 0.72);
+    this.smoke.emit(x, y + 0.3, z, {
       count: 2,
       color: this.tmp,
       speed: 1.0,
@@ -198,7 +293,7 @@ export class Fx {
     });
     if (boosting || charged) {
       this.tmp.setHSL(charged ? 0.55 : 0.08, 1, 0.6);
-      this.sparks.emit(x, 0.3, z, {
+      this.sparks.emit(x, y + 0.3, z, {
         count: charged ? 5 : 2,
         color: this.tmp,
         speed: 5,
@@ -324,11 +419,13 @@ export class Fx {
   // surface's own color carry the effect; a few bright flecks (torn grass /
   // sand grains) ride on top. The old version was all additive embers — off-
   // road looked like the car was on fire, not tearing up ground.
-  kickup(x: number, z: number, surface: "grass" | "sand", power: number): void {
+  kickup(x: number, y: number, z: number, surface: "grass" | "sand", power: number): void {
     if (surface === "grass")
       this.tmp.setRGB(0.42, 0.36, 0.24); // dry-dirt brown
-    else this.tmp.setRGB(0.82, 0.72, 0.5); // beach tan
-    this.smoke.emit(x, 0.25, z, {
+    // Beach tan, kept well under the old 0.82: the lit-smoke shader and the
+    // post S-curve sit on top now, and a bright tan stack read as fire.
+    else this.tmp.setRGB(0.66, 0.57, 0.41);
+    this.smoke.emit(x, y + 0.25, z, {
       count: 2,
       color: this.tmp,
       speed: power * 0.55,
@@ -341,7 +438,7 @@ export class Fx {
     });
     if (surface === "grass") this.tmp.setHSL(0.29, 0.8, 0.42);
     else this.tmp.setHSL(0.11, 0.7, 0.68);
-    this.sparks.emit(x, 0.3, z, {
+    this.sparks.emit(x, y + 0.3, z, {
       count: 2,
       color: this.tmp,
       speed: power * (0.6 + Math.random() * 0.5),
@@ -351,6 +448,7 @@ export class Fx {
       life: 0.5,
       gravity: 9,
       drag: 1.2,
+      bloomGain: 0,
     });
   }
 

--- a/games/crazy-waymo/src/fx/vehicle-fx.ts
+++ b/games/crazy-waymo/src/fx/vehicle-fx.ts
@@ -46,7 +46,7 @@ export class VehicleFxRig {
     this.px = -fwdZ; // axle direction (perpendicular to heading)
     this.pz = fwdX;
 
-    if (drifting || car.isBoosting || brakingHard) this.emitSmoke(dt, car);
+    if (drifting || car.isBoosting || brakingHard) this.emitSmoke(dt, car, surface);
     if ((drifting && !car.airborne) || brakingHard) this.stampSkids();
     else this.lastSkid = null; // next streak starts fresh, not joined to this one
     this.emitTrails(car, drifting);
@@ -64,8 +64,9 @@ export class VehicleFxRig {
     if (this.kickAccum < cadence) return;
     this.kickAccum = 0;
     const power = 1.6 + Math.min(2.2, car.speed * 0.05);
-    this.fx.kickup(this.ax + this.px * 0.7, this.az + this.pz * 0.7, surface, power);
-    this.fx.kickup(this.ax - this.px * 0.7, this.az - this.pz * 0.7, surface, power);
+    const y = car.position.y;
+    this.fx.kickup(this.ax + this.px * 0.7, y, this.az + this.pz * 0.7, surface, power);
+    this.fx.kickup(this.ax - this.px * 0.7, y, this.az - this.pz * 0.7, surface, power);
   }
 
   // Rear-wheel light ribbons: drift slides, charged drifts and boost runs each
@@ -93,17 +94,33 @@ export class VehicleFxRig {
     const tier = car.driftTier;
     const hue = tier === 2 ? 0.07 : tier === 1 ? 0.58 : 0.13;
     const power = 2.6 + tier * 1.2;
-    this.fx.burst(this.ax + this.px * 0.8, 0.35, this.az + this.pz * 0.8, hue, 2 + tier, power);
-    this.fx.burst(this.ax - this.px * 0.8, 0.35, this.az - this.pz * 0.8, hue, 2 + tier, power);
+    const y = car.position.y + 0.35;
+    this.fx.burst(this.ax + this.px * 0.8, y, this.az + this.pz * 0.8, hue, 2 + tier, power);
+    this.fx.burst(this.ax - this.px * 0.8, y, this.az - this.pz * 0.8, hue, 2 + tier, power);
   }
 
-  private emitSmoke(dt: number, car: Car): void {
+  private emitSmoke(dt: number, car: Car, surface: "road" | "grass" | "sand" | "concrete"): void {
     this.puffAccum += dt;
     if (this.puffAccum < 0.03) return;
     this.puffAccum = 0;
     const charged = car.driftCharge >= 1 && car.isDrifting;
-    this.fx.driftPuff(this.ax + this.px * 0.7, this.az + this.pz * 0.7, car.isBoosting, charged);
-    this.fx.driftPuff(this.ax - this.px * 0.7, this.az - this.pz * 0.7, car.isBoosting, charged);
+    const y = car.position.y;
+    this.fx.driftPuff(
+      this.ax + this.px * 0.7,
+      y,
+      this.az + this.pz * 0.7,
+      car.isBoosting,
+      charged,
+      surface,
+    );
+    this.fx.driftPuff(
+      this.ax - this.px * 0.7,
+      y,
+      this.az - this.pz * 0.7,
+      car.isBoosting,
+      charged,
+      surface,
+    );
   }
 
   private stampSkids(): void {

--- a/games/crazy-waymo/src/main.ts
+++ b/games/crazy-waymo/src/main.ts
@@ -90,7 +90,7 @@ const governor = new PerfGovernor(renderer, game.sunLight, (features) => {
 
 if (import.meta.env.DEV) {
   void import("./debug/dev-hooks").then(({ installDevHooks }) => installDevHooks(game, governor));
-  Object.assign(window, { __renderer: renderer, __waymo: game });
+  Object.assign(window, { __renderer: renderer, __waymo: game, __post: post });
 }
 
 const timer = new THREE.Timer();

--- a/games/crazy-waymo/src/render/day-night.ts
+++ b/games/crazy-waymo/src/render/day-night.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { setGradeNight } from "./grade";
+import { setGradeNight, setGradeWarmth } from "./grade";
 import { NightSky } from "./night-sky";
 import { nightFillScale } from "./quality";
 import type { Sky } from "./sky";
@@ -56,6 +56,11 @@ type Stop = {
   readonly env: number;
   readonly lamp: number; // streetlights/headlights 0 off .. 1 full
   readonly exposure: number;
+  // Golden-hour warmth for the post grade (render/grade.ts setGradeWarmth):
+  // 0 = neutral daylight, 1 = full gilded golden/sunset. Deliberately its own
+  // channel — the lamp factor is 0 at golden hour BY DESIGN (lamps wait for
+  // the horizon), so the warm grade cannot piggyback on it.
+  readonly warmth: number;
   // Sky dome scattering:
   // [turbidity, rayleigh, mieCoefficient, mieDirectionalG, horizonRolloff].
   // These belong to the cycle, not to scene construction — how much air the sun
@@ -173,6 +178,7 @@ function stop(
   env: number,
   lamp: number,
   exposure: number,
+  warmth: number,
   sky: SkyPreset,
 ): Stop {
   return {
@@ -192,6 +198,7 @@ function stop(
     env,
     lamp,
     exposure,
+    warmth,
     sky,
   };
 }
@@ -215,16 +222,16 @@ const STOPS: readonly Stop[] = [
   // Day stops (Mario-Kart pass 2026-07-10): brighter exposure, big blue-sky
   // hemisphere fill + warm ground bounce so shadow sides glow instead of
   // going grey. Sun eased down to keep the white sidewalks from clipping.
-  //    p     sunEl sunAz  lightDir       color     int   hemiSky   hemiGnd   hInt  amb   ambColor  fog      near far  env   lamp  exp
-  stop(0.00,  35,   115,   dir(35, 115),  0xfff6e0, 1.75, 0xa9dcff, 0x6b6852, 0.52, 0.13, 0xffffff, 0x86b4e2, 460, 960, 0.32, 0,    0.72, SKY_DAY),
-  stop(0.25,  50,   150,   dir(50, 150),  0xfff2d8, 1.85, 0xa9dcff, 0x6b6852, 0.52, 0.13, 0xffffff, 0x7fb2e4, 480, 980, 0.32, 0,    0.72, SKY_DAY),
+  //    p     sunEl sunAz  lightDir       color     int   hemiSky   hemiGnd   hInt  amb   ambColor  fog      near far  env   lamp  exp   warm
+  stop(0.00,  35,   115,   dir(35, 115),  0xfff6e0, 1.75, 0xa9dcff, 0x6b6852, 0.52, 0.13, 0xffffff, 0x86b4e2, 460, 960, 0.32, 0,    0.72, 0.15, SKY_DAY),
+  stop(0.25,  50,   150,   dir(50, 150),  0xfff2d8, 1.85, 0xa9dcff, 0x6b6852, 0.52, 0.13, 0xffffff, 0x7fb2e4, 480, 980, 0.32, 0,    0.72, 0.05, SKY_DAY),
   // Golden hour is DAYLIGHT: sun still 12° up, blue sky, full-strength key.
   // The lamp factor used to open at 0.25 here, which lit the player's night
   // rig (a 70-candela spot plus two head sprites) under a noon-blue sky — the
   // single loudest thing in the most flattering frame the game has. Lamps now
   // wait for the sun to reach the horizon.
-  stop(0.40,  12,   235,   dir(12, 235),  0xffc27a, 1.7,  0xffd9b0, 0x655c44, 0.42, 0.12, 0xffffff, 0xbf9a83, 430, 940, 0.26, 0,    0.68, SKY_GOLDEN),
-  stop(0.47,   2,   248,   dir(4, 248),   0xff9350, 1.25, 0xff9d70, 0x3e3a44, 0.36, 0.11, 0xe0dcf0, 0xac7160, 400, 900, 0.18, 0.62, 0.68, SKY_SUNSET),
+  stop(0.40,  11,   235,   dir(11, 235),  0xffbe74, 1.9,  0xffd6a6, 0x6b5c40, 0.42, 0.12, 0xfff2e2, 0xc49a80, 430, 940, 0.26, 0,    0.70, 0.85, SKY_GOLDEN),
+  stop(0.47,   2,   248,   dir(4, 248),   0xff9350, 1.25, 0xff9d70, 0x3e3a44, 0.36, 0.11, 0xe0dcf0, 0xac7160, 400, 900, 0.18, 0.62, 0.68, 1.0,  SKY_SUNSET),
   // Night floors are tuned for PHONES: a desktop panel at full brightness can
   // read a 0.3-fill scene, a dim phone outdoors cannot. Moonlight carries the
   // shape of the city; streetlight glow carries the color. The night ambient
@@ -256,11 +263,11 @@ const STOPS: readonly Stop[] = [
   // Every night tint still keeps RED at or above GREEN (see above) and the
   // moon stays the only directional — halving it costs shape, so it falls less
   // than the fills do.
-  stop(0.53,  -3,   255,   MOON,          0x8d92c0, 0.28, 0x6e6398, 0x2a2d38, 0.17, 0.27, 0xc8b0c4, 0x35446a, 380, 900, 0.05, 1,    0.66, SKY_NIGHT),
-  stop(0.62, -30,   270,   MOON,          0x9b9ed6, 0.32, 0x5b4a80, 0x20242e, 0.18, 0.30, 0xc2a3bd, 0x1f2c52, 360, 880, 0.05, 1,    0.66, SKY_NIGHT),
-  stop(0.80, -30,    60,   MOON,          0x9b9ed6, 0.32, 0x5b4a80, 0x20242e, 0.18, 0.30, 0xc2a3bd, 0x1f2c52, 360, 880, 0.05, 1,    0.66, SKY_NIGHT),
-  stop(0.88,  -3,    95,   MOON,          0xc087a0, 0.30, 0x84719a, 0x2a2d38, 0.17, 0.27, 0xc9aabf, 0x4a4668, 380, 920, 0.05, 1,    0.66, SKY_NIGHT),
-  stop(0.94,   4,   105,   dir(6, 105),   0xffb27a, 1.3,  0xffc9a0, 0x4a443c, 0.28, 0.10, 0xffffff, 0xba8f7a, 450, 980, 0.20, 0.45, 0.66, SKY_SUNSET),
+  stop(0.53,  -3,   255,   MOON,          0x8d92c0, 0.28, 0x6e6398, 0x2a2d38, 0.17, 0.27, 0xc8b0c4, 0x35446a, 380, 900, 0.05, 1,    0.66, 0.3,  SKY_NIGHT),
+  stop(0.62, -30,   270,   MOON,          0x9b9ed6, 0.32, 0x5b4a80, 0x20242e, 0.18, 0.30, 0xc2a3bd, 0x1f2c52, 360, 880, 0.05, 1,    0.66, 0,    SKY_NIGHT),
+  stop(0.80, -30,    60,   MOON,          0x9b9ed6, 0.32, 0x5b4a80, 0x20242e, 0.18, 0.30, 0xc2a3bd, 0x1f2c52, 360, 880, 0.05, 1,    0.66, 0,    SKY_NIGHT),
+  stop(0.88,  -3,    95,   MOON,          0xc087a0, 0.30, 0x84719a, 0x2a2d38, 0.17, 0.27, 0xc9aabf, 0x4a4668, 380, 920, 0.05, 1,    0.66, 0.1,  SKY_NIGHT),
+  stop(0.94,   4,   105,   dir(6, 105),   0xffb27a, 1.3,  0xffc9a0, 0x4a443c, 0.28, 0.10, 0xffffff, 0xba8f7a, 450, 980, 0.20, 0.45, 0.66, 0.8,  SKY_SUNSET),
 ];
 
 // SF wall-clock hour (fractional, 0..24) right now. Intl handles DST; some
@@ -522,7 +529,8 @@ export class DayNight {
     }
     this.lamp = THREE.MathUtils.lerp(a.lamp, b.lamp, t);
     // The post grade needs the cycle too, and has no per-frame call site of its
-    // own — see render/grade.ts for why this is a signal and not a parameter.
+    // own — see render/grade.ts for why these are signals and not parameters.
     setGradeNight(this.lamp);
+    setGradeWarmth(THREE.MathUtils.lerp(a.warmth, b.warmth, t));
   }
 }

--- a/games/crazy-waymo/src/render/grade.ts
+++ b/games/crazy-waymo/src/render/grade.ts
@@ -1,18 +1,26 @@
-// One-way signal from the day-night rig to the post-processing grade.
+// One-way signals from the simulation to the post-processing grade.
 //
 // PostPipeline is built with (renderer, scene, camera) and rendered with no
-// arguments, so there is no per-frame call site to thread the cycle through —
-// and adding one would mean the scene owner re-deriving state DayNight already
-// computes every frame. This module is that seam, and the contract is
-// deliberately one-directional:
+// arguments, so there is no per-frame call site to thread state through —
+// and adding one would mean the scene owner re-deriving state its systems
+// already compute every frame. This module is that seam, and the contract is
+// deliberately one-directional per signal:
 //
-//   WRITER: DayNight.update(), once a frame. Nothing else.
-//   READER: PostPipeline.render(). Nothing else.
+//   night:  WRITER DayNight.update(), once a frame. READER PostPipeline.
+//   warmth: WRITER DayNight.update(), once a frame. READER PostPipeline.
+//   motion: WRITER GameScene.update(), once a frame. READER PostPipeline.
 //
-// Kept as a function pair rather than an exported mutable object so no consumer
+// Kept as function pairs rather than exported mutable objects so no consumer
 // can hold a reference and quietly become a second writer.
+//
+// `warmth` exists because `night` is the LAMP factor, which is 0 at golden
+// hour by design (lamps wait for sunset) — the warm-grade ramp needs its own
+// per-stop channel, not a re-reading of the lamps.
 
 let night = 0;
+let warmth = 0;
+let motionSpeed = 0;
+let motionBoost = false;
 
 /** 0 = broad daylight .. 1 = full night. Called by DayNight.update only. */
 export function setGradeNight(value: number): void {
@@ -21,4 +29,26 @@ export function setGradeNight(value: number): void {
 
 export function gradeNight(): number {
   return night;
+}
+
+/** 0 = neutral daylight .. 1 = full golden-hour warmth. DayNight.update only. */
+export function setGradeWarmth(value: number): void {
+  warmth = value;
+}
+
+export function gradeWarmth(): number {
+  return warmth;
+}
+
+/**
+ * Player motion for the speed-reactive lens: speed as a 0..1 fraction of the
+ * boost top speed, plus the boost flag. GameScene.update only.
+ */
+export function setGradeMotion(speedFrac: number, boosting: boolean): void {
+  motionSpeed = speedFrac;
+  motionBoost = boosting;
+}
+
+export function gradeMotion(): { speed: number; boost: boolean } {
+  return { speed: motionSpeed, boost: motionBoost };
 }

--- a/games/crazy-waymo/src/render/n8ao.d.ts
+++ b/games/crazy-waymo/src/render/n8ao.d.ts
@@ -1,0 +1,31 @@
+// n8ao ships no type declarations; this covers the surface the post chain
+// uses. The pass is built for three's example EffectComposer (renders the
+// scene itself into an internal half-float target — it REPLACES RenderPass).
+declare module "n8ao" {
+  import type * as THREE from "three";
+  import { Pass } from "three/addons/postprocessing/Pass.js";
+
+  export type N8AOConfiguration = {
+    aoRadius: number;
+    distanceFalloff: number;
+    intensity: number;
+    color: THREE.Color;
+    aoSamples: number;
+    denoiseSamples: number;
+    denoiseRadius: number;
+    halfRes: boolean;
+    depthAwareUpsampling: boolean;
+    screenSpaceRadius: boolean;
+    gammaCorrection: boolean;
+    autoDetectTransparency: boolean;
+    transparencyAware: boolean;
+    accumulate: boolean;
+    renderMode: number;
+  };
+
+  export class N8AOPass extends Pass {
+    constructor(scene: THREE.Scene, camera: THREE.Camera, width?: number, height?: number);
+    readonly configuration: N8AOConfiguration;
+    setSize(width: number, height: number): void;
+  }
+}

--- a/games/crazy-waymo/src/render/post.ts
+++ b/games/crazy-waymo/src/render/post.ts
@@ -1,25 +1,41 @@
 import * as THREE from "three";
+import { N8AOPass } from "n8ao";
 import { EffectComposer } from "three/addons/postprocessing/EffectComposer.js";
-import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
-import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
 import { ShaderPass } from "three/addons/postprocessing/ShaderPass.js";
+import { SMAAPass } from "three/addons/postprocessing/SMAAPass.js";
 import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
 
-import { gradeNight } from "./grade";
+import { gradeMotion, gradeNight, gradeWarmth } from "./grade";
 
-// Desktop-only post chain (Mario-Kart pass): threshold bloom so the additive
-// FX (drift trails, boost, lamp glow, lit windows) actually GLOW, plus a
-// gentle vibrance + vignette grade. Mobile stays on the single forward pass —
-// the tile-GPU bandwidth cost isn't worth it (and the governor already fights
-// for frame time there).
+// Desktop-only post chain (kart-racer pass): contact AO so nothing floats,
+// threshold bloom so the additive FX (drift trails, boost, lamp glow, lit
+// windows) actually GLOW, a linear-HDR vibrance/night grade, SMAA, and a
+// final display transform that owns tone mapping (highlight shoulder + ACES)
+// plus the film look — S-curve, teal/warm split tone, saturation with
+// highlight rolloff, speed-scaled chromatic aberration, vignette, grain.
+// Mobile stays on the single forward pass — the tile-GPU bandwidth cost isn't
+// worth it (and the governor already fights for frame time there).
 //
-// Tone mapping moves to the OutputPass automatically: it reads the renderer's
-// toneMapping/exposure every frame, so the day-night exposure ramp keeps
-// working unchanged.
+// Chain: N8AOPass (renders the scene + multiplies AO) → UnrealBloom →
+// WaymoGradeShader (pre-tonemap linear ops) → SMAA (three's pass wants
+// linear input, pre tone map) → FinalGradeShader (tone map + look, writes
+// sRGB to screen).
+//
+// TONE MAPPING NOW LIVES IN FinalGradeShader, not an OutputPass: it reads the
+// renderer's toneMappingExposure every frame, so the day-night exposure ramp
+// keeps working unchanged, and the mobile no-composer path (renderer ACES)
+// stays the fallback reference look.
+//
+// N8AO TRADES MSAA FOR SMAA. N8AOPass renders the scene into its own
+// non-multisampled HalfFloat target (it needs a sampleable depth texture), so
+// the composer's MSAA buffer would never see geometry. SMAA takes over edge
+// AA; thin-geometry crawl (wires, masts) is the thing to watch in pairs.
 
-// The grade runs BEFORE OutputPass, i.e. on pre-tone-map linear HDR. Every
-// operation below is therefore a linear-light one (mixes toward luminance,
-// channel gains) — an sRGB-shaped curve here would fight the tone mapper.
+// The grade runs BEFORE the display transform, i.e. on pre-tone-map linear
+// HDR. Every operation below is therefore a linear-light one (mixes toward
+// luminance, channel gains) — an sRGB-shaped curve here would fight the tone
+// mapper. Display-referred ops (S-curve, split tone, vignette) live in
+// FinalGradeShader instead.
 //
 // NIGHT IS A DIFFERENT PAINTING, NOT A DIMMED DAY. Lights can only ever
 // MULTIPLY an albedo, so no amount of moonlight tinting can take the chroma out
@@ -44,7 +60,6 @@ const GradeShader = {
   uniforms: {
     tDiffuse: { value: null },
     uVibrance: { value: 0.14 },
-    uVignette: { value: 0.18 },
     uNight: { value: 0 },
   },
   vertexShader: /* glsl */ `
@@ -57,7 +72,6 @@ const GradeShader = {
   fragmentShader: /* glsl */ `
     uniform sampler2D tDiffuse;
     uniform float uVibrance;
-    uniform float uVignette;
     uniform float uNight;
     varying vec2 vUv;
     const vec3 LUMA = vec3(0.2126, 0.7152, 0.0722);
@@ -96,9 +110,165 @@ const GradeShader = {
         float band = smoothstep(0.022, 0.11, nl) * (1.0 - smoothstep(0.40, 1.0, nl));
         c.rgb *= mix(1.0, mix(mix(1.0, 0.60, band), 1.0, src), uNight);
       }
-      vec2 d = vUv - 0.5;
-      c.rgb *= 1.0 - uVignette * smoothstep(0.15, 0.5, dot(d, d));
       gl_FragColor = c;
+    }
+  `,
+};
+
+// The display transform + film look, in one pass (ported from a kart-racer
+// reference grade, adapted to this game's radiances). Order inside:
+//   1. chromatic aberration gather (on linear — the offsets are sub-texel and
+//      capped, so the HDR fringe risk the sun disc poses is bounded by the cap)
+//   2. exposure (renderer.toneMappingExposure, via the day-night ramp)
+//   3. highlight shoulder — a power-law rolloff gated on max(rgb) BEFORE ACES
+//      so a 4x sky and a 20x glint still separate instead of both slamming
+//      into the ACES ceiling; includes highlight desaturation toward luma.
+//      Faded out at night: the night painting's emissive values are measured
+//      against plain ACES and must not soften.
+//   4. ACES fit (bit-for-bit three.js ACESFilmicToneMapping)
+//   5. midtone S-curve — smoothstep-toward-self keeps 0 and 1 pinned so it
+//      adds snap without crushing the shadow detail the AO pass paid for.
+//      Day-only: the night mid-tone dip already owns that range.
+//   6. teal-shadow / warm-highlight split tone. The cool axis is TEAL (G with
+//      B above unity), not blue — pure blue against a warm key reads violet.
+//      Day-weighted, and the warm side leans harder with uWarmth so golden
+//      hour reads gilded rather than merely bright.
+//   7. saturation lift with a highlight rolloff so bloomed glints go white,
+//      not neon.
+//   8. vignette — post-tonemap print-down; amount and inner edge close in
+//      with speed.
+//   9. monochrome grain, midtone-weighted, rolled off in shadows.
+//  10. sRGB encode (this pass writes the canvas — no OutputPass follows).
+const FinalGradeShader = {
+  name: "WaymoFinalGradeShader",
+  uniforms: {
+    tDiffuse: { value: null },
+    uExposure: { value: 0.62 },
+    uNight: { value: 0 },
+    uWarmth: { value: 0 },
+    uContrast: { value: 0.16 },
+    uSaturation: { value: 1.08 },
+    // x amount, y inner-edge radius
+    uVignette: { value: new THREE.Vector2(0.18, 0.3) },
+    uCA: { value: 0.0 },
+    uGrain: { value: 0.009 },
+    uTime: { value: 0 },
+    uAspect: { value: 16 / 9 },
+    uTexel: { value: new THREE.Vector2(1 / 1920, 1 / 1080) },
+  },
+  vertexShader: /* glsl */ `
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */ `
+    uniform sampler2D tDiffuse;
+    uniform float uExposure;
+    uniform float uNight;
+    uniform float uWarmth;
+    uniform float uContrast;
+    uniform float uSaturation;
+    uniform vec2 uVignette;
+    uniform float uCA;
+    uniform float uGrain;
+    uniform float uTime;
+    uniform float uAspect;
+    uniform vec2 uTexel;
+    varying vec2 vUv;
+    const vec3 LUMA = vec3(0.2126, 0.7152, 0.0722);
+    // Shoulder: knee 0.9, exponent 0.72, desat 0.16 across a 30x span.
+    const vec4 ROLLOFF = vec4(0.90, 0.72, 0.16, 30.0);
+    float hash12(vec2 p) {
+      vec3 q = fract(vec3(p.x, p.y, p.x) * 0.1031);
+      q += dot(q, q.yzx + 33.33);
+      return fract((q.x + q.y) * q.z);
+    }
+    vec3 shoulder(vec3 c) {
+      float m = max(max(c.r, c.g), c.b);
+      float knee = ROLLOFF.x;
+      if (m <= knee) return c;
+      float mc = knee * pow(m / knee, ROLLOFF.y);
+      vec3 scaled = c * (mc / max(m, 1e-5));
+      float desat = smoothstep(knee, knee * ROLLOFF.w, m) * ROLLOFF.z;
+      return mix(scaled, vec3(dot(scaled, LUMA)), desat);
+    }
+    vec3 rrtOdtFit(vec3 v) {
+      vec3 a = v * (v + 0.0245786) - 0.000090537;
+      vec3 b = v * (0.983729 * v + 0.4329510) + 0.238081;
+      return a / b;
+    }
+    // three.js ACESFilmicToneMapping, exposure folded in (the 1/0.6 matches).
+    vec3 acesToneMap(vec3 c) {
+      c *= uExposure / 0.6;
+      c = mat3(0.59719, 0.07600, 0.02840,
+               0.35458, 0.90834, 0.13383,
+               0.04823, 0.01566, 0.83777) * c;
+      c = rrtOdtFit(c);
+      c = mat3( 1.60475, -0.10208, -0.00327,
+               -0.53108,  1.10813, -0.07276,
+               -0.07367, -0.00605,  1.07602) * c;
+      return clamp(c, 0.0, 1.0);
+    }
+    void main() {
+      vec2 fromCentre = vUv - 0.5;
+      // rad: 1.0 at the frame corner at any aspect.
+      vec2 a = vec2(uAspect, 1.0);
+      float rad = length(fromCentre * a) / (0.5 * length(a));
+      // Chromatic aberration: edge-only (middle third bit-exact clean), shape
+      // squared, offset capped in TEXELS — past ~2 texels the fringe
+      // decorrelates specular aliasing into confetti; under 0.05 px it snaps
+      // off and the branch is a single fetch.
+      float caShape = smoothstep(0.34, 1.0, rad);
+      vec2 fringe = fromCentre * (uCA * caShape * caShape);
+      float fringePx = length(fringe / uTexel);
+      vec3 c;
+      if (fringePx < 0.05) {
+        c = texture2D(tDiffuse, vUv).rgb;
+      } else {
+        fringe *= min(fringePx, 2.0) / fringePx;
+        c = vec3(
+          texture2D(tDiffuse, vUv + fringe).r,
+          texture2D(tDiffuse, vUv).g,
+          texture2D(tDiffuse, vUv - fringe).b);
+      }
+      float dayW = 1.0 - uNight;
+      c = mix(c, shoulder(c), dayW);
+      c = acesToneMap(c);
+      // Midtone S-curve, day-weighted.
+      c = mix(c, c * c * (3.0 - 2.0 * c), uContrast * dayW);
+      // Golden hour swims in amber: a whole-frame white-balance lean, not just
+      // a highlight tint — at this game's exposure most of a street frame
+      // lives in the midtones, and warming only the highs left golden hour
+      // reading dusky-blue.
+      c *= mix(vec3(1.0), vec3(1.05, 1.0, 0.93), uWarmth * dayW * 0.65);
+      // Split tone. Teal shadows via a tiny additive lift (multiplies cannot
+      // tint blacks) + a cool multiply — the cool side stands down as warmth
+      // rises so the amber hour isn't fighting its own shadows; warm
+      // highlights lean further and reach deeper into the midtones with
+      // uWarmth.
+      float lum = dot(c, LUMA);
+      float shadowW = (1.0 - smoothstep(0.0, 0.55, lum)) * dayW;
+      float highW = smoothstep(mix(0.40, 0.24, uWarmth), 1.0, lum) * dayW;
+      c += vec3(-0.0009, 0.0025, 0.0030) * shadowW;
+      c *= mix(vec3(1.0), vec3(0.900, 1.010, 1.045), shadowW * (0.70 - 0.38 * uWarmth));
+      vec3 warmTint = mix(vec3(1.115, 1.005, 0.878), vec3(1.16, 1.00, 0.80), uWarmth);
+      c *= mix(vec3(1.0), warmTint, highW * (0.55 + 0.30 * uWarmth));
+      c = max(c, 0.0);
+      // Saturation lift with highlight rolloff, day-weighted (night owns its
+      // own desaturation painting).
+      lum = dot(c, LUMA);
+      float satAmt = 1.0 + (uSaturation - 1.0) * dayW;
+      c = max(mix(vec3(lum), c, satAmt * (1.0 - 0.40 * smoothstep(0.70, 1.0, lum))), 0.0);
+      // Vignette: print-down on the finished image.
+      c *= 1.0 - uVignette.x * smoothstep(uVignette.y, 1.02, rad);
+      // Grain: monochrome, midtone-weighted, shadow-rolled-off.
+      float g = hash12(vUv / uTexel * 1.37 + fract(uTime * 0.37) * 977.0) - 0.5;
+      lum = dot(c, LUMA);
+      c += g * uGrain * (1.15 - 0.75 * lum) * smoothstep(0.015, 0.14, lum);
+      gl_FragColor = vec4(max(c, 0.0), 1.0);
+      #include <colorspace_fragment>
     }
   `,
 };
@@ -173,21 +343,80 @@ const NIGHT_BLOOM_THRESHOLD = 0.85;
 // the facade mean 1.4% and the blown share 0.07pp and is invisible in a
 // same-camera pair — do not spend those constants on it.
 
+// Speed-reactive bloom: the lens brightens with pace, never with the clock.
+// Additive on top of the day/night ramp; the transient ignite term buys the
+// boost-release frame a halo without building a sustained veil.
+const BLOOM_FAST_LIFT = 0.06;
+const BLOOM_KICK_LIFT = 0.14;
+const BLOOM_IGNITE_LIFT = 0.18;
+
+// Chromatic aberration bounds (per-channel uv offset at |fromCentre| = 1).
+const CA_REST = 0.00045;
+const CA_BOOST = 0.0019;
+// Vignette speed language: amount rises, inner edge walks in.
+const VIGNETTE_BASE = 0.18;
+const VIGNETTE_SPEED = 0.12;
+const VIGNETTE_INNER_REST = 0.3;
+const VIGNETTE_INNER_FAST = 0.18;
+
+// N8AO: tight contact AO, cool-tinted, half-res. The radius stays SHORT —
+// large radii produce the flat grey haze that gives cheap AO away; the point
+// is the last metre where a wheel meets asphalt and a plinth meets pavement.
+const AO_RADIUS = 1.6;
+const AO_INTENSITY = 3.5;
+const AO_COLOR = 0x101c2a;
+
+// The speed/boost signal easing (CPU side). `fast` is the eased top-speed
+// ramp; `kick` eases the boost flag with a fast attack and slow release (the
+// lens should not snap back when the boost expires); `ignite` is a
+// leading-edge pulse that exists only while kick RISES — the eye reads
+// onsets, not states, so every lens term may overshoot for a fraction of a
+// second on ignition.
+const FAST_TAU = 0.11;
+const KICK_ATTACK = 0.05;
+const KICK_RELEASE = 0.28;
+const IGNITE_TAU = 0.42;
+const IGNITE_GAIN = 2.1;
+
 export class PostPipeline {
   private composer: EffectComposer;
+  // DEV probes reach in to A/B the AO contribution (debug/dev-hooks.ts).
+  readonly ao: N8AOPass;
   private bloom: UnrealBloomPass;
   private grade: ShaderPass;
+  private finalGrade: ShaderPass;
+  private renderer: THREE.WebGLRenderer;
+  private lastTime = 0;
+  private fast = 0;
+  private kick = 0;
+  private kickSlow = 0;
 
   constructor(renderer: THREE.WebGLRenderer, scene: THREE.Scene, camera: THREE.Camera) {
-    // Explicit HDR + MSAA target: bloom needs >8bit to find highlights, and
-    // the composer must not silently drop the context's antialiasing.
+    this.renderer = renderer;
+    // HDR target: bloom needs >8bit to find highlights. MSAA is intentionally
+    // absent — N8AOPass renders the scene into its own half-float target with
+    // a sampleable depth texture; SMAA at the end of the chain is the AA.
     const size = renderer.getDrawingBufferSize(new THREE.Vector2());
     const target = new THREE.WebGLRenderTarget(size.x, size.y, {
       type: THREE.HalfFloatType,
-      samples: 4,
     });
     this.composer = new EffectComposer(renderer, target);
-    this.composer.addPass(new RenderPass(scene, camera));
+    const ao = new N8AOPass(scene, camera, size.x, size.y);
+    ao.configuration.aoRadius = AO_RADIUS;
+    ao.configuration.distanceFalloff = 1.0;
+    ao.configuration.intensity = AO_INTENSITY;
+    ao.configuration.color = new THREE.Color(AO_COLOR);
+    ao.configuration.aoSamples = 16;
+    ao.configuration.denoiseSamples = 8;
+    ao.configuration.denoiseRadius = 6;
+    ao.configuration.halfRes = true;
+    ao.configuration.depthAwareUpsampling = true;
+    ao.configuration.screenSpaceRadius = false;
+    // Output must stay linear HDR for the bloom threshold to mean anything.
+    ao.configuration.gammaCorrection = false;
+    ao.configuration.autoDetectTransparency = false;
+    this.ao = ao;
+    this.composer.addPass(ao);
     // Threshold sits in PRE-tonemap linear HDR, so every number here is a
     // radiance, not a pixel value: keep the cut high and the strength gentle —
     // bloom should kiss the emissives (lamps, windows, trails, sun glare), not
@@ -204,18 +433,72 @@ export class PostPipeline {
     this.composer.addPass(this.bloom);
     this.grade = new ShaderPass(GradeShader);
     this.composer.addPass(this.grade);
-    this.composer.addPass(new OutputPass());
+    // SMAA runs on linear values by three's own contract (before tone map).
+    this.composer.addPass(new SMAAPass());
+    this.finalGrade = new ShaderPass(FinalGradeShader);
+    this.composer.addPass(this.finalGrade);
+    this.syncViewportUniforms(size.x, size.y);
+  }
+
+  private syncViewportUniforms(width: number, height: number): void {
+    const u = this.finalGrade.uniforms;
+    const aspect = u.uAspect;
+    if (aspect) aspect.value = width / Math.max(1, height);
+    const texel = u.uTexel;
+    if (texel && texel.value instanceof THREE.Vector2) {
+      texel.value.set(1 / Math.max(1, width), 1 / Math.max(1, height));
+    }
   }
 
   setSize(width: number, height: number, pixelRatio: number): void {
     this.composer.setPixelRatio(pixelRatio);
     this.composer.setSize(width, height);
+    this.syncViewportUniforms(width * pixelRatio, height * pixelRatio);
   }
 
   render(): void {
+    const now = performance.now() / 1000;
+    const dt = this.lastTime > 0 ? Math.min(0.1, now - this.lastTime) : 1 / 60;
+    this.lastTime = now;
+
     const night = gradeNight();
-    const u = this.grade.uniforms.uNight;
-    if (u) u.value = night;
+    const warmth = gradeWarmth();
+    const motion = gradeMotion();
+
+    // Signal easing. `fast` opens above ~62% of boost top speed.
+    const fastTarget = THREE.MathUtils.clamp((motion.speed - 0.62) / 0.38, 0, 1);
+    this.fast += (fastTarget - this.fast) * Math.min(1, dt / FAST_TAU);
+    const kickTarget = motion.boost ? 1 : 0;
+    const kickTau = kickTarget > this.kick ? KICK_ATTACK : KICK_RELEASE;
+    this.kick += (kickTarget - this.kick) * Math.min(1, dt / kickTau);
+    this.kickSlow += (this.kick - this.kickSlow) * Math.min(1, dt / IGNITE_TAU);
+    const ignite = THREE.MathUtils.clamp((this.kick - this.kickSlow) * IGNITE_GAIN, 0, 1);
+    const drive = Math.max(this.fast, this.kick);
+
+    const gu = this.grade.uniforms;
+    const un = gu.uNight;
+    if (un) un.value = night;
+
+    const fu = this.finalGrade.uniforms;
+    const exp = fu.uExposure;
+    if (exp) exp.value = this.renderer.toneMappingExposure;
+    const fn = fu.uNight;
+    if (fn) fn.value = night;
+    const fw = fu.uWarmth;
+    if (fw) fw.value = warmth;
+    const ca = fu.uCA;
+    if (ca) ca.value = CA_REST + (CA_BOOST - CA_REST) * Math.min(1.35, drive + ignite * 0.55);
+    const vig = fu.uVignette;
+    if (vig && vig.value instanceof THREE.Vector2) {
+      vig.value.set(
+        VIGNETTE_BASE + VIGNETTE_SPEED * drive + 0.07 * ignite,
+        VIGNETTE_INNER_REST +
+          (VIGNETTE_INNER_FAST - VIGNETTE_INNER_REST) * Math.min(1, drive + ignite * 0.6),
+      );
+    }
+    const time = fu.uTime;
+    if (time) time.value = now % 600;
+
     // The cut falls on sqrt(night), not on night. `night` IS the lamp factor,
     // so at dusk it is still only ~0.6 when every streetlight in the city is
     // already burning — and a linearly-interpolated cut is 3.0 there, above the
@@ -225,7 +508,12 @@ export class PostPipeline {
     // ends of the ramp are unchanged.
     this.bloom.threshold =
       DAY_BLOOM_THRESHOLD + (NIGHT_BLOOM_THRESHOLD - DAY_BLOOM_THRESHOLD) * Math.sqrt(night);
-    this.bloom.strength = DAY_BLOOM_STRENGTH + (NIGHT_BLOOM_STRENGTH - DAY_BLOOM_STRENGTH) * night;
+    this.bloom.strength =
+      DAY_BLOOM_STRENGTH +
+      (NIGHT_BLOOM_STRENGTH - DAY_BLOOM_STRENGTH) * night +
+      BLOOM_FAST_LIFT * this.fast +
+      BLOOM_KICK_LIFT * this.kick +
+      BLOOM_IGNITE_LIFT * ignite;
     this.composer.render();
   }
 }

--- a/games/crazy-waymo/src/scenes/game-scene.ts
+++ b/games/crazy-waymo/src/scenes/game-scene.ts
@@ -9,6 +9,7 @@ import { type Beacon, BeaconLights, collectBeacons } from "../fx/beacon-lights";
 import { ChaseCamera } from "../fx/camera-rig";
 import { SkyClouds } from "../fx/clouds";
 import { Harbor } from "../fx/harbor";
+import { ImpactStars } from "../fx/impact-stars";
 import type { SmashCones } from "../fx/cones";
 import type { Debris } from "../fx/debris";
 import type { LampGlow } from "../fx/lamp-glow";
@@ -38,6 +39,7 @@ import { readTransform, type RemoteCars } from "../net/remote-cars";
 import type { PhysicsWorld } from "../physics/physics-world";
 import { installAerialFog } from "../render/aerial-fog";
 import { DayNight } from "../render/day-night";
+import { setGradeMotion } from "../render/grade";
 import { FarTerrain } from "../render/far-terrain";
 import { LandmarkSilhouettes } from "../render/landmark-silhouette";
 import { FULL_QUALITY, isCoarsePointer, type QualityFeatures } from "../render/quality";
@@ -282,6 +284,7 @@ export class GameScene {
     () => this.skids,
   );
   private shocks = new Shockwaves();
+  private impactStars = new ImpactStars();
   private harbor = new Harbor();
   private oceanTime = { value: 0 };
   private dayNight: DayNight;
@@ -298,6 +301,7 @@ export class GameScene {
   private sceneFog: THREE.Fog;
 
   private sun = new THREE.DirectionalLight(0xfff2d8, 2.0);
+  private hemi = new THREE.HemisphereLight(0xbfe0ff, 0x4a4a3e, 0.35);
   private sky: Sky;
   // Feature tier pushed by the perf governor; desktop never leaves FULL.
   private quality: QualityFeatures = FULL_QUALITY;
@@ -316,6 +320,7 @@ export class GameScene {
   private scrSnapRight = new THREE.Vector3();
   private scrSnapUp = new THREE.Vector3();
   private scrSnapAnchor = new THREE.Vector3();
+  private shadowExtent = 58; // current shadow ortho half-extent (see updateSun)
   private mode: GameMode = { kind: "loading", progress: 0 };
   ready: Promise<void> = Promise.resolve();
   // What the start CTA shows while the city finishes behind the title.
@@ -487,8 +492,7 @@ export class GameScene {
     this.scene.fog = fog;
     this.sceneFog = fog;
 
-    const hemi = new THREE.HemisphereLight(0xbfe0ff, 0x4a4a3e, 0.35);
-    this.scene.add(hemi);
+    this.scene.add(this.hemi);
     const ambient = new THREE.AmbientLight(0xffffff, 0.08);
     this.scene.add(ambient);
 
@@ -673,6 +677,7 @@ vec3 ocGerstner(vec2 p, float t) {
     this.scene.add(this.speedLines.object3D);
     this.scene.add(this.clouds.group);
     this.scene.add(this.shocks.group);
+    this.scene.add(this.impactStars.group);
     // The bay's traffic rides the ocean plane, so it goes in with it.
     this.scene.add(this.harbor.group);
 
@@ -680,7 +685,7 @@ vec3 ocGerstner(vec2 p, float t) {
     this.dayNight = new DayNight({
       sky: this.sky,
       sun: this.sun,
-      hemi,
+      hemi: this.hemi,
       ambient,
       fog,
       scene: this.scene,
@@ -756,31 +761,62 @@ vec3 ocGerstner(vec2 p, float t) {
   // looked fine). 8-bit source texels cannot overflow anywhere. The
   // day-night cycle keeps modulating intensity via environmentIntensity.
   applyEnvironment(renderer: THREE.WebGLRenderer): void {
-    const face = (top: string, mid: string, bottom: string): HTMLCanvasElement => {
-      const c = document.createElement("canvas");
-      c.width = 16;
-      c.height = 16;
-      const g = c.getContext("2d");
-      if (g) {
-        const grad = g.createLinearGradient(0, 0, 0, 16);
-        grad.addColorStop(0, top);
-        grad.addColorStop(0.55, mid);
-        grad.addColorStop(1, bottom);
-        g.fillStyle = grad;
-        g.fillRect(0, 0, 16, 16);
-      }
-      return c;
-    };
+    const SIZE = 64;
     const SKY_TOP = "#7fb2e0";
     const HORIZON = "#dde6ea";
+    // Warm band hugging the horizon line: gives the clearcoat a sky-to-warm
+    // graduation to reflect instead of a flat two-tone split. Phase-neutral —
+    // this cube shines day and night at scene-driven intensity.
+    const WARM = "#f2ddc4";
     const GROUND = "#55534a";
-    const side = (): HTMLCanvasElement => face(SKY_TOP, HORIZON, GROUND);
+    const face = (paint: (g: CanvasRenderingContext2D) => void): HTMLCanvasElement => {
+      const c = document.createElement("canvas");
+      c.width = SIZE;
+      c.height = SIZE;
+      const g = c.getContext("2d");
+      if (g) paint(g);
+      return c;
+    };
+    const flat = (color: string): HTMLCanvasElement =>
+      face((g) => {
+        g.fillStyle = color;
+        g.fillRect(0, 0, SIZE, SIZE);
+      });
+    const sideGradient = (g: CanvasRenderingContext2D): void => {
+      const grad = g.createLinearGradient(0, 0, 0, SIZE);
+      grad.addColorStop(0, SKY_TOP);
+      grad.addColorStop(0.47, HORIZON);
+      grad.addColorStop(0.56, WARM);
+      grad.addColorStop(0.66, "#9b8d78");
+      grad.addColorStop(1, GROUND);
+      g.fillStyle = grad;
+      g.fillRect(0, 0, SIZE, SIZE);
+    };
+    const side = (): HTMLCanvasElement => face(sideGradient);
+    // The +x face carries a soft brighter lobe (sun-ish side): one side of
+    // the paint reads a highlight sweep as the car turns.
+    const sunSide = (): HTMLCanvasElement =>
+      face((g) => {
+        sideGradient(g);
+        const lobe = g.createRadialGradient(
+          SIZE * 0.5,
+          SIZE * 0.42,
+          0,
+          SIZE * 0.5,
+          SIZE * 0.42,
+          SIZE * 0.55,
+        );
+        lobe.addColorStop(0, "rgba(255, 240, 214, 0.45)");
+        lobe.addColorStop(1, "rgba(255, 240, 214, 0)");
+        g.fillStyle = lobe;
+        g.fillRect(0, 0, SIZE, SIZE);
+      });
     // Face order: +x, -x, +y, -y, +z, -z — sides run zenith→ground.
     const cube = new THREE.CubeTexture([
+      sunSide(),
       side(),
-      side(),
-      face(SKY_TOP, SKY_TOP, SKY_TOP),
-      face(GROUND, GROUND, GROUND),
+      flat(SKY_TOP),
+      flat(GROUND),
       side(),
       side(),
     ]);
@@ -1434,6 +1470,7 @@ vec3 ocGerstner(vec2 p, float t) {
     this.bubbles.update(dt);
     this.hud.update(dt);
     this.fx.update(dt);
+    this.impactStars.update(dt);
     const chase = this.car?.position ?? this.rig.camera.position;
     this.ambient?.update(dt, this.dayNight.lamp, this.sceneFog, chase.x, chase.z);
     this.skids?.update(dt);
@@ -1449,6 +1486,15 @@ vec3 ocGerstner(vec2 p, float t) {
       this.scene.fog.far = 12000;
     }
     const night = this.dayNight.lamp;
+    // Particle lighting rides the day-night rig: smoke catches the live sun/
+    // hemisphere mix, sparks gain toward the day bloom threshold (1 - lamp).
+    this.fx.setLighting(
+      this.sun.color,
+      this.sun.intensity,
+      this.hemi.color,
+      this.hemi.intensity,
+      1 - night,
+    );
     this.lampGlow?.setIntensity(night);
     this.nightWindows?.setIntensity(night);
     this.lampGlow?.updateNear(this.rig.camera.position.x, this.rig.camera.position.z, dt);
@@ -1559,6 +1605,7 @@ vec3 ocGerstner(vec2 p, float t) {
     );
     this.rig.camera.lookAt(car.position.x, car.position.y + 1.0, car.position.z);
     this.speedLines.update(dt, this.rig.camera, 0); // fade out leftover streaks
+    setGradeMotion(0, false); // and drain the post lens the same way
   }
 
   // 3-2-1-GO: the camera swoops from the title orbit into the chase pose while
@@ -1738,6 +1785,7 @@ vec3 ocGerstner(vec2 p, float t) {
       this.rig.addTrauma(0.35 + p * 0.5);
       this.hud.flash("#ffffff", 0.25 + p * 0.3);
       this.fx.burst(car.position.x, 1, car.position.z, 0.07, 10, 6 + p * 8);
+      this.impactStars.burst(car.position.x, car.position.y, car.position.z, p);
       this.sfx.crash(impact);
       this.debris?.burst(
         car.position.x,
@@ -1820,6 +1868,9 @@ vec3 ocGerstner(vec2 p, float t) {
     // under freecam (trailer fixed shots, DEV) feed 0 so leftovers fade out
     // instead of rushing along a static camera's forward axis.
     this.speedLines.update(dt, this.rig.camera, this.freecam ? 0 : car.speed / CAR.boostSpeed);
+    // The post lens (CA / vignette squeeze / bloom lift) reads the same
+    // motion; freecam feeds 0 so staged shots stay clean.
+    setGradeMotion(this.freecam ? 0 : car.speed / CAR.boostSpeed, !this.freecam && car.isBoosting);
     this.hud.setVignette(THREE.MathUtils.clamp((car.speed - 45) / 40, 0, 1) * 0.6);
     this.tickHud(dt, car, fares, true);
   }
@@ -2085,6 +2136,32 @@ vec3 ocGerstner(vec2 p, float t) {
     // Shadows follow the camera in freecam so any inspected spot is lit.
     const raw = this.freecam ? this.rig.camera.position : this.car?.position;
     if (!raw) return;
+    // Long low-sun shadows (desktop only): widen the follow-box as the sun
+    // drops so golden-hour shadows cast across the block instead of clipping
+    // at the box edge — and the same 2048 texels spread wider, which is the
+    // soft penumbra plain PCF cannot otherwise buy. Mobile keeps the fixed
+    // box: the cadenced texel-snap below assumes a constant extent between
+    // re-renders. normalBias scales with texel size or the wider box acnes.
+    if (this.quality.shadowEvery === 1 && !isCoarsePointer()) {
+      const elevY = this.scrSnapDir.copy(this.dayNight.sunOffset).normalize().y;
+      const ext = 58 + 16 * (1 - THREE.MathUtils.smoothstep(elevY, 0.15, 0.45));
+      if (Math.abs(ext - this.shadowExtent) > 0.25) {
+        this.shadowExtent = ext;
+        const sc = this.sun.shadow.camera;
+        sc.left = -ext;
+        sc.right = ext;
+        sc.top = ext;
+        sc.bottom = -ext;
+        sc.updateProjectionMatrix();
+        // The bias pair was tuned at extent 58: normalBias tracks texel size
+        // up, and the negative depth bias backs off with it — at the wider
+        // box the fixed -0.0005 read as contour-band acne down every steep
+        // Sunset street at golden hour.
+        const k = ext / 58;
+        this.sun.shadow.normalBias = 0.04 * k * k;
+        this.sun.shadow.bias = -0.0005 / (k * k);
+      }
+    }
     const anchor = this.scrSnapAnchor.copy(raw);
     // Cadenced shadow updates (mobile low tiers): snap the shadow camera to a
     // shadow-texel grid in light space, or every 2nd/3rd-frame re-render

--- a/games/crazy-waymo/src/ui/hud.ts
+++ b/games/crazy-waymo/src/ui/hud.ts
@@ -82,9 +82,14 @@ export class Hud {
   private scoreTarget = 0;
   private lastScorePop = 0;
   private lastMphDrawn = -1;
+  // Needle spring: the displayed mph trails the real one with a little mass.
+  private mphTarget = 0;
+  private mphShown = 0;
+  private mphVel = 0;
+  private dialLive = false;
 
-  // `coarseUi` (mobile): skip sub-mph dial redraws — the arc moves less than
-  // a pixel between same-rounded values. Desktop keeps the every-call redraw.
+  // `coarseUi` (mobile): skip sub-mph dial redraws — the needle moves less
+  // than a pixel between same-rounded values. Desktop redraws while moving.
   constructor(private coarseUi = false) {}
 
   update(dt: number): void {
@@ -97,6 +102,25 @@ export class Hud {
           : Math.max(this.scoreTarget, this.scoreShown - step);
       if (this.scoreVal) {
         this.scoreVal.textContent = `$${Math.round(this.scoreShown).toLocaleString("en-US")}`;
+      }
+    }
+    if (this.dialLive) {
+      // Under-damped follower (ratio ~0.58 of critical): a hard throttle or
+      // brake makes the needle overshoot slightly, like a gauge with mass.
+      // Two substeps keep it stable across a clamped 50ms frame.
+      const h = Math.min(dt, 0.05) / 2;
+      for (let i = 0; i < 2; i++) {
+        this.mphVel += (190 * (this.mphTarget - this.mphShown) - 16 * this.mphVel) * h;
+        this.mphShown += this.mphVel * h;
+      }
+      const settled =
+        Math.abs(this.mphVel) < 0.05 && Math.abs(this.mphTarget - this.mphShown) < 0.05;
+      const rounded = Math.round(Math.max(0, this.mphShown));
+      // The coarse throttle keys off the DISPLAYED value, so the spring still
+      // animates on mobile — it only skips sub-mph repaints.
+      if (rounded !== this.lastMphDrawn || (!this.coarseUi && !settled)) {
+        this.lastMphDrawn = rounded;
+        this.drawDial(Math.max(0, this.mphShown));
       }
     }
   }
@@ -159,39 +183,61 @@ export class Hud {
     );
   }
   setSpeed(mph: number): void {
-    const rounded = Math.round(mph);
-    if (this.coarseUi && rounded === this.lastMphDrawn) return;
-    this.lastMphDrawn = rounded;
-    this.drawDial(mph);
+    this.mphTarget = Math.max(0, mph);
+    if (!this.dialLive) {
+      // Seed the follower with the first reading — no full-sweep spawn swing.
+      this.dialLive = true;
+      this.mphShown = this.mphTarget;
+      this.lastMphDrawn = Math.round(this.mphShown);
+      this.drawDial(this.mphShown);
+    }
   }
 
-  // Mini speedo, modern-cluster style: semicircle arc with a short rim
-  // needle; the digits sit in the middle where a hub needle would be.
+  // Analogue gauge, kart-cluster style: dark face in a bevel + gold rim,
+  // 240° sweep, ticks every 10 (majors at 20), needle from the hub. The
+  // digital readout sits in the sweep's bottom gap under the hub.
   private drawDial(mph: number): void {
     const canvas = this.dial;
     if (!(canvas instanceof HTMLCanvasElement)) return;
+    const W = 120;
+    const H = 84;
     if (!this.dialCtx) {
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      canvas.width = 88 * dpr;
-      canvas.height = 52 * dpr;
+      canvas.width = W * dpr;
+      canvas.height = H * dpr;
       this.dialCtx = canvas.getContext("2d");
       this.dialCtx?.scale(dpr, dpr);
     }
     const ctx = this.dialCtx;
     if (!ctx) return;
     const DIAL_MAX = 100;
-    const cx = 44;
-    const cy = 46;
-    const r = 38;
-    // Semicircle gauge: left horizon → right horizon over the top.
-    const a0 = Math.PI;
-    const sweep = Math.PI;
+    const cx = 60;
+    const cy = 42;
+    const r = 29;
+    // 240° sweep, symmetric about 12 o'clock, opening at the bottom.
+    const a0 = Math.PI * (5 / 6);
+    const sweep = Math.PI * (4 / 3);
     const frac = Math.max(0, Math.min(1, mph / DIAL_MAX));
-    ctx.clearRect(0, 0, 88, 52);
-    ctx.lineCap = "round";
+    ctx.clearRect(0, 0, W, H);
+    // Face, warm bevel ring, gold rim — matches the .pill plate recipe.
+    ctx.beginPath();
+    ctx.arc(cx, cy, 38, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(20, 16, 12, 0.96)";
+    ctx.fill();
+    ctx.lineWidth = 4;
+    ctx.strokeStyle = "#352a1e";
+    ctx.beginPath();
+    ctx.arc(cx, cy, 35.5, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = "rgba(255, 209, 71, 0.9)";
+    ctx.beginPath();
+    ctx.arc(cx, cy, 38, 0, Math.PI * 2);
+    ctx.stroke();
     // Track, then the speed arc over it (color shifts toward the redline).
-    ctx.strokeStyle = "rgba(255,255,255,0.18)";
-    ctx.lineWidth = 5;
+    ctx.lineCap = "butt";
+    ctx.lineWidth = 7;
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.14)";
     ctx.beginPath();
     ctx.arc(cx, cy, r, a0, a0 + sweep);
     ctx.stroke();
@@ -201,32 +247,60 @@ export class Hud {
       ctx.arc(cx, cy, r, a0, a0 + sweep * frac);
       ctx.stroke();
     }
-    // Ticks every 20 mph.
-    ctx.strokeStyle = "rgba(255,255,255,0.45)";
-    ctx.lineWidth = 1.5;
-    for (let m = 0; m <= DIAL_MAX; m += 20) {
+    // Ticks inside the track: minors every 10 mph, longer majors every 20.
+    for (let m = 0; m <= DIAL_MAX; m += 10) {
+      const major = m % 20 === 0;
       const a = a0 + sweep * (m / DIAL_MAX);
+      const t1 = major ? 17.5 : 21;
+      ctx.strokeStyle = major ? "rgba(255, 255, 255, 0.7)" : "rgba(255, 255, 255, 0.32)";
+      ctx.lineWidth = major ? 2 : 1.5;
       ctx.beginPath();
-      ctx.moveTo(cx + Math.cos(a) * (r - 7), cy + Math.sin(a) * (r - 7));
-      ctx.lineTo(cx + Math.cos(a) * (r - 3), cy + Math.sin(a) * (r - 3));
+      ctx.moveTo(cx + Math.cos(a) * 24, cy + Math.sin(a) * 24);
+      ctx.lineTo(cx + Math.cos(a) * t1, cy + Math.sin(a) * t1);
       ctx.stroke();
     }
-    // Short rim needle — keeps the centre clear for the digits.
+    // Needle from the hub with a short counterweight tail; dark contour
+    // underneath so it survives crossing the bright arc colors.
     const na = a0 + sweep * frac;
-    ctx.strokeStyle = "#ff5a52";
-    ctx.lineWidth = 2.5;
+    const nx = Math.cos(na);
+    const ny = Math.sin(na);
+    ctx.lineCap = "round";
+    ctx.strokeStyle = "rgba(10, 7, 4, 0.7)";
+    ctx.lineWidth = 5.5;
     ctx.beginPath();
-    ctx.moveTo(cx + Math.cos(na) * (r - 13), cy + Math.sin(na) * (r - 13));
-    ctx.lineTo(cx + Math.cos(na) * (r - 3), cy + Math.sin(na) * (r - 3));
+    ctx.moveTo(cx - nx * 6, cy - ny * 6);
+    ctx.lineTo(cx + nx * 23, cy + ny * 23);
     ctx.stroke();
-    // Digits + unit, centred like a modern cluster.
-    ctx.fillStyle = "#8fd9ff";
+    ctx.strokeStyle = "#ff5a52";
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(cx - nx * 6, cy - ny * 6);
+    ctx.lineTo(cx + nx * 23, cy + ny * 23);
+    ctx.stroke();
+    // Hub cap.
+    ctx.beginPath();
+    ctx.arc(cx, cy, 5, 0, Math.PI * 2);
+    ctx.fillStyle = "#241d16";
+    ctx.fill();
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = "#ffd147";
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(cx, cy, 1.8, 0, Math.PI * 2);
+    ctx.fillStyle = "#ff5a52";
+    ctx.fill();
+    // Digital readout under the hub.
     ctx.textAlign = "center";
+    ctx.lineJoin = "round";
     ctx.font = "800 19px ui-monospace, 'SF Mono', Menlo, monospace";
-    ctx.fillText(String(Math.round(mph)), cx, cy - 4);
-    ctx.fillStyle = "rgba(255,255,255,0.55)";
-    ctx.font = "700 8px ui-monospace, 'SF Mono', Menlo, monospace";
-    ctx.fillText("MPH", cx, cy + 5);
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = "rgba(0, 0, 0, 0.75)";
+    ctx.strokeText(String(Math.round(mph)), cx, 69);
+    ctx.fillStyle = "#fff";
+    ctx.fillText(String(Math.round(mph)), cx, 69);
+    ctx.font = "800 8px ui-monospace, 'SF Mono', Menlo, monospace";
+    ctx.fillStyle = "rgba(255, 209, 71, 0.85)";
+    ctx.fillText("MPH", cx, 78);
   }
   setBoost(frac: number): void {
     this.boostFill.style.width = `${Math.round(Math.max(0, Math.min(1, frac)) * 100)}%`;
@@ -320,12 +394,14 @@ export class Hud {
 
   showCountdown(text: string, big: boolean): void {
     this.countdown.textContent = text;
+    // Scale-settle: land past 1, snap back — the digit reads as slammed down.
     this.countdown.animate(
       [
         { opacity: 0, transform: `translate(-50%,-50%) scale(${big ? 1.6 : 1.35})` },
-        { opacity: 1, transform: "translate(-50%,-50%) scale(1)", offset: 0.3 },
-        { opacity: 1, transform: "translate(-50%,-50%) scale(0.95)", offset: 0.8 },
-        { opacity: 0, transform: "translate(-50%,-50%) scale(0.9)" },
+        { opacity: 1, transform: "translate(-50%,-50%) scale(1.06)", offset: 0.28 },
+        { opacity: 1, transform: "translate(-50%,-50%) scale(1)", offset: 0.5 },
+        { opacity: 1, transform: "translate(-50%,-50%) scale(1)", offset: 0.8 },
+        { opacity: 0, transform: "translate(-50%,-50%) scale(0.92)" },
       ],
       { duration: big ? 700 : 480, easing: "ease-out" },
     );

--- a/games/crazy-waymo/src/vehicle/car.ts
+++ b/games/crazy-waymo/src/vehicle/car.ts
@@ -48,12 +48,41 @@ const LIDAR_DARK = new THREE.MeshStandardMaterial({
   roughness: 0.5,
   metalness: 0.2,
 });
+// Glossy accents (drum ring + door lenses) so the sensors catch the sun the
+// way the lacquered body does.
 const LIDAR_BLUE = new THREE.MeshStandardMaterial({
   color: 0x2f7de0,
   emissive: 0x1a5fbf,
   emissiveIntensity: 0.4,
-  roughness: 0.4,
+  roughness: 0.2,
 });
+
+// Toy-car lacquer for player-class bodies: physical clearcoat over the kit
+// colormap. The loader dedups MeshStandardMaterial per kit, so this MUST
+// build a fresh material per mesh — mutating the shared one would lacquer
+// every traffic/parked car cut from the same kit.
+const BODY_ROUGHNESS = 0.32;
+const BODY_CLEARCOAT_ROUGHNESS = 0.09;
+function lacquerMaterial(
+  src: THREE.MeshStandardMaterial,
+  tint: THREE.Color | null,
+): THREE.MeshPhysicalMaterial {
+  const m = new THREE.MeshPhysicalMaterial({
+    map: src.map,
+    color: src.color.clone(),
+    roughness: BODY_ROUGHNESS,
+    metalness: 0,
+    clearcoat: 1,
+    clearcoatRoughness: BODY_CLEARCOAT_ROUGHNESS,
+    side: src.side,
+    transparent: src.transparent,
+    opacity: src.opacity,
+    alphaTest: src.alphaTest,
+    vertexColors: src.vertexColors,
+  });
+  if (tint) m.color.multiply(tint).lerp(tint, 0.55);
+  return m;
+}
 
 // --- Robotaxi skins: swap the Waymo for other robotaxis. The Waymo body is a
 // pre-baked recolor GLB; the others repaint a base car in-engine (cloned
@@ -255,13 +284,13 @@ export function buildSkinBody(cache: ModelCache, skin: RobotaxiSkin): THREE.Obje
     wrap.add(inner);
     body = wrap;
   }
-  if (skin.tint !== undefined) {
-    const tint = new THREE.Color(skin.tint);
+  // Kenney-frame bodies (and any in-engine repaint) get the clearcoat; fitted
+  // generated GLBs keep their authored materials unless they're being tinted.
+  const tint = skin.tint !== undefined ? new THREE.Color(skin.tint) : null;
+  if (!skin.fit || tint) {
     body.traverse((c) => {
       if (c instanceof THREE.Mesh && c.material instanceof THREE.MeshStandardMaterial) {
-        const m = c.material.clone();
-        m.color.multiply(tint).lerp(tint, 0.55);
-        c.material = m;
+        c.material = lacquerMaterial(c.material, tint);
       }
     });
   }
@@ -406,7 +435,7 @@ function buildNightRig(): NightRig {
 export class Car {
   readonly object3D: THREE.Group;
   private body: THREE.Object3D;
-  private wheels: { node: THREE.Object3D; front: boolean }[] = [];
+  private wheels: { node: THREE.Object3D; front: boolean; restY: number; phys: number }[] = [];
   readonly position = new THREE.Vector3();
   private velocity = new THREE.Vector2(); // world XZ
   heading = 0; // yaw; forward = (sin, cos)
@@ -473,7 +502,11 @@ export class Car {
     this.wheels.length = 0;
     this.body.traverse((c) => {
       if (c.name.startsWith("wheel")) {
-        this.wheels.push({ node: c, front: c.name.includes("front") });
+        const front = c.name.includes("front");
+        // Physics wheel order is FL, FR, RL, RR (raycast-vehicle corners);
+        // map by node position so left wheels read left suspension.
+        const phys = (front ? 0 : 2) + (c.position.x < 0 ? 0 : 1);
+        this.wheels.push({ node: c, front, restY: c.position.y, phys });
       }
     });
   }
@@ -708,13 +741,22 @@ export class Car {
     this.wasAirborne = airborneNow;
     this.yVel = lv.y;
 
-    // Wheels: spin with speed, fronts steer with the physics steering angle.
+    // Wheels: spin with speed, fronts steer with the physics steering angle,
+    // and each rides its own suspension. Shorter-than-rest (compressed) lifts
+    // the wheel toward the arch: the body origin tracks the chassis, so when
+    // a spring compresses the body drops and the wheel must rise to stay on
+    // the ground. Suspension is world units; wheel nodes live inside the
+    // hero-scaled body.
     const fwdSpeed = this.forwardSpeed;
     this.wheelSpin += (fwdSpeed / WHEEL_RADIUS) * dt;
     const steerAngle = veh.wheelVisual(0).steering;
+    const rest = veh.params.suspensionRestLength;
+    const invScale = 1 / this.object3D.scale.y;
     for (const w of this.wheels) {
       w.node.rotation.x = this.wheelSpin;
       if (w.front) w.node.rotation.y = steerAngle;
+      const travel = rest - veh.wheelVisual(w.phys).suspension;
+      w.node.position.y = w.restY + THREE.MathUtils.clamp(travel, -0.12, 0.2) * invScale;
     }
     this.squash = Math.max(0, this.squash - dt * 5.5);
     const sq = this.squash;

--- a/games/crazy-waymo/src/world/roads.ts
+++ b/games/crazy-waymo/src/world/roads.ts
@@ -651,9 +651,12 @@ float roadPolish = 0.0;
         * (1.0 - smoothstep(0.35, 0.9, dphase)); // drop the pattern once undersampled
       vec3 conc = vec3(0.30, 0.29, 0.26);
       #ifdef ROAD_SURFACE_FULL
-        conc *= 0.88 + 0.24 * roadNoise(wp * 0.35); // slab-to-slab value variation
+        // Depths re-tuned for the post S-curve: the original 0.24/0.15 were
+        // authored against the flat vibrance-only grade and read as loud
+        // woodgrain down every steep block once midtone contrast arrived.
+        conc *= 0.93 + 0.14 * roadNoise(wp * 0.35); // slab-to-slab value variation
       #endif
-      diffuseColor.rgb = mix(diffuseColor.rgb, conc * (1.0 - groove * 0.15), steep * 0.7);
+      diffuseColor.rgb = mix(diffuseColor.rgb, conc * (1.0 - groove * 0.08), steep * 0.6);
     }
   }
   // --- CONCRETE: the walk and the kerb, which ride this same material with

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ catalogs:
       version: 4.114.0
     zod:
       specifier: ^4.4.3
-      version: 3.25.76
+      version: 4.4.3
 
 overrides:
   react-hook-form: ^7.72.1
@@ -275,7 +275,7 @@ importers:
         version: 11.18.0(@tanstack/react-query@5.101.4(react@19.2.8))(@trpc/client@11.18.0(@trpc/server@11.18.0(typescript@7.0.2))(typescript@7.0.2))(@trpc/server@11.18.0(typescript@7.0.2))(react@19.2.8)(typescript@7.0.2)
       better-auth:
         specifier: ^1.6.25
-        version: 1.6.25(9d1f6572957f145dd619ee97abd9efa2)
+        version: 1.6.25(b1c0983c8571c4388034006caef19218)
       lucide-react:
         specifier: ^1.26.0
         version: 1.26.0(react@19.2.8)
@@ -420,6 +420,9 @@ importers:
       '@vibedgames/multiplayer':
         specifier: workspace:^
         version: link:../../packages/multiplayer
+      n8ao:
+        specifier: ^2.0.0
+        version: 2.0.0(postprocessing@6.39.4(three@0.185.1))(three@0.185.1)
       polygon-clipping:
         specifier: ^0.15.7
         version: 0.15.7
@@ -731,7 +734,7 @@ importers:
         version: 1.0.20
       better-auth:
         specifier: ^1.6.25
-        version: 1.6.25(9d1f6572957f145dd619ee97abd9efa2)
+        version: 1.6.25(b1c0983c8571c4388034006caef19218)
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
@@ -6256,6 +6259,12 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  n8ao@2.0.0:
+    resolution: {integrity: sha512-7oajUGXk10jJIcjGxOgjRY2X/gy5wiLOY4eOiAfFJ51ljN6Djmsg+j8HMOip+SpqV7OkwzF9VCkDRLluxVlySA==}
+    peerDependencies:
+      postprocessing: '>=6.30.0'
+      three: '>=0.137'
+
   named-placeholders@1.1.6:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
@@ -6652,6 +6661,11 @@ packages:
   postgres@3.4.7:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
+
+  postprocessing@6.39.4:
+    resolution: {integrity: sha512-oAS/PjAbc/xT3OzjUrGsorJ4J064XwhVD2t0OwKLP/E8QwDMUJ0oOv6ZI1SYMtLchv4g0ySEx+JcLy92+48vlA==}
+    peerDependencies:
+      three: '>= 0.168.0 < 0.186.0'
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
@@ -8580,7 +8594,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260724.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.25(9d1f6572957f145dd619ee97abd9efa2)
+      better-auth: 1.6.25(b1c0983c8571c4388034006caef19218)
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
 
@@ -8610,7 +8624,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260724.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1)
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.25(9d1f6572957f145dd619ee97abd9efa2)
+      better-auth: 1.6.25(b1c0983c8571c4388034006caef19218)
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -11365,7 +11379,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.1: {}
 
-  better-auth@1.6.25(9d1f6572957f145dd619ee97abd9efa2):
+  better-auth@1.6.25(b1c0983c8571c4388034006caef19218):
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260724.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1)
       '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260724.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260724.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(sql.js@1.14.1))
@@ -13660,6 +13674,11 @@ snapshots:
       thenify-all: 1.6.0
     optional: true
 
+  n8ao@2.0.0(postprocessing@6.39.4(three@0.185.1))(three@0.185.1):
+    dependencies:
+      postprocessing: 6.39.4(three@0.185.1)
+      three: 0.185.1
+
   named-placeholders@1.1.6:
     dependencies:
       lru.min: 1.1.4
@@ -14085,6 +14104,10 @@ snapshots:
 
   postgres@3.4.7:
     optional: true
+
+  postprocessing@6.39.4(three@0.185.1):
+    dependencies:
+      three: 0.185.1
 
   powershell-utils@0.1.0: {}
 


### PR DESCRIPTION
## What

Port the visual language of [ryancampbell/kart-royale](https://github.com/ryancampbell/kart-royale) (its `ART_DIRECTION.md` golden-hour art bible) onto crazy-waymo. Everything is runtime-only — no `WORLD_REV` bump, no rebake.

**Post chain** (`src/render/post.ts`)
- N8AO contact AO (half-res, cool-tinted, tight 1.6u radius) — grounds every prop, wheel and building; the single biggest change in how expensive a frame reads.
- New merged final display pass replacing `OutputPass`: highlight shoulder + exact ACES fit, day midtone S-curve, teal-shadow/warm-highlight split tone, saturation lift with highlight rolloff, edge-only speed-scaled chromatic aberration, speed-squeezed vignette, film grain.
- SMAA replaces the MSAA the AO pass costs (N8AO renders the scene into its own non-multisampled target).
- The measured night grade and bloom thresholds are untouched; every new op is day-weighted so the night painting is bit-for-bit the same intent.

**Golden-hour identity** (`src/render/day-night.ts`, `grade.ts`)
- New per-stop `warmth` channel feeding the grade (the lamp factor is 0 at golden hour by design, so warmth needed its own one-way signal).
- Deeper amber golden stop; low-sun shadow box widening (58→74u) with extent-scaled bias pair for long soft shadows.
- New `setGradeMotion` seam: eased fast/kick/ignite signals drive CA, vignette and a bloom lift on boost.

**Car** (`src/vehicle/car.ts`)
- Player-body clearcoat lacquer via per-mesh `MeshPhysicalMaterial` clones (the loader dedups kit materials — a shared edit would leak onto all traffic).
- Per-wheel suspension bob (travel was exposed but never applied), glossier lidar accents, 64px env cube with a warm horizon band.

**FX** (`src/fx/`)
- Sun-lit smoke (top-lit point sprites — golden-hour smoke goes warm instead of flat grey), surface-tinted drift dust, cartoon impact stars on crashes (new `impact-stars.ts`).
- Day bloom gain on spark cores, per-emit (`aGain`): drift sparks and boost flames get white-hot centers; sand/grass kickup flecks opt out (a pool-wide gain read as fire).
- Bug fix: ground FX emitted at hardcoded y≈0.3 world, so drift smoke/sparks were invisible on every hill. Now seated at car height.

**HUD** (`index.html`, `src/ui/hud.ts`)
- Solid chunky panels with hard offset shadows (backdrop-blur dropped — mobile GPU win), analogue speedometer with hub needle + underdamped overshoot, hard text contours.

**Surface shaders** (`src/world/roads.ts`)
- Steep-street scoring depths re-tuned: authored against the old flat grade, they read as loud woodgrain once the S-curve landed.

Also: `.claude/launch.json` fixed for fnm-managed node (preview launcher spawns without interactive zsh) + a direct-vite `crazy-waymo` entry.

## Why

The kart-royale reference nails the look this game was reaching for: golden-hour warmth, AO grounding, toy-lacquer paint, readable arcade FX. This ports the techniques at parameter fidelity while respecting crazy-waymo's own measured tuning (night repaint, bloom cuts, mobile tier vetoes).

## Reviewer notes

- **Verification**: same-camera before/after pairs at 6 probe cameras (noon vista / golden chase / sunset / night / car close-up), action captures for drift/boost/crash, mobile-profile boot. Night frames match baseline by design. `pnpm test` 33/33 (world untouched), `tsc` and `oxlint` clean. Desktop holds governor tier 0 at ~14ms median @720p.
- **Mobile** never gets the composer (existing tile-GPU veto) — it picks up the warmer stops, lit smoke, clearcoat, and the cheaper solid HUD.
- `n8ao` is a new dependency (no types shipped; local declaration in `src/render/n8ao.d.ts`).
- Deliberately skipped: backlit foliage wrap-lighting (shared kit materials make it invasive), motion blur/DoF from the reference chain.
- Deploy is not included; needs a rebuild + `vg deploy` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Golden-hour visual overhaul for crazy-waymo: adds contact AO, a film-style final grade, clearcoat paint, lit FX, and a new HUD. Night rendering stays the same; all changes are runtime-only (no world rebake).

- New Features
  - Post: `n8ao` contact AO and a merged final display pass (ACES fit, S‑curve, split tone, saturation rolloff, chromatic aberration, vignette, grain); SMAA replaces MSAA; day/night bloom cuts preserved.
  - Speed lens: CA, vignette squeeze, and bloom lift now scale with speed and boost.
  - Day/night: per-stop warmth channel; deeper golden stop; widened low-sun shadow box with bias scaling.
  - Vehicle: player clearcoat via per-mesh `MeshPhysicalMaterial`; per-wheel suspension bob; glossier lidar; 64px env cube with a warm horizon band.
  - FX: sun‑lit smoke and surface‑tinted drift dust; hot spark cores via per-emit bloom gain; cartoon crash impact stars.
  - HUD: solid panels (no blur), analogue speedometer with an underdamped needle, sharper text contours.
  - Surfaces: re-tuned steep-street road scoring for the new grade.
  - Tools: preview launch fixed for `fnm`; added direct `vite` entry for crazy-waymo.

- Bug Fixes
  - Ground FX now emit at car height (were hardcoded near y≈0.3), so smoke/sparks render correctly on hills.

<sup>Written for commit cb549d8e58834f60ddef48dab0fbaf36f5dd7721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

