### PR TITLE
feat(crazy-waymo): full kart-royale graphics port — atmosphere, materials, car, FX, HUD

### DIFF
--- a/games/crazy-waymo/index.html
+++ b/games/crazy-waymo/index.html
@@ -19,13 +19,82 @@
         user-select: none;
         -webkit-tap-highlight-color: transparent;
       }
+      /* Warm-ink HUD tokens. Every dark stays hue 20-28° (never #000), every
+         light is cream (never #fff), gold is reserved for rank/payoff. */
+      :root {
+        --f:
+          "Avenir Next", "SF Pro Display", "Segoe UI", system-ui, -apple-system, "Helvetica Neue",
+          Arial, sans-serif;
+        --fd:
+          "Avenir Next Condensed", "Roboto Condensed", "PT Sans Narrow", "Arial Narrow",
+          "Helvetica Neue Condensed", ui-rounded, "SF Pro Rounded", var(--f);
+        --ink-2: #170e0a;
+        --ink-c: rgba(28, 15, 7, 0.93);
+        --paper: #fff4e2;
+        --dim: rgba(240, 220, 190, 0.66);
+        --gold: #ffcf6b;
+        --sky-warm: #ffd0a0;
+        --kerb-red: #e0453f;
+        --boost-blue: #4fc3ff;
+        --sea-shallow: #3fc9c4;
+        --gain-green: #7ef0a4;
+        --r: clamp(8px, 1.5vmin, 18px);
+        --ch: clamp(10px, 1.7vmin, 24px);
+        --rim: 1.5px;
+        /* Chamfer clips — each corner plate cuts the corner pointing INTO frame. */
+        --clip-br: polygon(
+          0 0,
+          100% 0,
+          100% calc(100% - var(--ch)),
+          calc(100% - var(--ch)) 100%,
+          0 100%
+        );
+        --clip-bl: polygon(0 0, 100% 0, 100% 100%, var(--ch) 100%, 0 calc(100% - var(--ch)));
+        --clip-tr: polygon(0 0, calc(100% - var(--ch)) 0, 100% var(--ch), 100% 100%, 0 100%);
+        --clip-tl: polygon(var(--ch) 0, 100% 0, 100% 100%, 0 100%, 0 var(--ch));
+        --clip-b2: polygon(
+          0 0,
+          100% 0,
+          100% calc(100% - var(--ch)),
+          calc(100% - var(--ch)) 100%,
+          var(--ch) 100%,
+          0 calc(100% - var(--ch))
+        );
+        --plate-bg: linear-gradient(179deg, #54402f 0%, #3d2b1e 30%, #281a12 66%, #170e0a 100%);
+        /* Gradient border: accent-tinted rim-light along the top edge, dark
+           die-cut contour along the bottom — a flat `border` reads as a form
+           control. */
+        --plate-rim: linear-gradient(
+          177deg,
+          color-mix(in srgb, var(--accent, var(--sky-warm)) 72%, #fff6e6) 0%,
+          color-mix(in srgb, var(--accent, var(--sky-warm)) 34%, rgba(255, 226, 186, 0.34)) 16%,
+          rgba(150, 112, 74, 0.4) 46%,
+          rgba(24, 12, 5, 0.88) 100%
+        );
+        /* drop-shadow, not box-shadow — box-shadow would square off the chamfer. */
+        --plate-shadow: drop-shadow(0 0.16vmin 0.28vmin rgba(20, 10, 4, 0.58))
+          drop-shadow(0 1vmin 2vmin rgba(24, 12, 5, 0.48));
+        /* 8-offset zero-blur contour ring; 0.039 ≈ 0.055/√2 keeps it round. */
+        --ring:
+          0.055em 0 0 var(--ink-c), -0.055em 0 0 var(--ink-c), 0 0.055em 0 var(--ink-c),
+          0 -0.055em 0 var(--ink-c), 0.039em 0.039em 0 var(--ink-c),
+          -0.039em 0.039em 0 var(--ink-c), 0.039em -0.039em 0 var(--ink-c),
+          -0.039em -0.039em 0 var(--ink-c), 0 0.07em 0.14em rgba(22, 11, 4, 0.62);
+        --ring-s:
+          0.07em 0 0 var(--ink-c), -0.07em 0 0 var(--ink-c), 0 0.07em 0 var(--ink-c),
+          0 -0.07em 0 var(--ink-c), 0.05em 0.05em 0 var(--ink-c), -0.05em 0.05em 0 var(--ink-c),
+          0.05em -0.05em 0 var(--ink-c), -0.05em -0.05em 0 var(--ink-c);
+        --e-out: cubic-bezier(0.16, 0.84, 0.44, 1);
+        --e-soft: cubic-bezier(0.33, 0, 0.16, 1);
+        --e-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+      }
       html,
       body {
         margin: 0;
         padding: 0;
         height: 100%;
         overflow: hidden;
-        background: #14111a;
+        background: var(--ink-2);
         color: #fff;
         font-family: ui-monospace, "SF Mono", Menlo, monospace;
         touch-action: none;
@@ -44,46 +113,69 @@
         inset: 0;
         pointer-events: none;
         z-index: 5;
+        font-family: var(--fd);
         font-weight: 700;
-        /* Hard contour on every HUD text so it survives a bright sky. */
-        text-shadow: 0 2px 0 rgba(0, 0, 0, 0.55);
+        font-variant-numeric: tabular-nums lining-nums;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        /* Contour ring on every HUD text so it survives a bright sky. */
+        text-shadow: var(--ring-s);
       }
-      /* Chunky kart plate: solid warm-dark body, dark bevel ring outside the
-         gold accent border, hard offset drop. No backdrop blur — the solid
-         panel replaces it (and it cost GPU on phones). */
+      /* THE plate, two-layer rim-light: the element paints the gradient RIM,
+         ::before paints the body inset by --rim over it. No backdrop blur —
+         the solid body replaces it (and it cost GPU on phones). */
       .pill {
         position: fixed;
-        background: rgba(24, 20, 16, 0.92);
-        border: 2px solid rgba(255, 209, 71, 0.75);
-        border-radius: 14px;
-        padding: 8px 14px;
+        background: var(--plate-rim);
+        border-radius: var(--r);
+        clip-path: var(--clip, none);
+        filter: var(--plate-shadow);
+        padding: 9px 15px;
         letter-spacing: 1px;
-        box-shadow:
-          0 0 0 2px rgba(16, 11, 7, 0.9),
-          0 5px 0 rgba(0, 0, 0, 0.45);
+      }
+      .pill::before {
+        content: "";
+        position: absolute;
+        inset: var(--rim);
+        border-radius: inherit;
+        background: var(--plate-bg);
+        clip-path: var(--clip, none);
+        /* sand bounce from below */
+        box-shadow: inset 0 -0.55vmin 1.3vmin rgba(255, 172, 98, 0.16);
+        /* the filter makes .pill a stacking context, so this cannot escape */
+        z-index: -1;
       }
       .label {
-        font-size: 10px;
-        font-weight: 900;
-        letter-spacing: 2px;
-        opacity: 0.7;
         display: block;
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.22em;
+        /* matching indent so a centred label doesn't sit half a tracking off */
+        text-indent: 0.22em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--accent, var(--sky-warm)) 52%, var(--dim));
       }
       .value {
-        font-size: 22px;
-        font-weight: 800;
-        font-variant-numeric: tabular-nums;
+        display: inline-block;
+        min-width: 4.2ch;
+        font-size: 24px;
+        font-weight: 900;
+        letter-spacing: 0.01em;
+        color: var(--paper);
+        text-shadow: var(--ring);
       }
 
       /* Current area — persistent, top-center */
       #area {
+        --clip: var(--clip-b2);
         top: calc(14px + env(safe-area-inset-top));
         left: 50%;
         transform: translateX(-50%);
         padding: 6px 16px;
         font-size: 12px;
-        letter-spacing: 2px;
-        color: #ffd147;
+        letter-spacing: 0.22em;
+        text-indent: 0.22em;
+        color: color-mix(in srgb, var(--sky-warm) 62%, var(--paper));
         white-space: nowrap;
         opacity: 0;
         transition: opacity 0.3s;
@@ -94,21 +186,21 @@
 
       /* Timer — big, top-center */
       #timer {
+        --accent: var(--gold);
+        --clip: var(--clip-b2);
         top: calc(14px + env(safe-area-inset-top));
         left: 50%;
         transform: translateX(-50%);
         text-align: center;
-        border-color: rgba(255, 209, 71, 0.85);
         padding: 6px 22px;
       }
       #timer .value {
         font-size: 46px;
-        color: #ffd147;
-        text-shadow: 0 3px 0 rgba(0, 0, 0, 0.5);
+        color: var(--gold);
         line-height: 1;
       }
       #timer.low .value {
-        color: #ff5a52;
+        color: var(--kerb-red);
       }
       #timer.low {
         animation: heartbeat 1s ease-in-out infinite;
@@ -143,38 +235,37 @@
         font-size: 18px;
         font-weight: 900;
         font-style: italic;
-        color: #ffd147;
-        text-shadow: 0 2px 0 rgba(0, 0, 0, 0.5);
+        color: var(--gold);
+        text-shadow: var(--ring-s);
       }
       #combo-track {
         height: 5px;
         border-radius: 3px;
-        background: rgba(255, 255, 255, 0.18);
+        background: rgba(18, 10, 4, 0.64);
+        box-shadow: inset 0 -1px 0 rgba(255, 226, 186, 0.14);
         overflow: hidden;
         margin-top: 3px;
       }
       #combo-fill {
         height: 100%;
         width: 100%;
-        background: #ffd147;
+        background: var(--gold);
       }
       #combo-meter.urgent #combo-fill {
-        background: #ff5a52;
+        background: var(--kerb-red);
       }
       #district {
         position: fixed;
         top: calc(120px + env(safe-area-inset-top));
         left: 50%;
         transform: translateX(-50%);
-        font:
-          800 italic 22px/1 system-ui,
-          sans-serif;
+        font: 900 italic 22px/1 var(--fd);
         letter-spacing: 1px;
-        color: #fff;
+        color: var(--paper);
         white-space: nowrap;
         text-shadow:
-          0 2px 0 rgba(0, 0, 0, 0.5),
-          0 0 18px rgba(255, 209, 71, 0.45);
+          var(--ring),
+          0 0 18px rgba(255, 190, 90, 0.45);
         opacity: 0;
         pointer-events: none;
       }
@@ -184,40 +275,43 @@
         left: 50%;
         transform: translateX(-50%);
         font-size: 30px;
-        color: #6bff8e;
-        text-shadow: 0 2px 0 rgba(0, 0, 0, 0.5);
+        color: var(--gain-green);
+        text-shadow: var(--ring);
         opacity: 0;
         pointer-events: none;
-        font-weight: 800;
+        font-weight: 900;
       }
 
-      /* Score — top-left */
+      /* Score — top-left. The operator accent (Waymo green et al) arrives via
+         hud.setOperator writing --accent: rim light + label tint re-skin. */
       #score {
+        --clip: var(--clip-br);
         top: calc(14px + env(safe-area-inset-top));
         left: calc(14px + env(safe-area-inset-left));
-      }
-      #score .value {
-        color: #fff;
       }
       #boost-track {
         width: 100px;
         height: 8px;
         border-radius: 5px;
-        background: rgba(0, 0, 0, 0.45);
+        background: rgba(18, 10, 4, 0.64);
+        box-shadow:
+          inset 0 1px 2px rgba(14, 7, 3, 0.68),
+          inset 0 -1px 0 rgba(255, 226, 186, 0.14);
         overflow: hidden;
         margin-top: 4px;
       }
       #boost-fill {
         height: 100%;
         width: 0%;
-        background: linear-gradient(90deg, #ffd147, #ff8a3c);
+        /* boost gold — deliberately NOT a tier colour: banked ≠ earning */
+        background: linear-gradient(90deg, var(--paper), #ffc24a);
         transition: width 0.1s linear;
       }
       #speed.denied {
         animation: denyshake 0.16s linear 2;
       }
       #speed.denied #boost-fill {
-        background: #ff5a52;
+        background: var(--kerb-red);
       }
       @keyframes denyshake {
         25% {
@@ -230,6 +324,8 @@
 
       /* Mini dash — analogue speedo gauge + boost, bottom-left */
       #speed {
+        --accent: var(--kerb-red);
+        --clip: var(--clip-tr);
         left: calc(14px + env(safe-area-inset-left));
         bottom: calc(14px + env(safe-area-inset-bottom));
         padding: 7px 10px 7px;
@@ -247,11 +343,12 @@
 
       /* Fare card — top-right, only while carrying a passenger */
       #fare-card {
+        --accent: var(--boost-blue);
+        --clip: var(--clip-bl);
         top: calc(40px + env(safe-area-inset-top));
         right: calc(14px + env(safe-area-inset-right));
         min-width: 150px;
         text-align: right;
-        border-color: rgba(73, 224, 255, 0.8);
         transition:
           opacity 0.2s,
           transform 0.2s;
@@ -264,27 +361,31 @@
       }
       #fare-card .who {
         font-size: 13px;
-        color: #49e0ff;
+        letter-spacing: 0.14em;
+        color: color-mix(in srgb, var(--boost-blue) 62%, var(--paper));
       }
       #fare-card .dist {
         font-size: 22px;
-        font-variant-numeric: tabular-nums;
-        color: #fff;
+        font-weight: 900;
+        min-width: 5ch;
+        color: var(--paper);
+        text-shadow: var(--ring);
       }
       #patience-track {
         height: 5px;
         border-radius: 3px;
-        background: rgba(255, 255, 255, 0.16);
+        background: rgba(18, 10, 4, 0.64);
+        box-shadow: inset 0 -1px 0 rgba(255, 226, 186, 0.14);
         overflow: hidden;
         margin-top: 6px;
       }
       #patience-fill {
         height: 100%;
         width: 100%;
-        background: #6bff8e;
+        background: var(--gain-green);
       }
 
-      /* Combo — center-ish, punchy */
+      /* Combo — center-ish, punchy. Gold: this is the payoff slot. */
       #combo {
         position: fixed;
         top: 30%;
@@ -293,10 +394,10 @@
         font-size: clamp(26px, 6vw, 60px);
         font-weight: 900;
         font-style: italic;
-        color: #ffd147;
+        color: var(--gold);
         text-shadow:
-          0 0 18px rgba(255, 160, 40, 0.8),
-          0 4px 0 rgba(0, 0, 0, 0.5);
+          var(--ring),
+          0 0 18px rgba(255, 160, 40, 0.8);
         opacity: 0;
         pointer-events: none;
         letter-spacing: 1px;
@@ -309,12 +410,12 @@
         left: 50%;
         transform: translate(-50%, 0);
         font-size: clamp(16px, 3.2vw, 30px);
-        font-weight: 800;
+        font-weight: 900;
         font-style: italic;
-        color: #aee3ff;
+        color: var(--paper);
         text-shadow:
-          0 0 12px rgba(80, 180, 255, 0.6),
-          0 3px 0 rgba(0, 0, 0, 0.5);
+          var(--ring),
+          0 0 12px rgba(255, 200, 120, 0.4);
         opacity: 0;
         pointer-events: none;
         letter-spacing: 1px;
@@ -333,11 +434,11 @@
         font-weight: 900;
         font-style: italic;
         letter-spacing: 1px;
-        text-shadow: 0 3px 0 rgba(0, 0, 0, 0.5);
+        text-shadow: var(--ring);
         margin-top: 2px;
       }
 
-      /* Speed vignette */
+      /* Speed vignette — the ONE allowed cool element in the warm-ink system. */
       #vignette {
         position: fixed;
         inset: 0;
@@ -347,36 +448,186 @@
         background: radial-gradient(ellipse at center, transparent 55%, rgba(8, 6, 14, 0.55) 100%);
       }
 
-      /* Countdown 3-2-1-GO */
+      /* Screen-edge drift rails. Peripheral vision resolves motion + colour +
+         temporal frequency, not shape — so the charge lives at the edges and
+         the tier is triple-encoded: height (fill = ladder position), hue
+         (--cc banked / --cn earning, written by hud.ts from fx/tier.ts so
+         screen and sparks can never disagree), pulse-rate (.t0/.t1/.t2).
+         One composited translateY per frame; opacity damped in JS. */
+      .rail {
+        position: fixed;
+        top: clamp(64px, 15vh, 150px);
+        bottom: clamp(64px, 15vh, 150px);
+        width: clamp(26px, 4.6vmin, 72px);
+        overflow: hidden;
+        z-index: 4;
+        pointer-events: none;
+        opacity: 0;
+        --cc: #ffd75e;
+        --cn: #4fc3ff;
+      }
+      #rail-l {
+        left: calc(env(safe-area-inset-left, 0px) + 6px);
+        -webkit-mask-image: linear-gradient(
+          to right,
+          #000 0%,
+          rgba(0, 0, 0, 0.5) 38%,
+          transparent 100%
+        );
+        mask-image: linear-gradient(to right, #000 0%, rgba(0, 0, 0, 0.5) 38%, transparent 100%);
+        transform-origin: left center;
+      }
+      #rail-r {
+        right: calc(env(safe-area-inset-right, 0px) + 6px);
+        -webkit-mask-image: linear-gradient(
+          to left,
+          #000 0%,
+          rgba(0, 0, 0, 0.5) 38%,
+          transparent 100%
+        );
+        mask-image: linear-gradient(to left, #000 0%, rgba(0, 0, 0, 0.5) 38%, transparent 100%);
+        transform-origin: right center;
+      }
+      /* Cap/handover stops in PX, not % — the element is full-rail-height and
+         translated, so % stops would be % of the whole rail and the banked
+         colour would vanish at low fill. Floor alpha 0.58: hue survives a
+         blown-out sky. Second layer = warm scrim floor, never fades out. */
+      .rail > i {
+        position: absolute;
+        inset: 0;
+        transform: translateY(100%);
+        background:
+          linear-gradient(
+            to bottom,
+            rgba(255, 250, 240, 0.98) 0px,
+            rgba(255, 250, 240, 0.98) 4px,
+            var(--cn) 5px,
+            var(--cn) 20px,
+            color-mix(in srgb, var(--cn) 55%, var(--cc)) 26px,
+            var(--cc) 34px,
+            color-mix(in srgb, var(--cc) 90%, transparent) 22%,
+            color-mix(in srgb, var(--cc) 74%, transparent) 56%,
+            color-mix(in srgb, var(--cc) 58%, transparent) 100%
+          ),
+          linear-gradient(
+            to bottom,
+            rgba(24, 13, 5, 0.8) 0%,
+            rgba(24, 13, 5, 0.64) 40%,
+            rgba(24, 13, 5, 0.5) 100%
+          );
+        animation: rail-pulse var(--pulse, 1.1s) var(--e-soft) infinite;
+      }
+      /* Rungs at exactly ⅓ and ⅔, fixed to the frame, over the bar — height
+         becomes a COUNT; cream between ink edges survives any backdrop. */
+      .rail::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background:
+          linear-gradient(
+            to bottom,
+            transparent calc(33.33% - 3px),
+            rgba(30, 16, 7, 0.88) calc(33.33% - 3px),
+            rgba(30, 16, 7, 0.88) calc(33.33% - 1px),
+            rgba(255, 246, 230, 0.96) calc(33.33% - 1px),
+            rgba(255, 246, 230, 0.96) calc(33.33% + 1px),
+            rgba(30, 16, 7, 0.88) calc(33.33% + 1px),
+            rgba(30, 16, 7, 0.88) calc(33.33% + 3px),
+            transparent calc(33.33% + 3px)
+          ),
+          linear-gradient(
+            to bottom,
+            transparent calc(66.66% - 3px),
+            rgba(30, 16, 7, 0.88) calc(66.66% - 3px),
+            rgba(30, 16, 7, 0.88) calc(66.66% - 1px),
+            rgba(255, 246, 230, 0.96) calc(66.66% - 1px),
+            rgba(255, 246, 230, 0.96) calc(66.66% + 1px),
+            rgba(30, 16, 7, 0.88) calc(66.66% + 1px),
+            rgba(30, 16, 7, 0.88) calc(66.66% + 3px),
+            transparent calc(66.66% + 3px)
+          );
+      }
+      /* Tier as temporal frequency. */
+      .rail.t0 {
+        --pulse: 1.1s;
+        --pulse-lo: 0.84;
+      }
+      .rail.t1 {
+        --pulse: 0.7s;
+        --pulse-lo: 0.74;
+      }
+      .rail.t2 {
+        --pulse: 0.4s;
+        --pulse-lo: 0.6;
+      }
+      @keyframes rail-pulse {
+        0%,
+        100% {
+          opacity: var(--pulse-lo, 0.84);
+        }
+        50% {
+          opacity: 1;
+        }
+      }
+      /* Tier-up flare. fill-mode none on purpose: a `both` fill would leave a
+         standing brightness() compositing pass forever. */
+      .rail.pop {
+        animation: rail-pop 0.44s var(--e-out);
+      }
+      @keyframes rail-pop {
+        0% {
+          transform: scaleX(2.4);
+          filter: brightness(2.6);
+        }
+        100% {
+          transform: scaleX(1);
+          filter: brightness(1);
+        }
+      }
+
+      /* Countdown 3-2-1-GO — the gold display ramp; GO! flips it green. */
       #countdown {
         position: fixed;
         top: 34%;
         left: 50%;
         transform: translate(-50%, -50%);
-        font:
-          900 italic clamp(70px, 16vw, 170px) / 1 system-ui,
-          sans-serif;
-        color: #ffd147;
-        text-shadow:
-          0 8px 0 rgba(0, 0, 0, 0.45),
-          0 0 50px rgba(255, 160, 40, 0.6);
+        font: 900 italic clamp(70px, 16vw, 170px) / 1 var(--fd);
+        letter-spacing: -0.02em;
+        /* clip-text numeral: the inherited ring would paint behind the
+           transparent glyphs — the drop-shadow stack is the contour here */
+        text-shadow: none;
+        background: linear-gradient(180deg, #fffdf6 5%, #ffe7ae 45%, #f7ae3c 84%, #e07c14 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        filter: drop-shadow(0 0.014em 0.012em rgba(26, 18, 8, 0.95))
+          drop-shadow(0 0.006em 0 rgba(26, 18, 8, 0.9))
+          drop-shadow(0 0 0.1em rgba(255, 170, 70, 0.55));
         opacity: 0;
         pointer-events: none;
       }
+      #countdown.go {
+        background: linear-gradient(180deg, #fdfff6 4%, #d6ffd0 36%, #6fe06a 72%, #1d9c38 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+      }
 
-      /* Minimap — north-up SF, flush with the bottom-right corner */
+      /* Minimap — north-up SF, flush with the bottom-right corner. A canvas
+         cannot host ::before, so the plate's rim is the padding ring: the
+         bitmap paints the content box and the gradient shows through --rim of
+         padding. Chamfer + drop-shadow match the plates. */
       #minimap {
         position: fixed;
         right: calc(14px + env(safe-area-inset-right));
         bottom: calc(14px + env(safe-area-inset-bottom));
         width: 148px;
         height: 148px;
-        border-radius: 14px;
-        border: 2px solid rgba(255, 209, 71, 0.75);
-        background: rgba(24, 20, 16, 0.92);
-        box-shadow:
-          0 0 0 2px rgba(16, 11, 7, 0.9),
-          0 5px 0 rgba(0, 0, 0, 0.45);
+        padding: var(--rim);
+        border-radius: var(--r);
+        --accent: var(--sea-shallow);
+        background: var(--plate-rim);
+        clip-path: var(--clip-tl);
+        filter: var(--plate-shadow);
         display: none;
         z-index: 5;
         pointer-events: none;
@@ -392,6 +643,13 @@
           top: auto;
           left: calc(14px + env(safe-area-inset-left));
           bottom: calc(138px + env(safe-area-inset-bottom));
+          clip-path: var(--clip-tr);
+        }
+        /* Rails end above the thumb zone: a thumb pad is opaque flesh and no
+           z-index fixes flesh. */
+        .rail {
+          top: 10vh;
+          bottom: 46vh;
         }
       }
       @media (pointer: coarse) and (max-height: 500px) {
@@ -409,6 +667,7 @@
           bottom: auto;
           left: calc(12px + env(safe-area-inset-left));
           top: calc(170px + env(safe-area-inset-top));
+          clip-path: var(--clip-br);
         }
       }
 
@@ -443,51 +702,49 @@
         opacity: 0;
         transition: opacity 0.3s ease;
         background: radial-gradient(
-          circle at 50% 40%,
-          rgba(20, 16, 28, 0.35),
-          rgba(10, 8, 14, 0.78)
+          ellipse 90% 80% at 50% 42%,
+          rgba(26, 15, 9, 0.35),
+          rgba(16, 9, 5, 0.78) 82%
         );
       }
       #banner.show {
         opacity: 1;
       }
       #banner-title {
-        font:
-          900 clamp(44px, 11vw, 120px) / 0.95 system-ui,
-          sans-serif;
+        font: 900 clamp(44px, 11vw, 120px) / 0.95 var(--fd);
         font-style: italic;
-        color: #ffd147;
+        color: var(--gold);
         letter-spacing: -2px;
         text-shadow:
-          0 6px 0 rgba(0, 0, 0, 0.45),
+          0 6px 0 rgba(23, 11, 4, 0.45),
           0 0 40px rgba(255, 160, 40, 0.5);
         transform: rotate(-3deg);
       }
       #banner-sub {
         margin-top: 18px;
         font-size: clamp(15px, 3.4vw, 22px);
-        color: #fff;
+        color: var(--paper);
         max-width: 80vw;
         line-height: 1.5;
-        text-shadow: 0 2px 0 rgba(0, 0, 0, 0.5);
+        text-shadow: 0 2px 0 rgba(23, 11, 4, 0.5);
       }
       #banner-stats {
         margin-top: 10px;
         font-size: clamp(13px, 2.6vw, 17px);
-        color: #aee3ff;
+        color: var(--dim);
         font-variant-numeric: tabular-nums;
       }
       #banner-cta {
         margin-top: 26px;
         font-size: 15px;
         letter-spacing: 2px;
-        color: #14111a;
-        background: #ffd147;
+        color: var(--ink-2);
+        background: linear-gradient(180deg, #fff3cc, #ffc84e 58%, #f09a1c);
         border-radius: 10px;
         padding: 12px 22px;
         pointer-events: auto;
         cursor: pointer;
-        box-shadow: 0 5px 0 rgba(0, 0, 0, 0.4);
+        box-shadow: 0 5px 0 rgba(23, 11, 4, 0.4);
         animation: pulse 1.4s ease-in-out infinite;
       }
       @keyframes pulse {
@@ -532,15 +789,13 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        background: #14111a;
+        background: var(--ink-2);
         z-index: 20;
         gap: 16px;
       }
       #loading .lt {
-        font:
-          900 italic clamp(34px, 9vw, 80px) / 1 system-ui,
-          sans-serif;
-        color: #ffd147;
+        font: 900 italic clamp(34px, 9vw, 80px) / 1 var(--fd);
+        color: var(--gold);
         transform: rotate(-3deg);
         letter-spacing: -2px;
       }
@@ -548,13 +803,13 @@
         width: min(60vw, 320px);
         height: 10px;
         border-radius: 6px;
-        background: rgba(255, 255, 255, 0.12);
+        background: rgba(255, 244, 226, 0.12);
         overflow: hidden;
       }
       #bar-fill {
         height: 100%;
         width: 100%;
-        background: #ffd147;
+        background: var(--gold);
         /* scaleX, not width: a width transition is layout and therefore stops
            dead whenever the main thread blocks (the world decode does, for
            seconds). A transform runs on the compositor and keeps moving. */
@@ -752,6 +1007,10 @@
         #timer.low {
           animation: none;
         }
+        .rail > i,
+        .rail.pop {
+          animation: none;
+        }
       }
       /* Landing screen: the banner is the whole screen. Hide every gameplay
          surface behind it — HUD pills, minimap, driver count, touch pad. */
@@ -787,7 +1046,7 @@
           Menlo,
           monospace;
         letter-spacing: 3px;
-        color: rgba(255, 209, 71, 0.75);
+        color: rgba(255, 207, 107, 0.75);
       }
       #banner-controls .hint {
         display: inline-flex;
@@ -1005,6 +1264,8 @@
     />
     <div id="netinfo"></div>
     <div id="hud">
+      <div class="rail" id="rail-l" aria-hidden="true"><i></i></div>
+      <div class="rail" id="rail-r" aria-hidden="true"><i></i></div>
       <div class="pill" id="timer">
         <span class="label">TIME</span><span class="value">60</span>
       </div>

--- a/games/crazy-waymo/src/fx/boost-plume.ts
+++ b/games/crazy-waymo/src/fx/boost-plume.ts
@@ -1,0 +1,479 @@
+import * as THREE from "three";
+
+import { REINHARD_CLIP, REINHARD_GLSL } from "./reinhard";
+
+// Boost flame as a MESH, not particles: two crossed ribbons per exhaust that
+// pivot about the exhaust axis in the vertex shader (billboard clouds lose the
+// axis under a chase cam; a rigid oriented tongue never does). The fragment
+// ramp is the kart-racer 3-stop flame: the hot end is a COLOR (#ff9d2e), white
+// is confined to a blue-white root kiss on <=7.5% of the tongue. Also home to
+// the shared instanced ground-ring pool (ignition stacks, drift promotion,
+// tier pulse) — rings are always ground-plane, thin, fast, and inherit the
+// car's velocity.
+
+// Flame ramp (kart-racer art bible). FLAME_MID deliberately equals the tier-2
+// orange so a sustained burn and the tier ladder share one orange.
+export const FLAME_EMBER = "#c4331a";
+export const FLAME_MID = "#ff9d2e";
+export const FLAME_ROOT = "#dcefff";
+export const FLAME_HOT = "#fff2d4";
+
+// Cone clamp: the AXIS (not the length) is what keeps the flame behind the
+// car — 18 degree half-angle about straight-back.
+export const PLUME_CONE_COS = Math.cos((18 * Math.PI) / 180);
+const PLUME_CONE_SIN = Math.sin((18 * Math.PI) / 180);
+
+// Size / radiance knobs (hand-tune pass: all screen reads live here).
+// Spine composites ~3.4 pre-shoulder at full burn — clears the ~1.6 day bloom
+// gate through the 0.13 max-channel shoulder with margin.
+const PLUME_LEN_BASE = 1.7;
+const PLUME_LEN_BURN = 0.8;
+const PLUME_RAD_BASE = 0.3;
+const PLUME_RAD_BURN = 0.12;
+const PLUME_INT_BASE = 2.1;
+const PLUME_INT_BURN = 0.8;
+const PLUME_IGNITE_LEN = 0.3;
+const PLUME_IGNITE_RAD = 0.18;
+const PLUME_IGNITE_INT = 0.55;
+const PLUME_IGNITE_DECAY = 2.9; // 1/s — onset spike over plateau
+const PLUME_ALPHA = 0.88;
+// Screen-space budget as fractions of frame height, evaluated per frame in
+// the VS from the true view depth — waymo's chase cam sits closer than the
+// reference rig, so the clamp self-derives instead of hardcoding a distance.
+const PLUME_W_BUDGET = 0.16;
+const PLUME_L_BUDGET = 0.36;
+// Camera-alignment response: shorten and widen as the axis turns to face the
+// eye (the head-on afterburner read).
+const PLUME_SHORTEN = 0.26;
+const PLUME_WIDEN = 0.7;
+const PLUME_SEGS = 11;
+const PLUME_BURN_ATTACK = 12; // 1/s ease toward the drive target
+const PLUME_BURN_RELEASE = 8;
+
+/** Clamp unit vector (ax,ay,az) into the cone about unit (bx,by,bz). */
+export function clampAxisToCone(
+  ax: number,
+  ay: number,
+  az: number,
+  bx: number,
+  by: number,
+  bz: number,
+  out: { x: number; y: number; z: number },
+): void {
+  const d = ax * bx + ay * by + az * bz;
+  if (d >= PLUME_CONE_COS) {
+    out.x = ax;
+    out.y = ay;
+    out.z = az;
+    return;
+  }
+  let px = ax - bx * d;
+  let py = ay - by * d;
+  let pz = az - bz * d;
+  const pl = Math.hypot(px, py, pz);
+  if (pl < 1e-6) {
+    out.x = bx;
+    out.y = by;
+    out.z = bz;
+    return;
+  }
+  px /= pl;
+  py /= pl;
+  pz /= pl;
+  out.x = bx * PLUME_CONE_COS + px * PLUME_CONE_SIN;
+  out.y = by * PLUME_CONE_COS + py * PLUME_CONE_SIN;
+  out.z = bz * PLUME_CONE_COS + pz * PLUME_CONE_SIN;
+}
+
+const PLUME_VERT = /* glsl */ `
+  attribute vec3 aMeta; // x: exhaust stack (0|1), y: roll (0 tongue | 1 fin), z: seed
+  uniform float uTime;
+  uniform vec3 uOriginL;
+  uniform vec3 uOriginR;
+  uniform vec3 uAxis;
+  uniform float uLen;
+  uniform float uRad;
+  varying float vU;
+  varying float vSide;
+  varying float vAlign;
+  varying float vFade;
+  void main() {
+    float u = position.x;
+    float side = position.y;
+    vec3 origin = mix(uOriginL, uOriginR, aMeta.x);
+    vec3 toEye = cameraPosition - origin;
+    float dist = max(length(toEye), 0.001);
+    toEye /= dist;
+    float align = abs(dot(uAxis, toEye));
+    // Ribbon frame: tongue widens perpendicular to the view, the crossed fin
+    // sits 90 degrees around the axis and fades in as align^2 (head-on read).
+    vec3 s = cross(uAxis, toEye);
+    float sl = length(s);
+    vec3 fb = abs(uAxis.y) < 0.9 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+    s = sl > 0.001 ? s / sl : normalize(cross(uAxis, fb));
+    vec3 fin = normalize(cross(uAxis, s));
+    vec3 sideDir = mix(s, fin, aMeta.y);
+    float L = uLen * (1.0 - ${PLUME_SHORTEN.toFixed(2)} * align);
+    float W = uRad * (1.0 + ${PLUME_WIDEN.toFixed(2)} * align);
+    // Screen budget: scale DOWN (never up) so the flame stays smaller than
+    // its subject at any camera distance.
+    float viewZ = max(-(viewMatrix * vec4(origin, 1.0)).z, 0.5);
+    float pxPer = projectionMatrix[1][1] / (2.0 * viewZ); // frame-height fraction per metre
+    float budget = min(
+      1.0,
+      min(${PLUME_W_BUDGET} / max(2.0 * W * pxPer, 0.0001),
+          ${PLUME_L_BUDGET} / max(L * pxPer, 0.0001)));
+    L *= budget;
+    W *= budget;
+    // Pinched at the mouth, widest at ~1/4, never a cone.
+    float prof = pow(1.0 - u, 0.62) * (0.34 + 0.66 * smoothstep(0.0, 0.26, u));
+    // Flicker + lateral lick are both * u: the root stays welded to the pipe.
+    float flick = 1.0 + 0.26 * sin(u * 9.3 + uTime * (14.0 + 8.0 * aMeta.z)) * u;
+    float lick = sin(uTime * (9.0 + 6.0 * aMeta.z) + u * 4.0 + aMeta.z * 17.0) * 0.16 * u;
+    float w = W * prof * flick;
+    vec3 wp = origin + uAxis * (u * L) + sideDir * (side * w + lick * W);
+    vU = u;
+    vSide = side;
+    vAlign = align;
+    float finFade = mix(1.0, align * align, aMeta.y);
+    float distFade = clamp(1.25 - dist / 90.0, 0.15, 1.0);
+    vFade = finFade * distFade;
+    gl_Position = projectionMatrix * viewMatrix * vec4(wp, 1.0);
+  }
+`;
+
+// Coverage-driven knee: overlapping tongues saturate toward orange instead of
+// paper — the knee widens with alpha so dense coverage compresses harder.
+const PLUME_FRAG = /* glsl */ `
+  uniform float uIntensity;
+  uniform float uGain;
+  uniform vec3 uTint;
+  varying float vU;
+  varying float vSide;
+  varying float vAlign;
+  varying float vFade;
+  void main() {
+    float spine = exp(-vSide * vSide * 4.0);
+    float body = pow(max(1.0 - abs(vSide), 0.0), 0.62);
+    float axial = pow(1.0 - vU, 1.15) * smoothstep(0.0, 0.09, vU);
+    vec3 ember = vec3(0.769, 0.200, 0.102); // ${FLAME_EMBER}
+    vec3 mid   = vec3(1.000, 0.616, 0.180); // ${FLAME_MID}
+    vec3 root  = vec3(0.863, 0.937, 1.000); // ${FLAME_ROOT}
+    float temp = clamp((1.0 - vU * 1.15) * (0.28 + 0.72 * spine), 0.0, 1.0);
+    vec3 rgb = mix(ember, mid, smoothstep(0.0, 0.55, temp));
+    float kiss = spine * (1.0 - smoothstep(0.0, 0.075, vU)); // root kiss <= 7.5%
+    rgb = mix(rgb, root, kiss * 0.55);
+    // Tier owns the sheath and tail, with a floor so it reads on the spine too.
+    rgb = mix(rgb, uTint, clamp(0.26 + (1.0 - spine) * 0.50 + vU * 0.36, 0.0, 0.88));
+    float a = axial * (0.42 * body + 0.74 * spine) * mix(1.0, 0.80, vAlign) * vFade
+      * ${PLUME_ALPHA};
+    rgb *= uIntensity * uGain;
+    float mx = max(rgb.r, max(rgb.g, rgb.b));
+    float knee = ${REINHARD_CLIP} * (1.0 + 1.6 * a);
+    rgb *= 1.0 / (1.0 + mx * knee);
+    gl_FragColor = vec4(rgb, a);
+  }
+`;
+
+export class BoostPlume {
+  readonly mesh: THREE.Mesh;
+  private uTime = { value: 0 };
+  private uOriginL = { value: new THREE.Vector3() };
+  private uOriginR = { value: new THREE.Vector3() };
+  private uAxis = { value: new THREE.Vector3(0, 0, -1) };
+  private uLen = { value: 0 };
+  private uRad = { value: 0 };
+  private uIntensity = { value: 0 };
+  private uTint = { value: new THREE.Color(FLAME_MID) };
+  private burn = 0;
+  private burnTarget = 0;
+  private igniteT = 0;
+
+  constructor(gain: THREE.IUniform<number>) {
+    const ribs = 4; // 2 exhaust stacks x (tongue + fin)
+    const rows = PLUME_SEGS + 1;
+    const verts = ribs * rows * 2;
+    const pos = new Float32Array(verts * 3);
+    const meta = new Float32Array(verts * 3);
+    const index = new Uint16Array(ribs * PLUME_SEGS * 6);
+    const seeds = [0.13, 0.61, 0.37, 0.89];
+    let ii = 0;
+    for (let r = 0; r < ribs; r++) {
+      const stack = r >> 1;
+      const roll = r & 1;
+      const seed = seeds[r] ?? 0.5;
+      for (let i = 0; i < rows; i++) {
+        const u = i / PLUME_SEGS;
+        for (let sIdx = 0; sIdx < 2; sIdx++) {
+          const v = (r * rows + i) * 2 + sIdx;
+          pos[v * 3] = u;
+          pos[v * 3 + 1] = sIdx === 0 ? -1 : 1;
+          meta[v * 3] = stack;
+          meta[v * 3 + 1] = roll;
+          meta[v * 3 + 2] = seed;
+        }
+        if (i > 0) {
+          const a = (r * rows + i - 1) * 2;
+          const b = (r * rows + i) * 2;
+          index[ii++] = a;
+          index[ii++] = b;
+          index[ii++] = a + 1;
+          index[ii++] = b;
+          index[ii++] = b + 1;
+          index[ii++] = a + 1;
+        }
+      }
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute("position", new THREE.BufferAttribute(pos, 3));
+    geo.setAttribute("aMeta", new THREE.BufferAttribute(meta, 3));
+    geo.setIndex(new THREE.BufferAttribute(index, 1));
+    geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
+    const mat = new THREE.ShaderMaterial({
+      uniforms: {
+        uTime: this.uTime,
+        uOriginL: this.uOriginL,
+        uOriginR: this.uOriginR,
+        uAxis: this.uAxis,
+        uLen: this.uLen,
+        uRad: this.uRad,
+        uIntensity: this.uIntensity,
+        uTint: this.uTint,
+        uGain: gain,
+      },
+      vertexShader: PLUME_VERT,
+      fragmentShader: PLUME_FRAG,
+      transparent: true,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+    });
+    this.mesh = new THREE.Mesh(geo, mat);
+    this.mesh.frustumCulled = false;
+    this.mesh.renderOrder = 4;
+    this.mesh.visible = false;
+  }
+
+  /** Per-frame pose while boosting (burnTarget 0 hides after the ease-out).
+   *  The axis must already be cone-clamped (clampAxisToCone). */
+  drive(
+    lx: number,
+    ly: number,
+    lz: number,
+    rx: number,
+    ry: number,
+    rz: number,
+    ax: number,
+    ay: number,
+    az: number,
+    burnTarget: number,
+  ): void {
+    this.uOriginL.value.set(lx, ly, lz);
+    this.uOriginR.value.set(rx, ry, rz);
+    this.uAxis.value.set(ax, ay, az);
+    this.burnTarget = burnTarget;
+  }
+
+  setTint(c: THREE.Color): void {
+    this.uTint.value.copy(c);
+  }
+
+  /** Ignition spike: added on top of the smoothed burn so frame 1 of a boost
+   *  is visibly different from frame 20 — the eye reads onsets. */
+  ignite(strength: number): void {
+    this.igniteT = Math.max(this.igniteT, strength);
+  }
+
+  update(dt: number): void {
+    this.uTime.value += dt;
+    this.igniteT *= Math.exp(-PLUME_IGNITE_DECAY * dt);
+    const rate = this.burnTarget > this.burn ? PLUME_BURN_ATTACK : PLUME_BURN_RELEASE;
+    this.burn += (this.burnTarget - this.burn) * Math.min(1, dt * rate);
+    const ig = this.igniteT;
+    this.uLen.value = (PLUME_LEN_BASE + PLUME_LEN_BURN * this.burn) * (1 + PLUME_IGNITE_LEN * ig);
+    this.uRad.value = (PLUME_RAD_BASE + PLUME_RAD_BURN * this.burn) * (1 + PLUME_IGNITE_RAD * ig);
+    this.uIntensity.value =
+      (PLUME_INT_BASE + PLUME_INT_BURN * this.burn) * (1 + PLUME_IGNITE_INT * ig);
+    this.mesh.visible = this.burn > 0.02;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Instanced ground-ring pool. Grammar: ground-plane, thin (3.5-9% of radius),
+// fast (0.20-0.42 s), and the centre inherits the car's velocity with drag —
+// a world-pinned ring is metres adrift of the car by the time it fades.
+
+const RING_COUNT = 16;
+const RING_SEGS = 48;
+
+const RING_VERT = /* glsl */ `
+  attribute vec4 aCenter; // xyz + birth
+  attribute vec4 aShape;  // r0, r1, life, thickness (fraction of radius)
+  attribute vec4 aColor;  // rgb premultiplied by intensity, w = alpha
+  attribute vec4 aDrift;  // vx, vz, drag
+  uniform float uTime;
+  varying float vR;
+  varying float vA;
+  varying vec3 vCol;
+  void main() {
+    float age = uTime - aCenter.w;
+    float life = max(aShape.z, 0.001);
+    float u = age / life;
+    if (u < 0.0 || u > 1.0) {
+      vR = 0.0; vA = 0.0; vCol = vec3(0.0);
+      gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+      return;
+    }
+    float e = 1.0 - pow(1.0 - u, 2.8); // fastest the instant it is born
+    float r = mix(aShape.x, aShape.y, e);
+    float k = max(aDrift.z, 0.001);
+    float slide = (1.0 - exp(-k * age)) / k;
+    vec3 c = aCenter.xyz + vec3(aDrift.x, 0.0, aDrift.y) * slide;
+    float rad = r * (1.0 + (position.z * 2.0 - 1.0) * aShape.w);
+    vec3 wp = c + vec3(position.x, 0.0, position.y) * rad;
+    vR = position.z;
+    vA = aColor.w * (1.0 - u) * (1.0 - u) * smoothstep(0.0, 0.10, u);
+    vCol = aColor.rgb;
+    gl_Position = projectionMatrix * viewMatrix * vec4(wp, 1.0);
+  }
+`;
+
+// Radial profile reaches zero at BOTH rims — a plateau profile plus additive
+// color reads as an opaque matte torus, not a wave.
+const RING_FRAG = /* glsl */ `
+  uniform float uGain;
+  varying float vR;
+  varying float vA;
+  varying vec3 vCol;
+  ${REINHARD_GLSL}
+  void main() {
+    float e = sin(vR * 3.14159265);
+    float a = vA * (0.34 * pow(e, 1.7) + 0.66 * pow(e, 5.5));
+    vec3 rgb = reinhardClip(vCol * uGain);
+    gl_FragColor = vec4(rgb, a);
+  }
+`;
+
+export class FxRings {
+  readonly mesh: THREE.Mesh;
+  private uTime = { value: 0 };
+  private center: Float32Array;
+  private shape: Float32Array;
+  private color: Float32Array;
+  private drift: Float32Array;
+  private centerAttr: THREE.InstancedBufferAttribute;
+  private shapeAttr: THREE.InstancedBufferAttribute;
+  private colorAttr: THREE.InstancedBufferAttribute;
+  private driftAttr: THREE.InstancedBufferAttribute;
+  private cursor = 0;
+  private lastDeath = 0;
+
+  constructor(gain: THREE.IUniform<number>) {
+    const rows = RING_SEGS + 1;
+    const pos = new Float32Array(rows * 2 * 3);
+    const index = new Uint16Array(RING_SEGS * 6);
+    let ii = 0;
+    for (let i = 0; i < rows; i++) {
+      const ang = (i / RING_SEGS) * Math.PI * 2;
+      const co = Math.cos(ang);
+      const so = Math.sin(ang);
+      for (let e = 0; e < 2; e++) {
+        const v = i * 2 + e;
+        pos[v * 3] = co;
+        pos[v * 3 + 1] = so;
+        pos[v * 3 + 2] = e; // 0 inner rim, 1 outer rim
+      }
+      if (i > 0) {
+        const a = (i - 1) * 2;
+        const b = i * 2;
+        index[ii++] = a;
+        index[ii++] = b;
+        index[ii++] = a + 1;
+        index[ii++] = b;
+        index[ii++] = b + 1;
+        index[ii++] = a + 1;
+      }
+    }
+    const geo = new THREE.InstancedBufferGeometry();
+    geo.instanceCount = RING_COUNT;
+    geo.setAttribute("position", new THREE.BufferAttribute(pos, 3));
+    geo.setIndex(new THREE.BufferAttribute(index, 1));
+    this.center = new Float32Array(RING_COUNT * 4);
+    this.shape = new Float32Array(RING_COUNT * 4);
+    this.color = new Float32Array(RING_COUNT * 4);
+    this.drift = new Float32Array(RING_COUNT * 4);
+    // Dead until spawned: birth 0 with life epsilon collapses in the VS.
+    this.centerAttr = new THREE.InstancedBufferAttribute(this.center, 4);
+    this.shapeAttr = new THREE.InstancedBufferAttribute(this.shape, 4);
+    this.colorAttr = new THREE.InstancedBufferAttribute(this.color, 4);
+    this.driftAttr = new THREE.InstancedBufferAttribute(this.drift, 4);
+    for (const a of [this.centerAttr, this.shapeAttr, this.colorAttr, this.driftAttr]) {
+      a.setUsage(THREE.DynamicDrawUsage);
+    }
+    geo.setAttribute("aCenter", this.centerAttr);
+    geo.setAttribute("aShape", this.shapeAttr);
+    geo.setAttribute("aColor", this.colorAttr);
+    geo.setAttribute("aDrift", this.driftAttr);
+    geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
+    const mat = new THREE.ShaderMaterial({
+      uniforms: { uTime: this.uTime, uGain: gain },
+      vertexShader: RING_VERT,
+      fragmentShader: RING_FRAG,
+      transparent: true,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+    });
+    this.mesh = new THREE.Mesh(geo, mat);
+    this.mesh.frustumCulled = false;
+    this.mesh.renderOrder = 3;
+    this.mesh.visible = false;
+  }
+
+  spawn(
+    x: number,
+    y: number,
+    z: number,
+    r0: number,
+    r1: number,
+    life: number,
+    thickness: number,
+    color: THREE.Color,
+    intensity: number,
+    alpha: number,
+    velX: number,
+    velZ: number,
+    drag: number,
+  ): void {
+    const i = this.cursor;
+    this.cursor = (this.cursor + 1) % RING_COUNT;
+    const b = i * 4;
+    const t = this.uTime.value;
+    this.center[b] = x;
+    this.center[b + 1] = y;
+    this.center[b + 2] = z;
+    this.center[b + 3] = t;
+    this.shape[b] = r0;
+    this.shape[b + 1] = r1;
+    this.shape[b + 2] = life;
+    this.shape[b + 3] = thickness;
+    this.color[b] = color.r * intensity;
+    this.color[b + 1] = color.g * intensity;
+    this.color[b + 2] = color.b * intensity;
+    this.color[b + 3] = alpha;
+    this.drift[b] = velX;
+    this.drift[b + 1] = velZ;
+    this.drift[b + 2] = drag;
+    this.centerAttr.needsUpdate = true;
+    this.shapeAttr.needsUpdate = true;
+    this.colorAttr.needsUpdate = true;
+    this.driftAttr.needsUpdate = true;
+    this.lastDeath = Math.max(this.lastDeath, t + life);
+    this.mesh.visible = true;
+  }
+
+  update(dt: number): void {
+    this.uTime.value += dt;
+    if (this.mesh.visible && this.uTime.value > this.lastDeath) this.mesh.visible = false;
+  }
+}

--- a/games/crazy-waymo/src/fx/clouds.ts
+++ b/games/crazy-waymo/src/fx/clouds.ts
@@ -20,8 +20,34 @@ import { WORLD_H, WORLD_HALF_X, WORLD_W } from "../shared/constants";
 // sky, so at noon the entire upper half of every frame was a featureless
 // gradient with nothing in it. MK8 never ships an empty sky. The count is up,
 // the spread is tighter (see the constructor) and the puffs are shaded.
-const HIGH_COUNT = 46;
+const HIGH_COUNT = 64;
 const FOG_COUNT = 26;
+// Cumulus spawn in CLUSTERS — a hero puff with shoulder puffs overlapping it —
+// because a lone billboard reads as a blob while an overlapped stack reads as
+// massed cumulus (the reference sky is towers, not confetti). Members share
+// one drift speed so a cluster holds together crossing the map.
+const CLUSTER_PUFFS_MIN = 2;
+const CLUSTER_PUFFS_MAX = 5;
+/** Satellite lateral offset, as a fraction of the hero puff's width. */
+const CLUSTER_SPREAD_X = 0.46;
+/** Satellite depth offset (parallax between members), same units. */
+const CLUSTER_SPREAD_Z = 0.14;
+/** Satellites shoulder BELOW the hero — cumulus towers, not a flat row. */
+const CLUSTER_DROP = 0.14;
+// Sun-occlusion tap (kart-royale kr-sky-water §3): one extra texture fetch
+// displaced toward the sun gives both the anti-sun self-shadow AND — from the
+// sign of the same density gradient — the free silver lining on the sun flank.
+/** UV displacement of the sun tap, in quad heights (world-isotropic in VERT). */
+const SUN_TAP_FRAC = 0.35;
+const SUN_OCC_DEPTH = 0.38; // max darkening on the shadowed flank
+const SUN_OCC_GAIN = 1.6;
+const LINING_GAIN = 2.6; // (a - al) -> rim mask slope, KR verbatim
+/** Rim radiance vs the live sun color — re-derived for waymo's exposure 0.62. */
+const LINING_STRENGTH = 0.6;
+// Sun-keyed terms hold through sunset (lamp opens at 0.62 there) and die
+// across dusk, so the lit rims sweep dawn -> night without popping.
+const SUN_FADE_LO = 0.62;
+const SUN_FADE_HI = 1.0;
 // Vertical shading on a cumulus: the flat-lit top vs the sky-fill underside.
 // Without it a billboard is one flat alpha blob no matter how good the texture,
 // which is the other half of why they read as absent rather than as clouds.
@@ -53,9 +79,11 @@ const VERT = `
   attribute vec2 aSize;
   attribute float aAlpha;
   attribute float aSeed;
+  uniform vec3 uSunDir;
   varying vec2 vUv;
   varying float vAlpha;
   varying float vWorldY;
+  varying vec2 vSunUv;
   void main() {
     vUv = uv;
     vAlpha = aAlpha;
@@ -67,6 +95,11 @@ const VERT = `
     vec3 local = vec3(position.x * aSize.x, position.y * aSize.y, 0.0);
     vec3 world = aCenter + vec3(local.x * c + local.z * s, local.y, -local.x * s + local.z * c);
     vWorldY = world.y;
+    // The sun tap's UV displacement: project the sun direction onto the quad
+    // plane (local +x maps to world (c, 0, -s)), scaled per axis so the same
+    // world-space displacement lands on both the wide and the tall axis.
+    float sunX = dot(uSunDir.xz, vec2(c, -s));
+    vSunUv = vec2(sunX * aSize.y / max(aSize.x, 1.0), uSunDir.y) * ${SUN_TAP_FRAC.toFixed(2)};
     gl_Position = projectionMatrix * viewMatrix * vec4(world, 1.0);
   }
 `;
@@ -74,6 +107,9 @@ const VERT = `
 // skipping the blend write for them saves real ROP bandwidth on tile GPUs.
 // `floorFade` gives the low marine sheets a soft world-space underside (see
 // FLOOR_Y); the high cumulus sit 190u up and skip the extra work entirely.
+// `shade` also enables the sun tap: the marine layer is a flat sheet lit from
+// every side at once, so both the vertical ramp AND a directional rim on it
+// read as gradient errors — only the cumulus get either.
 function frag(discardLow: boolean, floorFade: boolean, shade: boolean): string {
   return `
   uniform sampler2D uMap;
@@ -82,6 +118,8 @@ function frag(discardLow: boolean, floorFade: boolean, shade: boolean): string {
   varying vec2 vUv;
   varying float vAlpha;
   varying float vWorldY;
+  varying vec2 vSunUv;
+  ${shade ? "uniform vec3 uSunCol;\n  uniform float uSunW;" : ""}
   void main() {
     float a = texture2D(uMap, vUv).a * vAlpha;
     ${floorFade ? `a *= smoothstep(${FLOOR_Y.toFixed(1)}, ${FLOOR_TOP.toFixed(1)}, vWorldY);` : ""}
@@ -90,7 +128,15 @@ function frag(discardLow: boolean, floorFade: boolean, shade: boolean): string {
     ${
       shade
         ? `rgb *= mix(${HIGH_BASE_SHADE.toFixed(2)}, 1.0,
-        smoothstep(${HIGH_SHADE_LO.toFixed(2)}, ${HIGH_SHADE_HI.toFixed(2)}, vUv.y));`
+        smoothstep(${HIGH_SHADE_LO.toFixed(2)}, ${HIGH_SHADE_HI.toFixed(2)}, vUv.y));
+    // One sun-displaced density tap: where the displaced sample is DENSER the
+    // texel sits behind cloud mass (self-shadow); where it is thinner the
+    // texel is the sun-facing flank and the same gradient is the silver lining.
+    float al = texture2D(uMap, vUv + vSunUv).a * vAlpha;
+    rgb *= 1.0 - ${SUN_OCC_DEPTH.toFixed(2)} * uSunW
+      * clamp((al - a) * ${SUN_OCC_GAIN.toFixed(2)}, 0.0, 1.0);
+    rgb += uSunCol * clamp((a - al) * ${LINING_GAIN.toFixed(2)}, 0.0, 1.0)
+      * smoothstep(0.05, 0.30, a);`
         : ""
     }
     gl_FragColor = vec4(rgb, a);
@@ -205,6 +251,9 @@ class CloudLayer {
         uMap: { value: opts.tex },
         uColor: { value: color },
         uDim: { value: 1 },
+        uSunDir: this.sunDirU,
+        uSunCol: this.sunColU,
+        uSunW: this.sunWU,
       },
       vertexShader: VERT,
       fragmentShader: frag(opts.discardLow, opts.floorFade, opts.shade),
@@ -224,6 +273,11 @@ class CloudLayer {
   readonly sizes: Float32Array;
   readonly seeds: Float32Array;
   dimUniform: { value: number } = { value: 1 };
+  // Live sun feed (SkyClouds writes the high layer's each frame; the marine
+  // layer keeps the defaults — its shader never reads them).
+  readonly sunDirU = { value: new THREE.Vector3(0, 1, 0) };
+  readonly sunColU = { value: new THREE.Color(0x000000) };
+  readonly sunWU = { value: 0 };
   private tint: THREE.Color;
   private dayColor: THREE.Color;
   private nightColor: THREE.Color;
@@ -253,6 +307,14 @@ export class SkyClouds {
   private level: CloudQuality = 2;
   private highActive = HIGH_COUNT;
   private fogActive = FOG_COUNT;
+  private nightF = 0;
+  // The scene's shadow light, found once from the cumulus mesh's own render
+  // callback. The update()/setNight() call sites only carry the night factor,
+  // and widening the god object's wiring for one vec3 isn't worth the drift —
+  // if a shared sun signal ever lands (render/grade.ts pattern), feed it there
+  // and delete this lookup.
+  private sunRef: THREE.DirectionalLight | null = null;
+  private scrSunDir = new THREE.Vector3();
 
   constructor(discardLow = false) {
     // Night tints are the moonlit sky's own blues, NOT grey: a white cloud
@@ -287,20 +349,64 @@ export class SkyClouds {
     this.group.add(this.high.mesh);
     this.group.add(this.fog.mesh);
 
+    // Feed the live sun to the cumulus shader (rim + occlusion tap). Runs on
+    // the mesh's own draw so the data is same-frame; direction comes from the
+    // light's position/target pair the way game-scene.updateSun writes them.
+    this.high.mesh.onBeforeRender = (_renderer, scene) => {
+      let sun = this.sunRef;
+      if (sun === null || sun.parent !== scene) {
+        sun = null;
+        for (const child of scene.children) {
+          if (child instanceof THREE.DirectionalLight) {
+            sun = child;
+            break;
+          }
+        }
+        this.sunRef = sun;
+      }
+      if (sun === null) return;
+      const dir = this.scrSunDir.copy(sun.position).sub(sun.target.position);
+      if (dir.lengthSq() < 1e-6) return;
+      this.high.sunDirU.value.copy(dir.normalize());
+      const dayW = 1 - THREE.MathUtils.smoothstep(this.nightF, SUN_FADE_LO, SUN_FADE_HI);
+      this.high.sunWU.value = dayW;
+      this.high.sunColU.value
+        .copy(sun.color)
+        .multiplyScalar(Math.min(sun.intensity, 1.2) * LINING_STRENGTH * dayW);
+    };
+
+    // Cluster spawner (see CLUSTER_*): a hero puff plus overlapping shoulder
+    // puffs per anchor. Members are contiguous in the instance buffer, so the
+    // mobile instanceCount cut drops whole clusters instead of gutting each.
     this.highSpeed = new Float32Array(HIGH_COUNT);
-    for (let i = 0; i < HIGH_COUNT; i++) {
-      const x = (Math.random() * 1.5 - 0.75) * WORLD_W;
-      const z = (Math.random() * 1.3 - 0.65) * WORLD_H;
-      const y = 175 + Math.random() * 150;
-      this.high.centers.set([x, y, z], i * 3);
-      // Squared roll: mostly modest puffs with a few big anvils, which is what
-      // gives a cumulus field its sense of scale (one uniform size reads as
-      // wallpaper).
-      const r = Math.random();
-      const w = 150 + r * r * 420;
-      this.high.sizes.set([w, w * (0.3 + Math.random() * 0.14)], i * 2);
-      this.high.alphas[i] = 0.78 + Math.random() * 0.22;
-      this.highSpeed[i] = 3.5 + Math.random() * 3;
+    let i = 0;
+    while (i < HIGH_COUNT) {
+      const puffs = Math.min(
+        HIGH_COUNT - i,
+        CLUSTER_PUFFS_MIN + Math.floor(Math.random() * (CLUSTER_PUFFS_MAX - CLUSTER_PUFFS_MIN + 1)),
+      );
+      const cx = (Math.random() * 1.5 - 0.75) * WORLD_W;
+      const cz = (Math.random() * 1.3 - 0.65) * WORLD_H;
+      const cy = 175 + Math.random() * 130;
+      const speed = 3.5 + Math.random() * 3;
+      // Squared roll: mostly modest clusters with a few big anvils, which is
+      // what gives a cumulus field its sense of scale (one uniform size reads
+      // as wallpaper).
+      const roll = Math.random();
+      const heroW = 190 + roll * roll * 380;
+      for (let k = 0; k < puffs; k++, i++) {
+        const hero = k === 0;
+        const w = hero ? heroW : heroW * (0.38 + Math.random() * 0.34);
+        const side = k % 2 === 1 ? 1 : -1;
+        const reach = 1 + Math.floor((k - 1) / 2) * 0.6; // outer pairs sit wider
+        const dx = hero ? 0 : side * heroW * CLUSTER_SPREAD_X * (0.6 + Math.random() * 0.4) * reach;
+        const dy = hero ? 0 : -heroW * CLUSTER_DROP * (0.4 + Math.random() * 0.6);
+        const dz = hero ? 0 : (Math.random() - 0.5) * 2 * heroW * CLUSTER_SPREAD_Z;
+        this.high.centers.set([cx + dx, cy + dy, cz + dz], i * 3);
+        this.high.sizes.set([w, w * (0.3 + Math.random() * 0.14)], i * 2);
+        this.high.alphas[i] = hero ? 0.85 + Math.random() * 0.15 : 0.55 + Math.random() * 0.35;
+        this.highSpeed[i] = speed;
+      }
     }
     this.fogSpeed = new Float32Array(FOG_COUNT);
     this.fogBase = new Float32Array(FOG_COUNT);
@@ -377,6 +483,7 @@ export class SkyClouds {
   // paper cutout no matter how far you dim it, so each layer crossfades to its
   // own moonlit BLUE as well — see the tints on the layers above.
   setNight(f: number): void {
+    this.nightF = f;
     this.high.setNight(f);
     this.fog.setNight(f);
   }

--- a/games/crazy-waymo/src/fx/clouds.ts
+++ b/games/crazy-waymo/src/fx/clouds.ts
@@ -397,11 +397,14 @@ export class SkyClouds {
       for (let k = 0; k < puffs; k++, i++) {
         const hero = k === 0;
         const w = hero ? heroW : heroW * (0.38 + Math.random() * 0.34);
-        const side = k % 2 === 1 ? 1 : -1;
-        const reach = 1 + Math.floor((k - 1) / 2) * 0.6; // outer pairs sit wider
-        const dx = hero ? 0 : side * heroW * CLUSTER_SPREAD_X * (0.6 + Math.random() * 0.4) * reach;
+        // Satellites scatter at random bearings — the old alternating left/
+        // right pairs at growing reach drew a shrinking chain that read as a
+        // generator signature from any angle (review pass).
+        const ang = Math.random() * Math.PI * 2;
+        const reach = 0.6 + Math.random() * 0.7 + k * 0.12;
+        const dx = hero ? 0 : Math.cos(ang) * heroW * CLUSTER_SPREAD_X * reach;
         const dy = hero ? 0 : -heroW * CLUSTER_DROP * (0.4 + Math.random() * 0.6);
-        const dz = hero ? 0 : (Math.random() - 0.5) * 2 * heroW * CLUSTER_SPREAD_Z;
+        const dz = hero ? 0 : Math.sin(ang) * heroW * CLUSTER_SPREAD_Z * 2 * reach;
         this.high.centers.set([cx + dx, cy + dy, cz + dz], i * 3);
         this.high.sizes.set([w, w * (0.3 + Math.random() * 0.14)], i * 2);
         this.high.alphas[i] = hero ? 0.85 + Math.random() * 0.15 : 0.55 + Math.random() * 0.35;

--- a/games/crazy-waymo/src/fx/particles.ts
+++ b/games/crazy-waymo/src/fx/particles.ts
@@ -244,9 +244,9 @@ export type FxTier = 0 | 1 | 2;
 // donut test). Only one-frame moments (promotion, ignition) may cross the
 // gate; the held shower reads as sparks, not glow.
 export const TIER_FX = [
-  { rate: 26, core: 0.22, coreInt: 1.25, halo: 0.45, haloInt: 0.8, jet: 0, pulse: 0 },
-  { rate: 44, core: 0.28, coreInt: 1.35, halo: 0.55, haloInt: 0.8, jet: 0, pulse: 0 },
-  { rate: 68, core: 0.34, coreInt: 1.45, halo: 0.7, haloInt: 0.8, jet: 30, pulse: 6.5 },
+  { rate: 34, core: 0.22, coreInt: 1.25, halo: 0.35, haloInt: 0.8, jet: 0, pulse: 0 },
+  { rate: 56, core: 0.28, coreInt: 1.35, halo: 0.45, haloInt: 0.8, jet: 0, pulse: 0 },
+  { rate: 84, core: 0.34, coreInt: 1.45, halo: 0.55, haloInt: 0.8, jet: 30, pulse: 6.5 },
 ] as const;
 
 // Day-weighted additive governor floor: authored 2.2-3.4 radiances are tuned
@@ -381,7 +381,7 @@ export class Fx {
       color: this.white,
       channel: true,
       intensity: t.coreInt,
-      speed: 3.4 + 1.1 * tier,
+      speed: 4.6 + 1.3 * tier,
       spread: 1.2,
       up: 2.5 + 0.5 * tier,
       size: t.core,

--- a/games/crazy-waymo/src/fx/particles.ts
+++ b/games/crazy-waymo/src/fx/particles.ts
@@ -1,5 +1,9 @@
 import * as THREE from "three";
 
+import { BoostPlume, FxRings } from "./boost-plume";
+import { REINHARD_GLSL } from "./reinhard";
+import { GRIND_COLOR } from "./tier";
+
 type EmitOpts = {
   count: number;
   color: THREE.Color;
@@ -13,10 +17,14 @@ type EmitOpts = {
   // Optional directional term: final velocity = radial term + dir * dirSpeed.
   dir?: { x: number; y: number; z: number };
   dirSpeed?: number;
-  // 0..1 scale on the day bloom gain (sparks pool only). Hot FX — drift
-  // sparks, boost flame, crash bursts — glow at 1; inert debris like sand and
-  // grass flecks opts out at 0, or every off-road run reads as a fire.
-  bloomGain?: number;
+  // HDR multiplier on color before additive blending. Hot FX author 2.2-3.4
+  // so a lone grain clears the ~1.6 day bloom gate through the max-channel
+  // Reinhard shoulder; inert debris (sand, grass flecks) stays at 1 and never
+  // blooms — no separate opt-out needed.
+  intensity?: number;
+  // Tier channel: the grain's color is uTierCol * intensity, re-read every
+  // frame — a tier promotion repaints grains already in the air (sparks only).
+  channel?: boolean;
 };
 
 // vAlpha = remaining life fraction (1 at birth -> 0 at death).
@@ -27,15 +35,14 @@ const VERT = `
   attribute float aMax;
   attribute float aSize;
   attribute vec3 aColor;
-  attribute float aGain;
+  attribute float aChannel;
   uniform float uScale;
   uniform float uGrow;
+  uniform vec3 uTierCol;
   varying float vAlpha;
   varying vec3 vColor;
-  varying float vGain;
   void main() {
-    vColor = aColor;
-    vGain = aGain;
+    vColor = aColor * mix(vec3(1.0), uTierCol, aChannel);
     vAlpha = clamp(aLife / max(aMax, 0.0001), 0.0, 1.0);
     float shrinkRamp = mix(0.6, 1.4, vAlpha);
     float growRamp = mix(1.5, 0.7, vAlpha);
@@ -69,16 +76,18 @@ const FRAG_SMOKE = `
     gl_FragColor = vec4(color, vAlpha * vAlpha * soft);
   }
 `;
-// Sparks: uGain boosts the CENTER of the sprite only (skirt stays at 1x, so a
-// gained spark reads white-hot core + colored halo, not a blob). By day the
-// bloom threshold sits at 6.5 pre-tonemap while spark colors peak ~1 — the
-// gain is what lets a day drift spark cross the cut and glow like the night
-// lamp halos do.
+// Sparks: intensities are authored pre-shoulder (hot FX 2.2-3.4) and the
+// max-channel Reinhard shoulder is the LAST op — stacked grains asymptote
+// toward their own hue instead of washing to white, and a lone core still
+// clears the day bloom gate. The hot-core desat only whitens the pinprick
+// centre (0.45, never 1.0 — a fully white core reads as fireflies with no
+// hue). uFxGain is the day-weighted governor: at night the bloom cut drops to
+// 0.85 and un-scaled 2-3x grains would flood the frame.
 const FRAG_SPARKS = `
-  uniform float uGain;
+  uniform float uFxGain;
   varying float vAlpha;
   varying vec3 vColor;
-  varying float vGain;
+  ${REINHARD_GLSL}
   void main() {
     vec2 d = gl_PointCoord - vec2(0.5);
     float r = dot(d, d);
@@ -86,10 +95,12 @@ const FRAG_SPARKS = `
     float soft = smoothstep(0.25, 0.0, r);
     vec3 color = mix(vColor * 0.35, vColor, pow(vAlpha, 0.6));
     // Hot core confined to the inner ~35% radius — r is SQUARED distance, so
-    // the earlier 1-4r ramp still covered most of the sprite and every gained
-    // spark rendered as a fat additive splat instead of a pinprick.
+    // a wider ramp would cover most of the sprite and every spark would
+    // render as a fat white splat instead of a pinprick.
     float core = pow(smoothstep(0.03, 0.0, r), 2.0);
-    color *= 1.0 + (uGain - 1.0) * core * vGain;
+    float mx = max(color.r, max(color.g, color.b));
+    color = mix(color, vec3(mx), core * 0.45);
+    color = reinhardClip(color * uFxGain);
     gl_FragColor = vec4(color, vAlpha * vAlpha * soft);
   }
 `;
@@ -101,7 +112,7 @@ class ParticleField {
   private size: Float32Array;
   private life: Float32Array;
   private max: Float32Array;
-  private gain: Float32Array;
+  private chan: Float32Array;
   private vel: Float32Array;
   private grav: Float32Array;
   private drag: Float32Array;
@@ -122,7 +133,7 @@ class ParticleField {
     this.size = new Float32Array(n);
     this.life = new Float32Array(n);
     this.max = new Float32Array(n);
-    this.gain = new Float32Array(n);
+    this.chan = new Float32Array(n);
     this.vel = new Float32Array(n * 3);
     this.grav = new Float32Array(n);
     this.drag = new Float32Array(n);
@@ -133,7 +144,7 @@ class ParticleField {
     geo.setAttribute("aSize", new THREE.BufferAttribute(this.size, 1));
     geo.setAttribute("aLife", new THREE.BufferAttribute(this.life, 1));
     geo.setAttribute("aMax", new THREE.BufferAttribute(this.max, 1));
-    geo.setAttribute("aGain", new THREE.BufferAttribute(this.gain, 1));
+    geo.setAttribute("aChannel", new THREE.BufferAttribute(this.chan, 1));
     geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
 
     this.mat = new THREE.ShaderMaterial({
@@ -158,6 +169,7 @@ class ParticleField {
     const dx = dir ? dir.x * ds : 0;
     const dy = dir ? dir.y * ds : 0;
     const dz = dir ? dir.z * ds : 0;
+    const intensity = o.intensity ?? 1;
     for (let k = 0; k < o.count; k++) {
       const i = this.cursor;
       this.cursor = (this.cursor + 1) % this.n;
@@ -169,13 +181,13 @@ class ParticleField {
       this.vel[i * 3] = Math.cos(ang) * o.spread + Math.cos(ang) * sp + dx;
       this.vel[i * 3 + 1] = o.up * (0.5 + Math.random()) + dy;
       this.vel[i * 3 + 2] = Math.sin(ang) * o.spread + Math.sin(ang) * sp + dz;
-      this.col[i * 3] = o.color.r;
-      this.col[i * 3 + 1] = o.color.g;
-      this.col[i * 3 + 2] = o.color.b;
+      this.col[i * 3] = o.color.r * intensity;
+      this.col[i * 3 + 1] = o.color.g * intensity;
+      this.col[i * 3 + 2] = o.color.b * intensity;
       this.size[i] = o.size * (0.7 + Math.random() * 0.6);
       this.life[i] = o.life;
       this.max[i] = o.life;
-      this.gain[i] = o.bloomGain ?? 1;
+      this.chan[i] = o.channel ? 1 : 0;
       this.grav[i] = o.gravity;
       this.drag[i] = o.drag;
     }
@@ -209,31 +221,70 @@ class ParticleField {
     geo.getAttribute("aSize").needsUpdate = true;
     geo.getAttribute("aLife").needsUpdate = true;
     geo.getAttribute("aMax").needsUpdate = true;
-    geo.getAttribute("aGain").needsUpdate = true;
+    geo.getAttribute("aChannel").needsUpdate = true;
   }
 }
 
 export type FxSurface = "road" | "grass" | "sand" | "concrete";
+
+export type FxTier = 0 | 1 | 2;
+
+// Drift-tier FX ladder — tiers are three DIFFERENT effects sharing a palette,
+// not one effect re-hued: rate and core size escalate, the top tier adds the
+// vertical ember jet (shape change) and the 6.5 Hz ground-ring pulse (rhythm
+// change — nothing else in the game beats). Hue itself comes from fx/tier.ts
+// via the live channel. rate = grains/s/wheel; sizes in point-sprite units.
+// Intensities sit just over the 1.6 day gate: each grain glows, but only the
+// dense center of the shower fuses. 2.25+ made EVERY grain a bloom kernel and
+// the whole spray read as one fireball at chase distance (measured, golden
+// hour) — the shower must stay grains, not a glow sprite.
+// Steady-state grains stay UNDER the 1.6 day bloom gate — a drift holds a
+// tight arc, so 0.4-0.7s of emissions pile into a few square metres and any
+// per-grain bloom fuses the pile into one fireball (measured, golden hour,
+// donut test). Only one-frame moments (promotion, ignition) may cross the
+// gate; the held shower reads as sparks, not glow.
+export const TIER_FX = [
+  { rate: 26, core: 0.22, coreInt: 1.25, halo: 0.45, haloInt: 0.8, jet: 0, pulse: 0 },
+  { rate: 44, core: 0.28, coreInt: 1.35, halo: 0.55, haloInt: 0.8, jet: 0, pulse: 0 },
+  { rate: 68, core: 0.34, coreInt: 1.45, halo: 0.7, haloInt: 0.8, jet: 30, pulse: 6.5 },
+] as const;
+
+// Day-weighted additive governor floor: authored 2.2-3.4 radiances are tuned
+// against the ~1.6 DAY bloom gate; the night gate sits at 0.85 with a coupled
+// emissive budget (window 1.1 / lamp 0.9 / headlight 1.6), so FX scale toward
+// this floor after dark instead of out-shining every lamp pool.
+const NIGHT_FX_SCALE = 0.55;
 
 // High-level effects used by the game.
 export class Fx {
   // Defaults approximate noon so the first frames before setLighting look sane.
   private smokeSun = { value: new THREE.Color(0.78, 0.72, 0.6) };
   private smokeAmbient = { value: new THREE.Color(0.55, 0.6, 0.65) };
-  private sparkGain = { value: 1 };
+  // Shared additive governor (sparks, rings, plume): mix(NIGHT_FX_SCALE, 1, day).
+  private fxGain = { value: 1 };
+  // Live tier channel — rewritten per frame; a promotion recolors every
+  // channel grain already in flight, that frame, for three floats.
+  private tierCol = { value: new THREE.Color(GRIND_COLOR) };
   readonly smoke = new ParticleField(420, THREE.NormalBlending, true, FRAG_SMOKE, {
     uSunTint: this.smokeSun,
     uAmbient: this.smokeAmbient,
+    uTierCol: { value: new THREE.Color(1, 1, 1) },
   }); // grows over life
   readonly sparks = new ParticleField(500, THREE.AdditiveBlending, false, FRAG_SPARKS, {
-    uGain: this.sparkGain,
+    uFxGain: this.fxGain,
+    uTierCol: this.tierCol,
   }); // shrinks over life
+  readonly plume = new BoostPlume(this.fxGain);
+  readonly rings = new FxRings(this.fxGain);
   private tmp = new THREE.Color();
+  private white = new THREE.Color(1, 1, 1);
   private tmpDir = { x: 0, y: 0, z: 0 };
 
   addTo(scene: THREE.Scene): void {
     scene.add(this.smoke.points);
     scene.add(this.sparks.points);
+    scene.add(this.plume.mesh);
+    scene.add(this.rings.mesh);
   }
   setScale(px: number): void {
     this.smoke.setScale(px);
@@ -246,12 +297,6 @@ export class Fx {
   // stack of puffs clipping toward white (the post S-curve + vibrance sit on
   // top of whatever leaves here; 0.45 read as a fireball).
   // Ambient floor 0.12 keeps night smoke readable against the dark ground.
-  // Spark gain tops out at x3.5 — deliberately UNDER the 6.5 day bloom cut.
-  // Cores at ~3.4 ACES-clip to a white-hot center on their own; pushing them
-  // past the cut instead (an earlier x7) fed every 20Hz spark trail into the
-  // bloom pyramid and a plain grind drift read as a chain of fireballs. Only
-  // spots where several sparks overlap now cross the cut, which is a glint,
-  // not a flood. At night the cut is 0.85 and gain MUST return to 1.
   setLighting(
     sun: THREE.Color,
     sunIntensity: number,
@@ -261,21 +306,21 @@ export class Fx {
   ): void {
     this.smokeSun.value.copy(sun).multiplyScalar(sunIntensity * 0.26);
     this.smokeAmbient.value.copy(ambient).multiplyScalar(ambientIntensity).addScalar(0.12);
-    this.sparkGain.value = 1 + 2.5 * Math.min(1, Math.max(0, day));
+    const d = Math.min(1, Math.max(0, day));
+    this.fxGain.value = NIGHT_FX_SCALE + (1 - NIGHT_FX_SCALE) * d;
+  }
+
+  /** Repaint the live tier channel (drift grains, jet, promotion layers). */
+  setTierChannel(css: string): void {
+    this.tierCol.value.set(css);
   }
 
   // Tire smoke while drifting. `charged` is the Mario-Kart mini-turbo tell:
-  // sparks turn cyan and the count jumps 2 -> 5. Smoke is tinted by the
-  // surface being torn up (same colors as kickup, so the two systems agree):
-  // road keeps grey rubber-smoke, off-road throws that surface's dust.
-  driftPuff(
-    x: number,
-    y: number,
-    z: number,
-    boosting: boolean,
-    charged = false,
-    surface: FxSurface = "road",
-  ): void {
+  // sparks ride the live tier channel and the count jumps 2 -> 5. Smoke is
+  // tinted by the surface being torn up (same colors as kickup, so the two
+  // systems agree): road keeps grey rubber-smoke, off-road throws that
+  // surface's dust.
+  driftPuff(x: number, y: number, z: number, boosting: boolean, surface: FxSurface = "road"): void {
     if (surface === "grass") this.tmp.setRGB(0.42, 0.36, 0.24);
     else if (surface === "sand") this.tmp.setRGB(0.66, 0.57, 0.41);
     else if (surface === "concrete") this.tmp.setRGB(0.8, 0.8, 0.78);
@@ -291,15 +336,20 @@ export class Fx {
       gravity: -1.2,
       drag: 2.4,
     });
-    if (boosting || charged) {
-      this.tmp.setHSL(charged ? 0.55 : 0.08, 1, 0.6);
+    // Boost-only ember kiss in the smoke. The drift-charge spark read belongs
+    // to the tier shower (driftShower) — a second charged emission here at
+    // smoke cadence stacked ~300 sprites/s on the same spot and fused into a
+    // fireball no shower tuning could fix (isolated by hiding the pool).
+    if (boosting) {
+      this.tmp.setHSL(0.08, 1, 0.6);
       this.sparks.emit(x, y + 0.3, z, {
-        count: charged ? 5 : 2,
+        count: 2,
         color: this.tmp,
+        intensity: 1.4,
         speed: 5,
         spread: 1,
         up: 0.5,
-        size: 1.1,
+        size: 0.4,
         life: 0.35,
         gravity: 0,
         drag: 3,
@@ -307,8 +357,188 @@ export class Fx {
     }
   }
 
-  // Boost exhaust: hot flame tongues shot backwards along (dirX, dirZ).
-  // Call per frame while boosting; one white-hot core + orange tails.
+  // Drift spark shower — the steady per-wheel spray. Three layers per call:
+  // hot cores (thrown along `dir`, the inherited-velocity + backward-throw
+  // vector precomputed by the rig), a colored halo cloud carrying the
+  // silhouette at chase distance, and an intermittent contact-patch lamp so
+  // every frame of a slide has SOME light at the tyre.
+  driftShower(
+    x: number,
+    y: number,
+    z: number,
+    tier: FxTier,
+    count: number,
+    dx: number,
+    dz: number,
+    dirSpeed: number,
+  ): void {
+    const t = TIER_FX[tier];
+    this.tmpDir.x = dx;
+    this.tmpDir.y = 0;
+    this.tmpDir.z = dz;
+    this.sparks.emit(x, y, z, {
+      count,
+      color: this.white,
+      channel: true,
+      intensity: t.coreInt,
+      speed: 3.4 + 1.1 * tier,
+      spread: 1.2,
+      up: 2.5 + 0.5 * tier,
+      size: t.core,
+      life: 0.4,
+      gravity: 14,
+      drag: 1.5,
+      dir: this.tmpDir,
+      dirSpeed,
+    });
+    this.sparks.emit(x, y + 0.12, z, {
+      count: Math.max(1, count >> 1),
+      color: this.white,
+      channel: true,
+      intensity: t.haloInt,
+      speed: 1.5,
+      spread: 0.9,
+      up: 1.2,
+      size: t.halo,
+      life: 0.3,
+      gravity: 2,
+      drag: 2.4,
+      dir: this.tmpDir,
+      dirSpeed: dirSpeed * 0.7,
+    });
+    if (Math.random() < 0.6) {
+      this.sparks.emit(x, y + 0.05, z, {
+        count: 1,
+        color: this.white,
+        channel: true,
+        intensity: 1.45,
+        speed: 0.2,
+        spread: 0.2,
+        up: 0.2,
+        size: 2.3 + 0.4 * tier,
+        life: 0.12,
+        gravity: 0,
+        drag: 6,
+        dir: this.tmpDir,
+        dirSpeed: dirSpeed * 0.9,
+      });
+    }
+  }
+
+  // Top-tier vertical ember jet: long life + low drag makes it a standing
+  // column — a STATE the eye can hold onto, not a stream of events.
+  emberJet(x: number, y: number, z: number, count: number, ix: number, iz: number): void {
+    this.tmpDir.x = ix;
+    this.tmpDir.y = 0;
+    this.tmpDir.z = iz;
+    this.sparks.emit(x, y, z, {
+      count,
+      color: this.white,
+      channel: true,
+      intensity: 1.5,
+      speed: 0.4,
+      spread: 1.5,
+      up: 6.2,
+      size: 0.16,
+      life: 0.7,
+      gravity: 11,
+      drag: 0.55,
+      dir: this.tmpDir,
+      dirSpeed: 1,
+    });
+  }
+
+  // Tier-promotion burst at one wheel: fast stretch-read cores + a colored
+  // glow shell. All on the live channel so the burst and the recolored shower
+  // land as one event.
+  promotionBurst(
+    x: number,
+    y: number,
+    z: number,
+    tier: FxTier,
+    count: number,
+    ix: number,
+    iz: number,
+  ): void {
+    this.tmpDir.x = ix;
+    this.tmpDir.y = 0;
+    this.tmpDir.z = iz;
+    this.sparks.emit(x, y, z, {
+      count,
+      color: this.white,
+      channel: true,
+      intensity: 3.0,
+      speed: 6.5,
+      spread: 1.4,
+      up: 3.2,
+      size: 0.6 + 0.12 * tier,
+      life: 0.62,
+      gravity: 13,
+      drag: 1.1,
+      dir: this.tmpDir,
+      dirSpeed: 1,
+    });
+    this.sparks.emit(x, y + 0.2, z, {
+      count: Math.max(1, count >> 1),
+      color: this.white,
+      channel: true,
+      intensity: 1.75,
+      speed: 3,
+      spread: 1.2,
+      up: 1.6,
+      size: 1.7,
+      life: 0.4,
+      gravity: 2,
+      drag: 2.5,
+      dir: this.tmpDir,
+      dirSpeed: 0.6,
+    });
+  }
+
+  // Air flare: one soft glow at rear-deck height — puts the promotion in the
+  // AIR where the chase camera actually looks.
+  promotionFlare(x: number, y: number, z: number, tier: FxTier): void {
+    this.sparks.emit(x, y, z, {
+      count: 1,
+      color: this.white,
+      channel: true,
+      intensity: 1.3 + 0.3 * tier,
+      speed: 0.3,
+      spread: 0.2,
+      up: 0.2,
+      size: 2.0 + 1.0 * tier,
+      life: 0.3,
+      gravity: -0.5,
+      drag: 4.5,
+    });
+  }
+
+  // Ground flash pool under the car on promotion — pops at birth (the alpha
+  // curve peaks on frame 1) so every promotion channel crests the same frame.
+  promotionPool(x: number, y: number, z: number, tier: FxTier, ix: number, iz: number): void {
+    this.tmpDir.x = ix;
+    this.tmpDir.y = 0;
+    this.tmpDir.z = iz;
+    this.sparks.emit(x, y + 0.15, z, {
+      count: 1,
+      color: this.white,
+      channel: true,
+      intensity: 0.95 + 0.16 * tier,
+      speed: 0,
+      spread: 0.1,
+      up: 0.05,
+      size: 4.2 + 1.2 * tier,
+      life: 0.34,
+      gravity: 0,
+      drag: 5,
+      dir: this.tmpDir,
+      dirSpeed: 0.75,
+    });
+  }
+
+  // Boost exhaust support cone: hot flame tongues shot backwards along
+  // (dirX, dirZ) UNDER the ribbon plume — the particulate the rigid mesh
+  // can't do (root kisses, cooling wisps). Call per frame while boosting.
   exhaustFlame(x: number, y: number, z: number, dirX: number, dirZ: number): void {
     const len = Math.hypot(dirX, dirZ);
     const inv = len > 0.0001 ? 1 / len : 0;
@@ -320,6 +550,7 @@ export class Fx {
     this.sparks.emit(x, y, z, {
       count: 1,
       color: this.tmp,
+      intensity: 2.8,
       speed: 0.4,
       spread: 0.2,
       up: 0.2,
@@ -335,6 +566,7 @@ export class Fx {
     this.sparks.emit(x, y, z, {
       count: 1,
       color: this.tmp,
+      intensity: 2.4,
       speed: 0.6,
       spread: 0.3,
       up: 0.3,
@@ -350,6 +582,7 @@ export class Fx {
     this.sparks.emit(x, y, z, {
       count: 1,
       color: this.tmp,
+      intensity: 1.8,
       speed: 0.7,
       spread: 0.4,
       up: 0.35,
@@ -363,8 +596,8 @@ export class Fx {
   }
 
   // Boost ignition pop (the Mario Kart read): a fat one-shot flame tongue
-  // from each exhaust plus a spray of hot flecks. Replaces the old expanding
-  // ground shockwave — boosts read from the pipes, not the pavement.
+  // from each exhaust plus a spray of hot flecks — the particulate half of
+  // the ignition stack (the ground rings + plume spike fire alongside it).
   boostFlash(x: number, y: number, z: number, dirX: number, dirZ: number, hue: number): void {
     const len = Math.hypot(dirX, dirZ);
     const inv = len > 0.0001 ? 1 / len : 0;
@@ -375,6 +608,7 @@ export class Fx {
     this.sparks.emit(x, y, z, {
       count: 3,
       color: this.tmp,
+      intensity: 3.0,
       speed: 0.5,
       spread: 0.25,
       up: 0.3,
@@ -389,6 +623,7 @@ export class Fx {
     this.sparks.emit(x, y, z, {
       count: 4,
       color: this.tmp,
+      intensity: 2.6,
       speed: 0.9,
       spread: 0.5,
       up: 0.4,
@@ -403,6 +638,7 @@ export class Fx {
     this.sparks.emit(x, y, z, {
       count: 6,
       color: this.tmp,
+      intensity: 2.4,
       speed: 4.5,
       spread: 1.2,
       up: 1.4,
@@ -438,6 +674,7 @@ export class Fx {
     });
     if (surface === "grass") this.tmp.setHSL(0.29, 0.8, 0.42);
     else this.tmp.setHSL(0.11, 0.7, 0.68);
+    // Inert debris: intensity stays at 1 (under the bloom gate by authoring).
     this.sparks.emit(x, y + 0.3, z, {
       count: 2,
       color: this.tmp,
@@ -448,7 +685,6 @@ export class Fx {
       life: 0.5,
       gravity: 9,
       drag: 1.2,
-      bloomGain: 0,
     });
   }
 
@@ -489,6 +725,7 @@ export class Fx {
     this.sparks.emit(x, y, z, {
       count: 2 + (Math.random() < 0.5 ? 1 : 0),
       color: this.tmp,
+      intensity: 2.3,
       speed: 2,
       spread: 0.8,
       up: 0.6,
@@ -507,6 +744,7 @@ export class Fx {
       this.sparks.emit(x, y, z, {
         count: 1,
         color: this.tmp,
+        intensity: 2.2,
         speed: power * (0.5 + Math.random()),
         spread: 1,
         up: power * 0.7,
@@ -521,5 +759,7 @@ export class Fx {
   update(dt: number): void {
     this.smoke.update(dt);
     this.sparks.update(dt);
+    this.plume.update(dt);
+    this.rings.update(dt);
   }
 }

--- a/games/crazy-waymo/src/fx/reinhard.ts
+++ b/games/crazy-waymo/src/fx/reinhard.ts
@@ -1,0 +1,13 @@
+// Max-channel chroma-preserving Reinhard shoulder for additive FX shaders.
+// Dividing by the max channel (not luminance) means stacked additive quads
+// asymptote toward their own hue instead of washing to white — the kart-racer
+// "saturated glow" identity. Apply as the LAST op before writing gl_FragColor
+// in any additive material; pre-shoulder intensities are then free to sit at
+// 2-3.5 so they clear the day bloom gate.
+export const REINHARD_CLIP = 0.13;
+
+export const REINHARD_GLSL = /* glsl */ `
+vec3 reinhardClip(vec3 c) {
+  return c / (1.0 + max(c.r, max(c.g, c.b)) * ${REINHARD_CLIP});
+}
+`;

--- a/games/crazy-waymo/src/fx/skids.ts
+++ b/games/crazy-waymo/src/fx/skids.ts
@@ -3,12 +3,14 @@ import * as THREE from "three";
 import { DRAPE_MAX_ERROR } from "../world/conform";
 import { ASPHALT_LIFT } from "../world/roads";
 
-// Tire skid marks: a single mesh holding a ring buffer of dark quads stamped
-// onto the road. One draw call, zero allocation per stamp, per-quad age fade.
+// Tire skid marks: a single mesh holding a ring buffer of quads stamped onto
+// the road. One draw call, zero allocation per stamp, per-quad age fade.
 //
-// Quads use an RGBA vertex color attribute (three.js enables vertex alpha when
-// the color attribute has itemSize 4), so fading is a buffer write, not a
-// material change. Inactive quads are degenerate (all verts at origin).
+// The material MULTIPLIES the framebuffer (r185 requires premultipliedAlpha
+// for MultiplyBlending: src DST_COLOR / dst ONE_MINUS_SRC_ALPHA, so the
+// effective multiplier is mix(1, tint, a)). A mark darkens whatever it lands
+// on — correct on sunlit and night asphalt alike, and it can never float like
+// black paint. Output is a multiplier, not radiance: no tone map, no fog.
 
 const MAX_QUADS = 600;
 const LIFE = 10; // seconds until a mark fully fades
@@ -19,6 +21,49 @@ const HALF_L = 0.25; // ~0.5u long
 // verts — marks must clear the worst-case road SURFACE, not the terrain, or
 // the road swallows them. Exported so trails layer above skids by contract.
 export const SKID_LIFT = ASPHALT_LIFT + DRAPE_MAX_ERROR + 0.02; // 0.18
+
+// Plain rubber: near-black, slightly cool (multiplier target at full alpha).
+const RUBBER_TINT = { r: 0.17, g: 0.16, b: 0.19 } as const;
+
+// A multiply layer cannot show an emissive tier color, so the tier hue becomes
+// a tint OF the darkening: normalize the color's max channel to a fixed lift
+// so every tier darkens equally and the hue lives only in the channel ratios —
+// reads as burnt road (cool / warm / violet scorch), never glowing paint.
+const SCORCH_LIFT = 0.34;
+const SCORCH_BASE = { r: 0.07, g: 0.065, b: 0.06 } as const;
+
+export function scorchTint(color: THREE.Color, out: THREE.Color): THREE.Color {
+  const mx = Math.max(color.r, Math.max(color.g, color.b), 1e-4);
+  const k = SCORCH_LIFT / mx;
+  out.setRGB(SCORCH_BASE.r + color.r * k, SCORCH_BASE.g + color.g * k, SCORCH_BASE.b + color.b * k);
+  return out;
+}
+
+// Age fade runs on the GPU: each vertex carries its stamp time and the shader
+// compares it to a clock uniform — update() advances ONE float instead of
+// rewriting the whole color buffer every frame. Fade holds, then dissolves
+// over the back half of LIFE.
+const SKID_VERT = /* glsl */ `
+  attribute vec4 aTint;
+  attribute float aBirth;
+  uniform float uTime;
+  varying vec4 vTint;
+  varying float vFade;
+  void main() {
+    vTint = aTint;
+    float age = (uTime - aBirth) / ${LIFE.toFixed(1)};
+    vFade = 1.0 - smoothstep(0.5, 1.0, age);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+const SKID_FRAG = /* glsl */ `
+  varying vec4 vTint;
+  varying float vFade;
+  void main() {
+    float a = vTint.a * vFade;
+    gl_FragColor = vec4(vTint.rgb * a, a);
+  }
+`;
 
 export class SkidMarks {
   readonly mesh: THREE.Mesh;
@@ -54,49 +99,29 @@ export class SkidMarks {
     this.colAttr = new THREE.BufferAttribute(this.colors, 4);
     this.birthAttr = new THREE.BufferAttribute(this.births, 1);
     geo.setAttribute("position", this.posAttr);
-    geo.setAttribute("color", this.colAttr);
+    geo.setAttribute("aTint", this.colAttr);
     geo.setAttribute("aBirth", this.birthAttr);
     geo.setIndex(new THREE.BufferAttribute(index, 1));
     geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
 
-    const mat = new THREE.MeshBasicMaterial({
-      color: 0xffffff, // vertex colors carry the (near-black) tint
-      vertexColors: true,
+    const mat = new THREE.ShaderMaterial({
+      uniforms: { uTime: this.timeU },
+      vertexShader: SKID_VERT,
+      fragmentShader: SKID_FRAG,
       transparent: true,
       depthWrite: false,
+      blending: THREE.MultiplyBlending,
+      premultipliedAlpha: true,
       polygonOffset: true,
       polygonOffsetFactor: -3,
       polygonOffsetUnits: -4,
       side: THREE.DoubleSide,
     });
-    // Age fade runs on the GPU: each vertex carries its stamp time and the
-    // shader compares it to a clock uniform — update() advances ONE float
-    // instead of rewriting (and re-uploading) the whole color buffer every
-    // frame. Same curve as before: linear alpha over LIFE seconds.
-    const timeU = this.timeU;
-    mat.onBeforeCompile = (shader) => {
-      shader.uniforms.uTime = timeU;
-      shader.vertexShader = shader.vertexShader
-        .replace(
-          "#include <common>",
-          "#include <common>\nattribute float aBirth;\nvarying float vBirth;",
-        )
-        .replace("#include <begin_vertex>", "#include <begin_vertex>\nvBirth = aBirth;");
-      shader.fragmentShader = shader.fragmentShader
-        .replace(
-          "#include <common>",
-          "#include <common>\nuniform float uTime;\nvarying float vBirth;",
-        )
-        .replace(
-          "#include <color_fragment>",
-          `#include <color_fragment>\n\tdiffuseColor.a *= clamp(1.0 - (uTime - vBirth) / ${LIFE.toFixed(1)}, 0.0, 1.0);`,
-        );
-    };
     this.mesh = new THREE.Mesh(geo, mat);
     this.mesh.frustumCulled = false;
   }
 
-  // Stamp one dark quad aligned to `yaw` (forward = (sin yaw, cos yaw)) at
+  // Stamp one rubber quad aligned to `yaw` (forward = (sin yaw, cos yaw)) at
   // terrain height + SKID_LIFT. Ring buffer: the oldest mark is overwritten.
   stamp(x: number, z: number, yaw: number, alpha = 0.7): void {
     const fx = Math.sin(yaw) * HALF_L;
@@ -106,7 +131,17 @@ export class SkidMarks {
 
   // Stamp a quad spanning (x0,z0) → (x1,z1) — consecutive segments share
   // their endpoints, so a braking line reads continuous, never dashed.
-  stampSegment(x0: number, z0: number, x1: number, z1: number, alpha = 0.7): void {
+  // `tint` is the multiplier target (default plain rubber); `halfW` widens
+  // one-shot scorch stamps (promotion kisses) past the tyre width.
+  stampSegment(
+    x0: number,
+    z0: number,
+    x1: number,
+    z1: number,
+    alpha = 0.7,
+    tint: { r: number; g: number; b: number } = RUBBER_TINT,
+    halfW = HALF_W,
+  ): void {
     const dx = x1 - x0;
     const dz = z1 - z0;
     if (dx * dx + dz * dz < 0.002) return;
@@ -114,8 +149,8 @@ export class SkidMarks {
     const q = this.cursor;
     this.cursor = (this.cursor + 1) % MAX_QUADS;
 
-    const rx = Math.cos(yaw) * HALF_W;
-    const rz = -Math.sin(yaw) * HALF_W;
+    const rx = Math.cos(yaw) * halfW;
+    const rz = -Math.sin(yaw) * halfW;
 
     const p = q * 4 * 3;
     // Vertex order: back-left, back-right, front-left, front-right.
@@ -132,7 +167,7 @@ export class SkidMarks {
     this.births[b + 3] = this.time;
     this.birthAttr.needsUpdate = true;
 
-    this.writeQuadColor(q, alpha);
+    this.writeQuadColor(q, alpha, tint);
     this.colAttr.needsUpdate = true;
   }
 
@@ -149,13 +184,17 @@ export class SkidMarks {
     this.positions[offset + 2] = z;
   }
 
-  private writeQuadColor(q: number, alpha: number): void {
+  private writeQuadColor(
+    q: number,
+    alpha: number,
+    tint: { r: number; g: number; b: number },
+  ): void {
     const c = q * 4 * 4;
     for (let v = 0; v < 4; v++) {
       const o = c + v * 4;
-      this.colors[o] = 0.03;
-      this.colors[o + 1] = 0.03;
-      this.colors[o + 2] = 0.035;
+      this.colors[o] = tint.r;
+      this.colors[o + 1] = tint.g;
+      this.colors[o + 2] = tint.b;
       this.colors[o + 3] = alpha;
     }
   }

--- a/games/crazy-waymo/src/fx/tier.ts
+++ b/games/crazy-waymo/src/fx/tier.ts
@@ -1,0 +1,13 @@
+// Drift-tier visual ladder, shared by spark FX, skid scorch and the HUD so
+// the three surfaces can never disagree about what a tier looks like. The
+// ladder is the Mario-Kart-family escalation (blue → orange → violet):
+// `Car.driftTier` 1 → blue, 2 → orange; violet is reserved for the
+// boost-release / promotion moment, not a holdable state.
+export const TIER_COLORS = ["#4fc3ff", "#ff9d2e", "#c05cff"] as const;
+
+/** Grind sparks below tier 1 — the uncharged scrape, never a "reward" hue. */
+export const GRIND_COLOR = "#ffd75e";
+
+export function tierColor(tier: 0 | 1 | 2): string {
+  return tier === 0 ? GRIND_COLOR : tier === 1 ? TIER_COLORS[0] : TIER_COLORS[1];
+}

--- a/games/crazy-waymo/src/fx/trails.ts
+++ b/games/crazy-waymo/src/fx/trails.ts
@@ -1,15 +1,17 @@
 import * as THREE from "three";
 
+import { REINHARD_GLSL } from "./reinhard";
 import { SKID_LIFT } from "./skids";
+import { TIER_COLORS } from "./tier";
 
 // Drift light-trails: two glowing ribbons laid onto the road behind the rear
 // wheels while sliding or boosting — the arcade "light streak" that makes a
 // drift read from across the screen. One mesh, one draw call, ring-buffered
 // samples, additive blend so streaks pop over dark asphalt.
 //
-// Color is captured per sample (white slide → cyan charged → orange boost), so
-// a drift that arms mid-corner leaves a visible white→cyan gradient down the
-// ribbon.
+// Color is captured per sample (white slide → tier blue → tier orange), so a
+// drift that arms mid-corner leaves a visible white→blue gradient down the
+// ribbon. Tier hues come from fx/tier.ts so ribbon, sparks and HUD agree.
 
 const SAMPLES = 44; // per ribbon
 const RIBBONS = 2;
@@ -19,6 +21,11 @@ const HALF_W = 0.26;
 // still well below the car body.
 const LIFT = SKID_LIFT + 0.04; // 0.22
 const MIN_STEP = 0.45; // world units between samples
+// Ribbons cover big screen area, so they sit near the bottom of the 2.2-3.4
+// additive band — the shoulder still keeps stacked crossings from whiting out,
+// and only dense overlaps graze the day bloom gate.
+const TIER_INTENSITY = 1.2;
+const SLIDE_INTENSITY = 0.85;
 
 type Sample = {
   x: number;
@@ -70,6 +77,17 @@ export class DriftTrails {
       blending: THREE.AdditiveBlending,
       side: THREE.DoubleSide,
     });
+    // Max-channel Reinhard shoulder as the last op before write: two ribbons
+    // crossing (or ribbon over sparks) asymptote toward the tier hue instead
+    // of clipping to white.
+    mat.onBeforeCompile = (shader) => {
+      shader.fragmentShader = shader.fragmentShader
+        .replace("#include <common>", `#include <common>\n${REINHARD_GLSL}`)
+        .replace(
+          "#include <opaque_fragment>",
+          "outgoingLight = reinhardClip(outgoingLight);\n#include <opaque_fragment>",
+        );
+    };
     this.mesh = new THREE.Mesh(geo, mat);
     this.mesh.frustumCulled = false;
     this.mesh.renderOrder = 2;
@@ -106,9 +124,9 @@ export class DriftTrails {
     }
     head.x = x;
     head.z = z;
-    if (kind === 2) this.tmp.setRGB(1.0, 0.5, 0.14);
-    else if (kind === 1) this.tmp.setRGB(0.25, 0.92, 1.0);
-    else this.tmp.setRGB(0.8, 0.88, 1.0);
+    if (kind === 2) this.tmp.set(TIER_COLORS[1]).multiplyScalar(TIER_INTENSITY);
+    else if (kind === 1) this.tmp.set(TIER_COLORS[0]).multiplyScalar(TIER_INTENSITY);
+    else this.tmp.setRGB(0.8, 0.88, 1.0).multiplyScalar(SLIDE_INTENSITY);
     const sample: Sample = {
       x,
       z,

--- a/games/crazy-waymo/src/fx/vehicle-fx.ts
+++ b/games/crazy-waymo/src/fx/vehicle-fx.ts
@@ -1,18 +1,57 @@
+import * as THREE from "three";
+
 import { CAR } from "../shared/constants";
 import type { Car } from "../vehicle/car";
-import type { Fx } from "./particles";
+import { FLAME_HOT, clampAxisToCone } from "./boost-plume";
+import type { Fx, FxTier } from "./particles";
+import { TIER_FX } from "./particles";
+import { scorchTint } from "./skids";
 import type { SkidMarks } from "./skids";
+import { TIER_COLORS, tierColor } from "./tier";
 import type { DriftTrails } from "./trails";
 
+// Sparks visibly slip from the contact patch but stay within ~1.5 m of it.
+const SPARK_INHERIT = 0.68;
+const SPARK_THROW_BACK = 2.0; // m/s backwards out of the patch
+const SPARK_THROW_OUT = 1.6; // m/s away from the turn
+const JET_INHERIT = 0.66;
+// Promotion burst counts per wheel, indexed by the tier being entered.
+const PROMO_BURST = [0, 22, 46] as const;
+// Top-tier ground-ring pulse (rate lives in TIER_FX).
+const PULSE_R0 = 0.35;
+const PULSE_R1 = 3.1;
+const PULSE_LIFE = 0.3;
+const PULSE_THICKNESS = 0.05;
+const PULSE_INTENSITY = 0.95;
+// Exhaust rig: rear corners of the SUV body, matching game-scene's
+// exhaustFlash anchors, with the plume root biased further back so the ribbon
+// mouth hides behind the bumper.
+const EXHAUST_BACK = 1.9;
+const EXHAUST_SIDE = 0.55;
+const EXHAUST_UP = 0.5;
+const PLUME_ROOT_BIAS = 0.2;
+const PLUME_AXIS_UP = 0.1;
+const PLUME_AXIS_SLIP = 0.5; // rad of slip -> lateral axis lean (cone-clamped)
+const BURN_RAMP = 0.9; // s to full flame
+const BURN_FLOOR = 0.32; // a fresh boost still shows a real tongue
+const IGNITE_DEDUPE = 0.24; // s — item-boost + release can land the same frame
+
 // Rear-wheel FX rig: the drift/boost ground effects that hang off the rear
-// axle — light-ribbon trails, tier-colored sparks, tire smoke, rubber skid
-// segments. Extracted from the game-scene god object: everything here derives
-// from (car, dt) plus the three FX systems, and the four emitters previously
-// quadruplicated the same axle math inline.
+// axle — light-ribbon trails, tier-channel sparks, tire smoke, scorch skids,
+// the boost plume pose and the ignition/promotion ring stacks. Extracted from
+// the game-scene god object: everything here derives from (car, dt) plus the
+// FX systems.
 export class VehicleFxRig {
-  private sparkAccum = 0;
+  private sparkCarry = 0;
+  private jetCarry = 0;
+  private jetSide = 1;
+  private pulseClock = 0;
   private puffAccum = 0;
   private kickAccum = 0;
+  private prevTier: FxTier = 0;
+  private prevBoosting = false;
+  private igniteCooldown = 0;
+  private boostTime = 0;
   // Last stamped rear-wheel points — each frame extends the streak from here,
   // so marks stay continuous at any speed (per-frame quads read as dashes).
   private lastSkid: { lx: number; lz: number; rx: number; rz: number } | null = null;
@@ -22,6 +61,11 @@ export class VehicleFxRig {
   private az = 0;
   private px = 0;
   private pz = 0;
+  private tmpColor = new THREE.Color();
+  private tmpHot = new THREE.Color();
+  private tmpScorch = new THREE.Color();
+  private cone = { x: 0, y: 0, z: -1 };
+  private dir = { x: 0, z: 0, speed: 0 };
 
   constructor(
     private readonly fx: Fx,
@@ -46,8 +90,26 @@ export class VehicleFxRig {
     this.px = -fwdZ; // axle direction (perpendicular to heading)
     this.pz = fwdX;
 
+    // Promotion: every channel peaks on the raise frame — the in-flight
+    // shower recolors, the ring/pool/flares/scorch all spawn in this call.
+    const tier: FxTier = drifting ? car.driftTier : 0;
+    if (tier > this.prevTier && drifting && !car.airborne) this.firePromotion(car, tier);
+    this.prevTier = tier;
+
+    // Boost ignition: rising isBoosting edge covers pad/item boosts too;
+    // miniBoostFired flags the drift-release turbo. Deduped — both can land
+    // on the same frame.
+    this.igniteCooldown = Math.max(0, this.igniteCooldown - dt);
+    const ignite = (car.isBoosting && !this.prevBoosting) || car.miniBoostFired;
+    this.prevBoosting = car.isBoosting;
+    if (ignite && this.igniteCooldown <= 0) {
+      this.igniteCooldown = IGNITE_DEDUPE;
+      this.fireIgnition(car);
+    }
+    this.drivePlume(dt, car, fwdX, fwdZ);
+
     if (drifting || car.isBoosting || brakingHard) this.emitSmoke(dt, car, surface);
-    if ((drifting && !car.airborne) || brakingHard) this.stampSkids();
+    if ((drifting && !car.airborne) || brakingHard) this.stampSkids(car, drifting);
     else this.lastSkid = null; // next streak starts fresh, not joined to this one
     this.emitTrails(car, drifting);
     if (drifting && !car.airborne) this.emitSparks(dt, car);
@@ -76,54 +138,278 @@ export class VehicleFxRig {
     if (!trails || car.airborne) return;
     const cornering = Math.abs(car.slip) > 0.12 && car.speed > 20;
     if (!drifting && !car.isBoosting && !cornering) return;
-    // Ribbon color follows the mini-turbo tier: white grind → cyan → orange.
+    // Ribbon color follows the mini-turbo tier: white grind → blue → orange.
     const kind = car.isBoosting || car.driftTier === 2 ? 2 : car.driftTier === 1 ? 1 : 0;
     const strength = Math.min(1, car.speed / CAR.maxSpeed);
     trails.emit(0, this.ax + this.px * 0.7, this.az + this.pz * 0.7, car.heading, kind, strength);
     trails.emit(1, this.ax - this.px * 0.7, this.az - this.pz * 0.7, car.heading, kind, strength);
   }
 
-  // Mario-Kart drift sparks: a steady spray off the rear wheels while the
-  // drift holds, colored by the charge tier — yellow grind → blue (tier 1
-  // armed) → orange (tier 2 armed). The tier-up moments themselves flare in
-  // the scene's update loop.
+  // Steady tier shower off the rear wheels. Escalation is SHAPE, not hue:
+  // TIER_FX raises rate and core size per tier; the top tier adds the
+  // vertical ember jet and the 6.5 Hz ground-ring pulse. Hue rides the live
+  // channel (fx.setTierChannel) so grains already in the air repaint on
+  // promotion.
   private emitSparks(dt: number, car: Car): void {
-    this.sparkAccum += dt;
-    if (this.sparkAccum < 0.05) return;
-    this.sparkAccum = 0;
     const tier = car.driftTier;
-    const hue = tier === 2 ? 0.07 : tier === 1 ? 0.58 : 0.13;
-    const power = 2.6 + tier * 1.2;
-    const y = car.position.y + 0.35;
-    this.fx.burst(this.ax + this.px * 0.8, y, this.az + this.pz * 0.8, hue, 2 + tier, power);
-    this.fx.burst(this.ax - this.px * 0.8, y, this.az - this.pz * 0.8, hue, 2 + tier, power);
+    const t = TIER_FX[tier];
+    this.fx.setTierChannel(tierColor(tier));
+    const y = car.position.y + 0.25;
+
+    this.sparkCarry += dt * t.rate;
+    let n = Math.floor(this.sparkCarry);
+    this.sparkCarry -= n;
+    n = Math.min(n, 10); // hitch guard: never dump a stalled frame's backlog
+    if (n > 0) {
+      // Thrown backwards + away from the turn, inheriting most of the car's
+      // velocity so the cone swings with the drift angle.
+      const outSign = car.slip >= 0 ? -1 : 1;
+      const dx =
+        car.velX * SPARK_INHERIT -
+        Math.sin(car.heading) * SPARK_THROW_BACK +
+        this.px * outSign * SPARK_THROW_OUT;
+      const dz =
+        car.velZ * SPARK_INHERIT -
+        Math.cos(car.heading) * SPARK_THROW_BACK +
+        this.pz * outSign * SPARK_THROW_OUT;
+      const speed = Math.hypot(dx, dz);
+      const inv = speed > 1e-4 ? 1 / speed : 0;
+      this.dir.x = dx * inv;
+      this.dir.z = dz * inv;
+      this.dir.speed = speed;
+      // Outside wheel throws harder than the inside one.
+      const outerLeft = outSign > 0;
+      const nl = Math.max(1, Math.round(n * (outerLeft ? 1.25 : 0.75)));
+      const nr = Math.max(1, Math.round(n * (outerLeft ? 0.75 : 1.25)));
+      this.fx.driftShower(
+        this.ax + this.px * 0.8,
+        y,
+        this.az + this.pz * 0.8,
+        tier,
+        nl,
+        this.dir.x,
+        this.dir.z,
+        this.dir.speed,
+      );
+      this.fx.driftShower(
+        this.ax - this.px * 0.8,
+        y,
+        this.az - this.pz * 0.8,
+        tier,
+        nr,
+        this.dir.x,
+        this.dir.z,
+        this.dir.speed,
+      );
+    }
+
+    if (t.jet > 0) {
+      this.jetCarry += dt * t.jet;
+      const nj = Math.min(Math.floor(this.jetCarry), 6);
+      this.jetCarry -= Math.floor(this.jetCarry);
+      if (nj > 0) {
+        this.jetSide = -this.jetSide;
+        this.fx.emberJet(
+          this.ax + this.px * 0.8 * this.jetSide,
+          y,
+          this.az + this.pz * 0.8 * this.jetSide,
+          nj,
+          car.velX * JET_INHERIT,
+          car.velZ * JET_INHERIT,
+        );
+      }
+    } else {
+      this.jetCarry = 0;
+    }
+
+    if (t.pulse > 0) {
+      this.pulseClock += dt;
+      const interval = 1 / t.pulse;
+      if (this.pulseClock >= interval) {
+        this.pulseClock -= interval;
+        this.tmpColor.set(tierColor(tier));
+        this.fx.rings.spawn(
+          car.position.x,
+          car.position.y + 0.12,
+          car.position.z,
+          PULSE_R0,
+          PULSE_R1,
+          PULSE_LIFE,
+          PULSE_THICKNESS,
+          this.tmpColor,
+          PULSE_INTENSITY,
+          0.95,
+          car.velX,
+          car.velZ,
+          1.8,
+        );
+      }
+    } else {
+      this.pulseClock = 0;
+    }
+  }
+
+  // Tier promotion — burst + recolor + ring + pool + air flares + scorch, all
+  // in one call so they crest on the same frame.
+  private firePromotion(car: Car, tier: FxTier): void {
+    this.fx.setTierChannel(tierColor(tier)); // repaints the in-flight shower too
+    const y = car.position.y;
+    const burst = PROMO_BURST[tier];
+    const skids = this.getSkids();
+    scorchTint(this.tmpColor.set(tierColor(tier)), this.tmpScorch);
+    const fwdX = Math.sin(car.heading);
+    const fwdZ = Math.cos(car.heading);
+    for (const s of [-1, 1] as const) {
+      const wx = this.ax + this.px * 0.8 * s;
+      const wz = this.az + this.pz * 0.8 * s;
+      this.fx.promotionBurst(wx, y + 0.3, wz, tier, burst, car.velX * 0.5, car.velZ * 0.5);
+      this.fx.promotionFlare(
+        this.ax + this.px * 0.72 * s,
+        y + 0.9,
+        this.az + this.pz * 0.72 * s,
+        tier,
+      );
+      // One hot scorch kiss under each patch, wider than the running streak.
+      skids?.stampSegment(
+        wx - fwdX * 0.45,
+        wz - fwdZ * 0.45,
+        wx + fwdX * 0.45,
+        wz + fwdZ * 0.45,
+        0.5 + 0.1 * tier,
+        this.tmpScorch,
+        0.4 + 0.14 * tier,
+      );
+    }
+    this.tmpColor.set(tierColor(tier));
+    this.fx.rings.spawn(
+      car.position.x,
+      y + 0.12,
+      car.position.z,
+      0.6,
+      2.6 + 2.0 * tier,
+      0.22 + 0.04 * tier,
+      0.06,
+      this.tmpColor,
+      0.75 + 0.42 * tier,
+      0.9,
+      car.velX,
+      car.velZ,
+      1.6,
+    );
+    this.fx.promotionPool(car.position.x, y, car.position.z, tier, car.velX, car.velZ);
+  }
+
+  // Boost ignition: three staggered ground-plane rings (never travel-facing —
+  // road-plane from a chase rig reads as a fast edge-on ellipse). The violet
+  // accent is the release color reserved by fx/tier.ts; the y+1.05 overtaking
+  // front sweeps PAST the lens. The plume spike and game-scene's exhaust
+  // flash land on the same frame.
+  private fireIgnition(car: Car): void {
+    const tier = car.miniTurboTier;
+    const x = car.position.x;
+    const y = car.position.y;
+    const z = car.position.z;
+    this.tmpColor.set(TIER_COLORS[2]);
+    this.fx.rings.spawn(
+      x,
+      y + 0.3,
+      z,
+      0.9,
+      7.5 + 2.2 * tier,
+      0.34,
+      0.055,
+      this.tmpColor,
+      1.55 + 0.45 * tier,
+      0.9,
+      car.velX,
+      car.velZ,
+      1.4,
+    );
+    this.tmpHot.set(FLAME_HOT);
+    this.fx.rings.spawn(
+      x,
+      y + 0.52,
+      z,
+      0.5,
+      4.8,
+      0.24,
+      0.075,
+      this.tmpHot,
+      1.25,
+      0.9,
+      car.velX,
+      car.velZ,
+      1.5,
+    );
+    this.tmpColor.set(TIER_COLORS[2]);
+    this.fx.rings.spawn(
+      x,
+      y + 1.05,
+      z,
+      2.2,
+      9.5 + 2.0 * tier,
+      0.2,
+      0.035,
+      this.tmpColor,
+      0.95 + 0.42 * tier,
+      0.9,
+      car.velX,
+      car.velZ,
+      1.2,
+    );
+    this.fx.plume.ignite(0.45 + 0.25 * tier);
+    // Sustained sheath keeps the color of the tier that was released; the
+    // violet stays reserved for the release moment itself.
+    this.tmpColor.set(tier === 1 ? TIER_COLORS[0] : TIER_COLORS[1]);
+    this.fx.plume.setTint(this.tmpColor);
+  }
+
+  // Plume pose runs every frame: burnTarget 0 lets the ribbon ease out and
+  // hide when the boost ends. The axis leans with slip but is clamped into
+  // the 18-degree cone about straight-back — the cone, not the length, keeps
+  // the flame behind the car.
+  private drivePlume(dt: number, car: Car, fwdX: number, fwdZ: number): void {
+    if (car.isBoosting) this.boostTime += dt;
+    else this.boostTime = 0;
+    const burn = car.isBoosting ? Math.min(1, Math.max(BURN_FLOOR, this.boostTime / BURN_RAMP)) : 0;
+    const bx = car.position.x - fwdX * (EXHAUST_BACK + PLUME_ROOT_BIAS);
+    const bz = car.position.z - fwdZ * (EXHAUST_BACK + PLUME_ROOT_BIAS);
+    const y = car.position.y + EXHAUST_UP;
+    const lat = Math.max(-0.45, Math.min(0.45, car.slip * PLUME_AXIS_SLIP));
+    let axx = -fwdX + this.px * lat;
+    let axy = PLUME_AXIS_UP;
+    let axz = -fwdZ + this.pz * lat;
+    const al = Math.hypot(axx, axy, axz);
+    axx /= al;
+    axy /= al;
+    axz /= al;
+    clampAxisToCone(axx, axy, axz, -fwdX, 0, -fwdZ, this.cone);
+    this.fx.plume.drive(
+      bx - fwdZ * EXHAUST_SIDE,
+      y,
+      bz + fwdX * EXHAUST_SIDE,
+      bx + fwdZ * EXHAUST_SIDE,
+      y,
+      bz - fwdX * EXHAUST_SIDE,
+      this.cone.x,
+      this.cone.y,
+      this.cone.z,
+      burn,
+    );
   }
 
   private emitSmoke(dt: number, car: Car, surface: "road" | "grass" | "sand" | "concrete"): void {
     this.puffAccum += dt;
     if (this.puffAccum < 0.03) return;
     this.puffAccum = 0;
-    const charged = car.driftCharge >= 1 && car.isDrifting;
     const y = car.position.y;
-    this.fx.driftPuff(
-      this.ax + this.px * 0.7,
-      y,
-      this.az + this.pz * 0.7,
-      car.isBoosting,
-      charged,
-      surface,
-    );
-    this.fx.driftPuff(
-      this.ax - this.px * 0.7,
-      y,
-      this.az - this.pz * 0.7,
-      car.isBoosting,
-      charged,
-      surface,
-    );
+    this.fx.driftPuff(this.ax + this.px * 0.7, y, this.az + this.pz * 0.7, car.isBoosting, surface);
+    this.fx.driftPuff(this.ax - this.px * 0.7, y, this.az - this.pz * 0.7, car.isBoosting, surface);
   }
 
-  private stampSkids(): void {
+  // Drift streaks scorch in the tier's hue (via the multiply-decal tint);
+  // straight-line braking keeps plain rubber.
+  private stampSkids(car: Car, drifting: boolean): void {
     const skids = this.getSkids();
     if (!skids) return;
     const now = {
@@ -140,8 +426,14 @@ export class VehicleFxRig {
         return;
       }
       if (d < 0.3) return; // too short to matter; wait for more travel
-      skids.stampSegment(last.lx, last.lz, now.lx, now.lz);
-      skids.stampSegment(last.rx, last.rz, now.rx, now.rz);
+      if (drifting) {
+        scorchTint(this.tmpColor.set(tierColor(car.driftTier)), this.tmpScorch);
+        skids.stampSegment(last.lx, last.lz, now.lx, now.lz, 0.7, this.tmpScorch);
+        skids.stampSegment(last.rx, last.rz, now.rx, now.rz, 0.7, this.tmpScorch);
+      } else {
+        skids.stampSegment(last.lx, last.lz, now.lx, now.lz);
+        skids.stampSegment(last.rx, last.rz, now.rx, now.rz);
+      }
     }
     this.lastSkid = now;
   }

--- a/games/crazy-waymo/src/fx/vehicle-fx.ts
+++ b/games/crazy-waymo/src/fx/vehicle-fx.ts
@@ -371,7 +371,14 @@ export class VehicleFxRig {
   private drivePlume(dt: number, car: Car, fwdX: number, fwdZ: number): void {
     if (car.isBoosting) this.boostTime += dt;
     else this.boostTime = 0;
-    const burn = car.isBoosting ? Math.min(1, Math.max(BURN_FLOOR, this.boostTime / BURN_RAMP)) : 0;
+    // Speed-scaled: a standstill boost put the camera nearly inside the ribbon
+    // and the full-burn plume filled the frame (review pass) — the flame earns
+    // its size with motion.
+    const spd = Math.hypot(car.velX, car.velZ);
+    const spdScale = 0.4 + 0.6 * Math.min(1, Math.max(0, (spd - 3) / 11));
+    const burn = car.isBoosting
+      ? Math.min(1, Math.max(BURN_FLOOR, this.boostTime / BURN_RAMP)) * spdScale
+      : 0;
     const bx = car.position.x - fwdX * (EXHAUST_BACK + PLUME_ROOT_BIAS);
     const bz = car.position.z - fwdZ * (EXHAUST_BACK + PLUME_ROOT_BIAS);
     const y = car.position.y + EXHAUST_UP;

--- a/games/crazy-waymo/src/render/aerial-fog.ts
+++ b/games/crazy-waymo/src/render/aerial-fog.ts
@@ -87,6 +87,19 @@ const WEST_NONE_X = toX(0.32);
 // bank readable as weather without erasing what it sits on.
 const WEST_WEIGHT = 0.3;
 
+// --- Dual-rate mix (the painter's aerial perspective) ---------------------
+// A surface loses its HUE before it loses its VALUE: chroma converges onto the
+// haze FOG_CHROMA_RATE times faster than the plain fog lerp converges
+// brightness. A single-rate lerp keeps a far facade reading as saturated
+// cardboard right up until it vanishes; with the drain, a distant ridge is
+// mostly desaturated while still holding its value step, so the silhouette
+// ladder survives. The caps are the residuals: FOG_MAX leaves 8% of the
+// surface in the mix so backdrop planes never fuse into one sheet, and
+// FOG_CHROMA_MAX leaves a whisper of the surface's own hue at full drain.
+const FOG_CHROMA_RATE = 1.85;
+const FOG_CHROMA_MAX = 0.96;
+const FOG_MAX = 0.92;
+
 const f = (n: number): string => n.toFixed(2);
 
 let installed = false;
@@ -191,8 +204,14 @@ export function installAerialFog(): void {
 	vec3 marineColor = mix( fogColor, vec3( lum ), 0.8 ) * ( 1.0 + 0.26 * lum );
 	vec3 hazeColor = mix( fogColor, marineColor, marine * 0.85 );
 
-	fogFactor = clamp( fogFactor + marineFog * ( 1.0 - fogFactor ), 0.0, 1.0 );
-	gl_FragColor.rgb = mix( gl_FragColor.rgb, hazeColor, fogFactor );
+	fogFactor = min( fogFactor + marineFog * ( 1.0 - fogFactor ), ${f(FOG_MAX)} );
+	// Dual-rate mix (see FOG_CHROMA_RATE): first rotate the fragment onto the
+	// haze's chromaticity at its OWN luminance, then converge value at the
+	// base rate — hue drains faster than brightness at every distance.
+	float hazeLum = max( dot( hazeColor, vec3( 0.2126, 0.7152, 0.0722 ) ), 1e-4 );
+	vec3 drained = hazeColor * ( dot( gl_FragColor.rgb, vec3( 0.2126, 0.7152, 0.0722 ) ) / hazeLum );
+	float chromaFog = min( fogFactor * ${f(FOG_CHROMA_RATE)}, ${f(FOG_CHROMA_MAX)} );
+	gl_FragColor.rgb = mix( mix( gl_FragColor.rgb, drained, chromaFog ), hazeColor, fogFactor );
 
 #endif
 `;

--- a/games/crazy-waymo/src/render/day-night.ts
+++ b/games/crazy-waymo/src/render/day-night.ts
@@ -108,7 +108,7 @@ const SKY_DAY: SkyPreset = [2.0, 0.5, 0.0018, 0.8, 1.7];
 // Golden hour wants a VEIL, not a clear sky: turbidity + mie forward-scatter
 // paint the amber quarter around the low sun (the kart-racer money shot);
 // loose g keeps the glare see-through instead of a hard disc halo.
-const SKY_GOLDEN: SkyPreset = [2.8, 0.7, 0.0022, 0.66, 1.2];
+const SKY_GOLDEN: SkyPreset = [4.0, 0.45, 0.0022, 0.66, 1.2];
 const SKY_SUNSET: SkyPreset = [3.0, 0.85, 0.0016, 0.68, 0.55];
 const SKY_NIGHT: SkyPreset = [2.0, 0.5, 0.002, 0.8, 0.55];
 
@@ -233,7 +233,7 @@ const STOPS: readonly Stop[] = [
   // rig (a 70-candela spot plus two head sprites) under a noon-blue sky — the
   // single loudest thing in the most flattering frame the game has. Lamps now
   // wait for the sun to reach the horizon.
-  stop(0.40,  11,   235,   dir(11, 235),  0xffbe74, 1.9,  0xffd6a6, 0x6b5c40, 0.48, 0.12, 0xfff2e2, 0xc49a80, 430, 940, 0.26, 0,    0.70, 1.0,  SKY_GOLDEN),
+  stop(0.40,   9,   235,   dir(9, 235),   0xffa860, 1.9,  0xffd6a6, 0x6b5c40, 0.48, 0.12, 0xfff2e2, 0xc49a80, 430, 940, 0.26, 0,    0.76, 1.0,  SKY_GOLDEN),
   stop(0.47,   2,   248,   dir(4, 248),   0xff9350, 1.25, 0xff9d70, 0x3e3a44, 0.36, 0.11, 0xe0dcf0, 0xac7160, 400, 900, 0.18, 0.62, 0.68, 1.0,  SKY_SUNSET),
   // Night floors are tuned for PHONES: a desktop panel at full brightness can
   // read a 0.3-fill scene, a dim phone outdoors cannot. Moonlight carries the

--- a/games/crazy-waymo/src/render/day-night.ts
+++ b/games/crazy-waymo/src/render/day-night.ts
@@ -105,7 +105,10 @@ type SkyPreset = readonly [number, number, number, number, number];
 // it only gives up the clipping that was washing out its own oranges (2°
 // elevation, into the sun, goes from a cream (234,226,191) to (223,212,165)).
 const SKY_DAY: SkyPreset = [2.0, 0.5, 0.0018, 0.8, 1.7];
-const SKY_GOLDEN: SkyPreset = [2.2, 0.62, 0.001, 0.62, 1.2];
+// Golden hour wants a VEIL, not a clear sky: turbidity + mie forward-scatter
+// paint the amber quarter around the low sun (the kart-racer money shot);
+// loose g keeps the glare see-through instead of a hard disc halo.
+const SKY_GOLDEN: SkyPreset = [2.8, 0.7, 0.0022, 0.66, 1.2];
 const SKY_SUNSET: SkyPreset = [3.0, 0.85, 0.0016, 0.68, 0.55];
 const SKY_NIGHT: SkyPreset = [2.0, 0.5, 0.002, 0.8, 0.55];
 
@@ -230,7 +233,7 @@ const STOPS: readonly Stop[] = [
   // rig (a 70-candela spot plus two head sprites) under a noon-blue sky — the
   // single loudest thing in the most flattering frame the game has. Lamps now
   // wait for the sun to reach the horizon.
-  stop(0.40,  11,   235,   dir(11, 235),  0xffbe74, 1.9,  0xffd6a6, 0x6b5c40, 0.42, 0.12, 0xfff2e2, 0xc49a80, 430, 940, 0.26, 0,    0.70, 0.85, SKY_GOLDEN),
+  stop(0.40,  11,   235,   dir(11, 235),  0xffbe74, 1.9,  0xffd6a6, 0x6b5c40, 0.48, 0.12, 0xfff2e2, 0xc49a80, 430, 940, 0.26, 0,    0.70, 1.0,  SKY_GOLDEN),
   stop(0.47,   2,   248,   dir(4, 248),   0xff9350, 1.25, 0xff9d70, 0x3e3a44, 0.36, 0.11, 0xe0dcf0, 0xac7160, 400, 900, 0.18, 0.62, 0.68, 1.0,  SKY_SUNSET),
   // Night floors are tuned for PHONES: a desktop panel at full brightness can
   // read a 0.3-fill scene, a dim phone outdoors cannot. Moonlight carries the

--- a/games/crazy-waymo/src/render/far-terrain.ts
+++ b/games/crazy-waymo/src/render/far-terrain.ts
@@ -57,6 +57,33 @@ const FRINGE_MIN = 6; // ...but never thinner than this in world units
 // each vertex gets a value multiplier from a low-frequency bearing wave (broad
 // flanks catching or losing the light) plus a lift toward the crest.
 const RELIEF = 0.2;
+// Painter's value ladder (kart-royale backdrop treatment): the fog drains hue
+// faster than value (render/aerial-fog.ts), so VALUE is the only channel a
+// silhouette stack survives on at range — nearest ridge darkest, lightening
+// toward the sky. Applied per PIXEL before the fog mix (the camera roams
+// ±~1.5km of the band centre, so distance varies a lot within one band) and
+// day-weighted so the tuned night fog convergence is untouched.
+const LADDER_NEAR = 260;
+const LADDER_FAR = 3600;
+const LADDER_LO = 0.42;
+const LADDER_HI = 0.8;
+// Azimuthal aerial tint, desaturate-first: warm toward the live sun color in
+// the near-sun sector, violet-grey away — that contrast IS golden hour. Both
+// ops ramp with distance so the near band keeps most of its own color.
+const AERIAL_NEAR = 900;
+const AERIAL_FAR = 3600;
+const AERIAL_DESAT = 0.42;
+const AERIAL_TINT = 0.34;
+const COOL_AWAY = 0xa9b0c8;
+// smoothstep bounds on cos(view azimuth, sun azimuth): warm ONLY into the sun.
+const WARM_LO = 0.15;
+const WARM_HI = 0.92;
+// Sun-keyed terms hold through sunset (lamp opens at 0.62 there), die across
+// dusk; the intensity ramp keeps the night moon (0.28-0.32) from ever tinting.
+const SUN_FADE_LO = 0.62;
+const SUN_FADE_HI = 1.0;
+const SUN_INT_LO = 0.5;
+const SUN_INT_HI = 1.2;
 
 /** A summit in bearing space: 0 = north (-Z), 90 = east (+X). */
 type Ridge = {
@@ -186,6 +213,8 @@ function bearings(band: Band): readonly number[] {
   return out;
 }
 
+const glf = (n: number): string => n.toFixed(2);
+
 const VERT = /* glsl */ `
   attribute float aTop;
   attribute float aHaze;
@@ -193,14 +222,18 @@ const VERT = /* glsl */ `
   attribute float aFringe;
   attribute float aRelief;
   uniform float uShell;
-  uniform vec3 uFog;
   uniform float uNight;
-  varying vec3 vColor;
+  varying vec3 vTint;
+  varying float vToFog;
+  varying vec2 vDir;
+  varying float vDist;
   void main() {
     vec3 rel = position - cameraPosition;
     float d = max(length(rel.xz), 1.0);
     vec3 p = cameraPosition + rel * (uShell / d);
     gl_Position = projectionMatrix * viewMatrix * vec4(p, 1.0);
+    vDist = d;
+    vDir = rel.xz / d;
     // Aerial perspective within the band: the foot sits deeper in the haze
     // than the crest, which is what sells one ridge standing behind another.
     float toFog = clamp(aHaze + (1.0 - aHaze) * (1.0 - aTop) * 0.55, 0.0, 1.0);
@@ -212,14 +245,35 @@ const VERT = /* glsl */ `
     // down stayed BRIGHTER than the sky it stood against and drew a pale
     // horizontal seam right across the bay in every night vista.
     toFog = mix(toFog, 1.0, uNight * 0.55);
-    vColor = mix(aTint * aRelief * (1.0 - 0.86 * uNight), uFog, toFog);
+    vToFog = toFog;
+    vTint = aTint * aRelief * (1.0 - 0.86 * uNight);
   }
 `;
 
 const FRAG = /* glsl */ `
-  varying vec3 vColor;
+  uniform vec3 uFog;
+  uniform vec2 uSunAzim;
+  uniform vec3 uSunWarm;
+  uniform vec3 uCool;
+  uniform float uDay;
+  varying vec3 vTint;
+  varying float vToFog;
+  varying vec2 vDir;
+  varying float vDist;
   void main() {
-    gl_FragColor = vec4(vColor, 1.0);
+    vec3 col = vTint;
+    // Value ladder, then desaturate, then azimuth tint, then the fog mix —
+    // the kart-royale registration order (ladder -> aerial -> fog).
+    float ladder = mix(${glf(LADDER_LO)}, ${glf(LADDER_HI)},
+      smoothstep(${glf(LADDER_NEAR)}, ${glf(LADDER_FAR)}, vDist));
+    col *= mix(1.0, ladder, uDay);
+    float aer = smoothstep(${glf(AERIAL_NEAR)}, ${glf(AERIAL_FAR)}, vDist) * uDay;
+    float lum = dot(col, vec3(0.2126, 0.7152, 0.0722));
+    col = mix(col, vec3(lum), ${glf(AERIAL_DESAT)} * aer);
+    float az = dot(vDir, uSunAzim);
+    col = mix(col, mix(uCool, uSunWarm, smoothstep(${glf(WARM_LO)}, ${glf(WARM_HI)}, az)),
+      ${glf(AERIAL_TINT)} * aer);
+    gl_FragColor = vec4(mix(col, uFog, vToFog), 1.0);
   }
 `;
 
@@ -227,6 +281,16 @@ export class FarTerrain {
   readonly mesh: THREE.Mesh;
   private uFog = { value: new THREE.Color(0xbfdcf2) };
   private uNight = { value: 0 };
+  private uSunAzim = { value: new THREE.Vector2(0, -1) };
+  private uSunWarm = { value: new THREE.Color(0xffd9a8) };
+  private uCool = { value: new THREE.Color(COOL_AWAY) };
+  private uDay = { value: 0 };
+  // The scene's shadow light, found once from the mesh's own render callback.
+  // update()'s call site only carries fog + night, and widening the god
+  // object's wiring for one vec3 isn't worth the drift — if a shared sun
+  // signal ever lands (render/grade.ts pattern), feed it there instead.
+  private sunRef: THREE.DirectionalLight | null = null;
+  private scrSun = new THREE.Vector3();
 
   constructor() {
     const rings = BANDS.map(bearings);
@@ -318,7 +382,15 @@ export class FarTerrain {
     geo.setIndex(new THREE.BufferAttribute(indices, 1));
 
     const mat = new THREE.ShaderMaterial({
-      uniforms: { uShell: { value: SHELL }, uFog: this.uFog, uNight: this.uNight },
+      uniforms: {
+        uShell: { value: SHELL },
+        uFog: this.uFog,
+        uNight: this.uNight,
+        uSunAzim: this.uSunAzim,
+        uSunWarm: this.uSunWarm,
+        uCool: this.uCool,
+        uDay: this.uDay,
+      },
       vertexShader: VERT,
       fragmentShader: FRAG,
       side: THREE.DoubleSide, // the ring is viewed from inside AND from outside
@@ -332,6 +404,38 @@ export class FarTerrain {
     this.mesh.frustumCulled = false; // the shader moves every vertex
     this.mesh.matrixAutoUpdate = false;
     this.mesh.renderOrder = -1; // after the sky dome (-2), before everything real
+
+    // Live sun for the azimuth tint, read same-frame on the mesh's own draw;
+    // direction from the light's position/target pair (game-scene.updateSun).
+    this.mesh.onBeforeRender = (_renderer, scene) => {
+      let sun = this.sunRef;
+      if (sun === null || sun.parent !== scene) {
+        sun = null;
+        for (const child of scene.children) {
+          if (child instanceof THREE.DirectionalLight) {
+            sun = child;
+            break;
+          }
+        }
+        this.sunRef = sun;
+      }
+      if (sun === null) {
+        this.uDay.value = 0;
+        return;
+      }
+      const dir = this.scrSun.copy(sun.position).sub(sun.target.position);
+      if (dir.lengthSq() < 1e-6) {
+        this.uDay.value = 0;
+        return;
+      }
+      dir.normalize();
+      const azLen = Math.hypot(dir.x, dir.z);
+      if (azLen > 1e-4) this.uSunAzim.value.set(dir.x / azLen, dir.z / azLen);
+      this.uSunWarm.value.copy(sun.color);
+      this.uDay.value =
+        (1 - THREE.MathUtils.smoothstep(this.uNight.value, SUN_FADE_LO, SUN_FADE_HI)) *
+        THREE.MathUtils.smoothstep(sun.intensity, SUN_INT_LO, SUN_INT_HI);
+    };
   }
 
   /** Track the day-night grade: horizon tint from the fog, darkness from lamp. */

--- a/games/crazy-waymo/src/render/material-breakup.ts
+++ b/games/crazy-waymo/src/render/material-breakup.ts
@@ -1,0 +1,227 @@
+import * as THREE from "three";
+
+import { isCoarsePointer } from "./quality";
+
+// World-space material breakup + specular AA for the batched city surfaces —
+// the kart-racer "three scales per surface" doctrine, ported texture-free.
+//
+// Runtime-only: one onBeforeCompile injection on the SHARED materials, so it
+// covers live AND baked worlds with no rebake and zero extra draw calls. It
+// never touches material.color (world-bin round-trips identify road materials
+// BY colour — see roads.ts roadCollapseTarget) and never clones a material.
+//
+// What it adds, per fragment:
+//   1. A macro field pair — two decorrelated value-noise fields sampled on a
+//      world plane, periods at a non-integer ratio (x0.319) so they never
+//      re-phase. Field A drives a warm/cool HUE-ONLY drift (sun-bleached vs
+//      unbleached), field B a small value band. Kills the "one flat sheet"
+//      read on asphalt and kit facades. Albedo-space multiplication, so every
+//      hour of the day-night cycle grades it correctly for free.
+//   2. A third decorrelated field cutting roughness — metre-scale sheen
+//      variation that a raking sun reads as surface, applied at the SLOW
+//      period so the far field never converges on one constant roughness
+//      (the uniform-plastic-sheet tell).
+//   3. Distance settle: field B fades over settleNear..settleFar so the fine
+//      band cannot shimmer at range; the slow fields carry the distance.
+//   4. dFdx-variance specular AA + a per-family roughness floor — three's own
+//      geometryRoughness term at unit gain is not enough under a low warm sun
+//      against a blue zenith (aliased speculars sparkle orange/cyan); the
+//      extra gained term plus the floor is what kills the rainbow glitter on
+//      distant facades.
+//
+// Phones render this too (no post composer there), so the coarse-pointer
+// build compiles a reduced variant: one macro tap (hue drift) plus floor +
+// specAA — same compile-time device-class gate as roads.ts lowDetailSurfaces.
+// (The runtime perf-governor tier can't gate a compiled shader; if a runtime
+// rung is ever wanted here it needs a uniform driven from main.ts onApply.)
+//
+// Reference constants ran at exposure 1.05 pinned to golden hour with a
+// +-0.30 albedo band; amplitudes below are re-derived for this game's 0.62
+// exposure, existing street-paint variety and the "felt, not read" +-10%
+// surface doctrine.
+
+export type BreakupConfig = {
+  /** Macro field A world period (m) — also the roughness field's period. */
+  readonly period: number;
+  /** Blend weight of the warm/cool hue-only drift (field A). */
+  readonly hueAmp: number;
+  /** Value band amplitude (field B, period x MACRO_PERIOD_RATIO); settles out. */
+  readonly valueAmp: number;
+  /** Roughness cut depth of the decorrelated field (0..amp glossier patches). */
+  readonly roughAmp: number;
+  /** Per-family hard floor, applied before the specular-AA add. */
+  readonly roughFloor: number;
+  /** Warm drift endpoint, read as a per-channel RATIO (max channel -> 1). */
+  readonly warm: number;
+  /** Cool drift endpoint, same encoding. */
+  readonly cool: number;
+  /** Distance band over which field B fades to the mean. */
+  readonly settleNear: number;
+  readonly settleFar: number;
+  /** Scale on the dFdx-variance term (1 = reference strength). */
+  readonly specAA: number;
+};
+
+/** Non-integer period ratio between the two macro fields — they never re-phase. */
+export const MACRO_PERIOD_RATIO = 0.319;
+/** Extra gain on the dFdx normal-variance term, over three's own unit term. */
+export const SPEC_AA_GAIN = 1.6;
+/** Cap on the variance add — past this it is fog, not anti-aliasing. */
+export const SPEC_AA_CAP = 0.42;
+
+// The collapsed street material (asphalt + walk + kerb share one shader).
+// Period matches the reference tarmac macro; amplitudes sit inside the road
+// shader's own +-10% band so the drift layers UNDER its patches and seams.
+export const ROAD_BREAKUP: BreakupConfig = {
+  period: 29.7,
+  hueAmp: 0.1,
+  valueAmp: 0.05,
+  roughAmp: 0.22,
+  roughFloor: 0.62,
+  warm: 0xfff0dc,
+  cool: 0xdce6ff,
+  settleNear: 34,
+  settleFar: 95,
+  specAA: 1,
+};
+
+// Everything batched: kit facades, prisms, plinths, masonry, props. Period is
+// incommensurate with the road period so street and city never share a beat.
+// Floor 0.45 stays under the glass prisms' 0.55 roughness — it must catch
+// aliased glitter, not repaint the one deliberate sheen family.
+export const CITY_BREAKUP: BreakupConfig = {
+  period: 23.0,
+  hueAmp: 0.12,
+  valueAmp: 0.06,
+  roughAmp: 0.2,
+  roughFloor: 0.45,
+  warm: 0xffeed6,
+  cool: 0xd6dfea,
+  settleNear: 40,
+  settleFar: 120,
+  specAA: 1,
+};
+
+// GLSL float literal — String(0.1) has a dot, String(1) does not.
+function f(n: number): string {
+  const s = String(n);
+  return s.includes(".") || s.includes("e") ? s : `${s}.0`;
+}
+
+// Hex -> per-channel ratio with the max channel rescaled to 1 (a pure hue
+// shift, no energy change). Raw byte ratios on purpose, NOT THREE.Color: a
+// transfer curve applied to a ratio is meaningless (0xb3 means "70% of
+// whatever is there"; through 2.2 gamma it would mean 45%).
+function hueRatio(hex: number): string {
+  const r = ((hex >> 16) & 0xff) / 255;
+  const g = ((hex >> 8) & 0xff) / 255;
+  const b = (hex & 0xff) / 255;
+  const m = Math.max(r, g, b, 1e-6);
+  const p = (v: number): string => f(Math.round((v / m) * 1000) / 1000);
+  return `vec3(${p(r)}, ${p(g)}, ${p(b)})`;
+}
+
+const FRAG_ANCHOR = "#include <lights_physical_fragment>";
+const VERT_ANCHOR = "#include <project_vertex>";
+
+const applied = new WeakSet<THREE.Material>();
+
+/**
+ * Inject the breakup into a lit opaque material. Safe to call on anything:
+ * unlit, transparent and decal (polygon-offset paint) materials are skipped,
+ * and a second call on the same material is a no-op — the batch builder runs
+ * on both load paths and shares canonical kit materials across buckets.
+ *
+ * Chains any existing onBeforeCompile (the road base already carries the
+ * asphalt speckle shader) and folds the config into customProgramCacheKey —
+ * three cannot see inside onBeforeCompile, so without this two materials
+ * differing only in breakup config would share one compiled program.
+ */
+export function applyMaterialBreakup(mat: THREE.Material, cfg: BreakupConfig): void {
+  if (!(mat instanceof THREE.MeshStandardMaterial)) return;
+  if (mat.transparent || mat.polygonOffset) return;
+  if (applied.has(mat)) return;
+  applied.add(mat);
+
+  const prev = mat.onBeforeCompile;
+  const prevKey = mat.customProgramCacheKey();
+  const cfgKey = `kbreakup:${JSON.stringify(cfg)}`;
+
+  mat.onBeforeCompile = (shader, renderer) => {
+    prev.call(mat, shader, renderer);
+    if (
+      !shader.fragmentShader.includes(FRAG_ANCHOR) ||
+      !shader.vertexShader.includes(VERT_ANCHOR)
+    ) {
+      // A shader injection that quietly does nothing is the most expensive
+      // kind of bug — say so once, loudly.
+      console.warn("[material-breakup] anchor missing, injection skipped:", mat.name || mat.uuid);
+      return;
+    }
+    const full = !isCoarsePointer();
+    shader.vertexShader = shader.vertexShader
+      .replace("#include <common>", "#include <common>\nvarying vec3 vKbWorld;")
+      .replace(
+        VERT_ANCHOR,
+        // Mirrors project_vertex's batching/instancing transforms — the city
+        // renders through BatchedMesh, and a world position taken from
+        // modelMatrix alone would sample every instance at the batch origin.
+        `vec4 kbWorld = vec4(transformed, 1.0);
+#ifdef USE_BATCHING
+kbWorld = batchingMatrix * kbWorld;
+#endif
+#ifdef USE_INSTANCING
+kbWorld = instanceMatrix * kbWorld;
+#endif
+vKbWorld = (modelMatrix * kbWorld).xyz;
+${VERT_ANCHOR}`,
+      );
+    shader.fragmentShader = shader.fragmentShader
+      .replace(
+        "#include <common>",
+        `#include <common>
+${full ? "#define KB_MACRO_FULL 1" : ""}
+varying vec3 vKbWorld;
+float kbHash(vec2 p) { return fract(sin(dot(p, vec2(157.31, 269.53))) * 43758.5453); }
+float kbNoise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 fp = p - i;
+  vec2 u = fp * fp * (3.0 - 2.0 * fp);
+  return mix(
+    mix(kbHash(i), kbHash(i + vec2(1.0, 0.0)), u.x),
+    mix(kbHash(i + vec2(0.0, 1.0)), kbHash(i + vec2(1.0, 1.0)), u.x),
+    u.y);
+}
+// One 2D slice of world space that never smears on a vertical surface —
+// facades get the same breakup language as the ground.
+vec2 kbPlane(vec3 p, float period) { return (p.xz + p.y * 0.71) / period; }`,
+      )
+      .replace(
+        FRAG_ANCHOR,
+        // Runs after every upstream albedo op (vertex colours, atlas map, the
+        // road surface shader) so the drift cannot shift the colour gates
+        // those shaders key on. Derivatives stay in uniform control flow.
+        `{
+  float kbA = kbNoise(kbPlane(vKbWorld, ${f(cfg.period)})) - 0.5;
+  diffuseColor.rgb *= mix(vec3(1.0), mix(${hueRatio(cfg.cool)}, ${hueRatio(cfg.warm)}, kbA + 0.5), ${f(cfg.hueAmp)});
+#ifdef KB_MACRO_FULL
+  float kbSettle = smoothstep(${f(cfg.settleNear)}, ${f(cfg.settleFar)}, distance(vKbWorld, cameraPosition));
+  float kbB = kbNoise(kbPlane(vKbWorld, ${f(cfg.period * MACRO_PERIOD_RATIO)}) + vec2(0.19, 0.57)) - 0.5;
+  diffuseColor.rgb *= 1.0 + kbB * ${f(cfg.valueAmp)} * (1.0 - kbSettle);
+  float kbR = kbNoise(kbPlane(vKbWorld, ${f(cfg.period)}) + vec2(0.21, 0.83));
+  roughnessFactor *= 1.0 - kbR * ${f(cfg.roughAmp)};
+#endif
+  roughnessFactor = max(roughnessFactor, ${f(cfg.roughFloor)});
+  vec3 kbDxy = max(abs(dFdx(normal)), abs(dFdy(normal)));
+  float kbVar = min(max(max(kbDxy.x, kbDxy.y), kbDxy.z) * ${f(SPEC_AA_GAIN * cfg.specAA)}, ${f(SPEC_AA_CAP)});
+  roughnessFactor = min(roughnessFactor + kbVar, 1.0);
+}
+${FRAG_ANCHOR}`,
+      );
+  };
+  mat.customProgramCacheKey = () => `${prevKey}|${cfgKey}|${isCoarsePointer() ? "lo" : "hi"}`;
+  // A shared kit material may already have a compiled program (dynamic props
+  // render during load); without the bump the renderer would keep it and the
+  // injection would silently never run.
+  mat.needsUpdate = true;
+}

--- a/games/crazy-waymo/src/render/material-breakup.ts
+++ b/games/crazy-waymo/src/render/material-breakup.ts
@@ -74,9 +74,9 @@ export const SPEC_AA_CAP = 0.42;
 // shader's own +-10% band so the drift layers UNDER its patches and seams.
 export const ROAD_BREAKUP: BreakupConfig = {
   period: 29.7,
-  hueAmp: 0.1,
-  valueAmp: 0.05,
-  roughAmp: 0.22,
+  hueAmp: 0.15,
+  valueAmp: 0.08,
+  roughAmp: 0.3,
   roughFloor: 0.62,
   warm: 0xfff0dc,
   cool: 0xdce6ff,
@@ -91,8 +91,8 @@ export const ROAD_BREAKUP: BreakupConfig = {
 // aliased glitter, not repaint the one deliberate sheen family.
 export const CITY_BREAKUP: BreakupConfig = {
   period: 23.0,
-  hueAmp: 0.12,
-  valueAmp: 0.06,
+  hueAmp: 0.15,
+  valueAmp: 0.09,
   roughAmp: 0.2,
   roughFloor: 0.45,
   warm: 0xffeed6,

--- a/games/crazy-waymo/src/render/n8ao.d.ts
+++ b/games/crazy-waymo/src/render/n8ao.d.ts
@@ -13,6 +13,7 @@ declare module "n8ao" {
     aoSamples: number;
     denoiseSamples: number;
     denoiseRadius: number;
+    denoiseIterations: number;
     halfRes: boolean;
     depthAwareUpsampling: boolean;
     screenSpaceRadius: boolean;

--- a/games/crazy-waymo/src/render/night-sky.ts
+++ b/games/crazy-waymo/src/render/night-sky.ts
@@ -25,6 +25,12 @@ const ZENITH_MUL = 0.6; // how much of the horizon value survives at the zenith
 const HORIZON_MUL = 0.78; // matches the flat background this replaced (fog * 0.72-ish)
 const STARS = 700;
 const REBAKE_EPS = 0.012; // per-channel fog drift that forces a re-bake
+// Triangular-PDF dither amplitude for the gradient, in 8-bit steps. The dome
+// ramp spans only a few dozen values over 128 rows, so an undithered 8-bit
+// paint shows fat horizontal bands on the one half of the night frame that is
+// otherwise a clean gradient; under one step of triangular noise they read as
+// grain that hides beneath the star field.
+const DITHER_AMPLITUDE = 0.75;
 
 // Deterministic star field: a re-bake must not re-roll the sky.
 function starRng(seed: number): () => number {
@@ -36,28 +42,51 @@ function starRng(seed: number): () => number {
 }
 
 const scratch = new THREE.Color();
+const hRGB = { r: 0, g: 0, b: 0 };
+const zRGB = { r: 0, g: 0, b: 0 };
 
 function paint(ctx: CanvasRenderingContext2D, fog: THREE.Color): void {
-  // getStyle(), never `r * 255`: with three's colour management on, a Color's
-  // channels are LINEAR, and the canvas this paints into is read back as sRGB.
-  // Writing linear bytes straight to it costs roughly a factor of three in
-  // value — the whole dome came out near-black on the first pass.
-  const hStyle = scratch.copy(fog).multiplyScalar(HORIZON_MUL).getStyle();
+  // getStyle()/getRGB(SRGBColorSpace), never `r * 255`: with three's colour
+  // management on, a Color's channels are LINEAR, and the canvas this paints
+  // into is read back as sRGB. Writing linear bytes straight to it costs
+  // roughly a factor of three in value — the whole dome came out near-black
+  // on the first pass.
+  scratch.copy(fog).multiplyScalar(HORIZON_MUL);
+  const hStyle = scratch.getStyle();
+  scratch.getRGB(hRGB, THREE.SRGBColorSpace);
   // Zenith drifts BLUER as well as darker — a straight multiply keeps the fog's
   // hue and reads as "the same colour, dimmer", which is the flat look again.
   scratch.copy(fog).multiplyScalar(HORIZON_MUL * ZENITH_MUL);
   scratch.b = Math.min(1, scratch.b * 1.5 + 0.004);
   scratch.r *= 0.72;
   scratch.g *= 0.86;
-  const zStyle = scratch.getStyle();
+  scratch.getRGB(zRGB, THREE.SRGBColorSpace);
 
-  const grad = ctx.createLinearGradient(0, 0, 0, H * HORIZON_V);
-  grad.addColorStop(0, zStyle);
-  grad.addColorStop(1, hStyle);
-  ctx.fillStyle = grad;
-  ctx.fillRect(0, 0, W, H * HORIZON_V);
+  // The gradient half is painted per-pixel with a triangular dither (see
+  // DITHER_AMPLITUDE) — createLinearGradient quantises straight to bands.
+  // Uint8ClampedArray assignment rounds and clamps, so the noisy float can be
+  // written as-is. The sRGB lerp per row matches what the canvas gradient did.
+  const rows = Math.round(H * HORIZON_V);
+  const img = ctx.createImageData(W, rows);
+  const px = img.data;
+  const ditherRnd = starRng(0x2b9d43);
+  let i = 0;
+  for (let y = 0; y < rows; y++) {
+    const t = y / (rows - 1);
+    const r = (zRGB.r + (hRGB.r - zRGB.r) * t) * 255;
+    const g = (zRGB.g + (hRGB.g - zRGB.g) * t) * 255;
+    const b = (zRGB.b + (hRGB.b - zRGB.b) * t) * 255;
+    for (let x = 0; x < W; x++) {
+      const n = (ditherRnd() + ditherRnd() - 1) * DITHER_AMPLITUDE;
+      px[i++] = r + n;
+      px[i++] = g + n;
+      px[i++] = b + n;
+      px[i++] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
   ctx.fillStyle = hStyle;
-  ctx.fillRect(0, H * HORIZON_V, W, H - H * HORIZON_V);
+  ctx.fillRect(0, rows, W, H - rows);
 
   // Stars thin out toward the horizon (haze) and never sit below it.
   const rnd = starRng(0x5f3a11);

--- a/games/crazy-waymo/src/render/post.ts
+++ b/games/crazy-waymo/src/render/post.ts
@@ -320,7 +320,7 @@ const FinalGradeShader = {
       // a highlight tint — at this game's exposure most of a street frame
       // lives in the midtones, and warming only the highs left golden hour
       // reading dusky-blue.
-      c *= mix(vec3(1.0), vec3(1.12, 1.0, 0.82), uWarmth * dayW * 0.80);
+      c *= mix(vec3(1.0), vec3(1.12, 1.0, 0.82), uWarmth * dayW);
       // Split tone. Teal shadows via a tiny additive lift (multiplies cannot
       // tint blacks) + a cool multiply — the cool side stands down as warmth
       // rises so the amber hour isn't fighting its own shadows; warm
@@ -332,7 +332,7 @@ const FinalGradeShader = {
       c += vec3(-0.0009, 0.0025, 0.0030) * shadowW;
       c *= mix(vec3(1.0), vec3(0.900, 1.010, 1.045), shadowW * (0.70 - 0.38 * uWarmth));
       vec3 warmTint = mix(vec3(1.115, 1.005, 0.878), vec3(1.16, 1.00, 0.80), uWarmth);
-      c *= mix(vec3(1.0), warmTint, highW * (0.55 + 0.30 * uWarmth));
+      c *= mix(vec3(1.0), warmTint, highW * (0.65 + 0.35 * uWarmth));
       c = max(c, 0.0);
       // Saturation lift with highlight rolloff, day-weighted (night owns its
       // own desaturation painting).
@@ -517,9 +517,12 @@ const SUBJECT_LIFT = 0.9;
 // under-chassis core reads), and a wide denoise blurs the contact band away,
 // which is what a soft 6-radius blur was doing to the wheel patches.
 const AO_RADIUS = 1.2;
-const AO_INTENSITY = 5.0;
+const AO_INTENSITY = 4.2;
 const AO_COLOR = 0x101c2a;
-const AO_DENOISE_RADIUS = 2;
+// 2 left the paint drape's z-offset seams as black speckle dashes along every
+// painted line at speed (review pass); 4 + two iterations blurs the seam away
+// while the wheel-contact core survives.
+const AO_DENOISE_RADIUS = 4;
 
 // The speed/boost signal easing (CPU side). `fast` is the eased top-speed
 // ramp; `kick` eases the boost flag with a fast attack and slow release (the
@@ -588,7 +591,7 @@ export class PostPipeline {
     ao.configuration.aoSamples = 16;
     ao.configuration.denoiseSamples = 8;
     ao.configuration.denoiseRadius = AO_DENOISE_RADIUS;
-    ao.configuration.denoiseIterations = 1;
+    ao.configuration.denoiseIterations = 2;
     ao.configuration.halfRes = true;
     ao.configuration.depthAwareUpsampling = true;
     ao.configuration.screenSpaceRadius = false;
@@ -665,7 +668,7 @@ export class PostPipeline {
     const motion = gradeMotion();
 
     // Signal easing. `fast` opens above ~62% of boost top speed.
-    const fastTarget = THREE.MathUtils.clamp((motion.speed - 0.62) / 0.38, 0, 1);
+    const fastTarget = THREE.MathUtils.clamp((motion.speed - 0.45) / 0.55, 0, 1);
     this.fast += (fastTarget - this.fast) * Math.min(1, dt / FAST_TAU);
     const kickTarget = motion.boost ? 1 : 0;
     const kickTau = kickTarget > this.kick ? KICK_ATTACK : KICK_RELEASE;

--- a/games/crazy-waymo/src/render/post.ts
+++ b/games/crazy-waymo/src/render/post.ts
@@ -5,6 +5,7 @@ import { ShaderPass } from "three/addons/postprocessing/ShaderPass.js";
 import { SMAAPass } from "three/addons/postprocessing/SMAAPass.js";
 import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
 
+import { CAMERA } from "../shared/constants";
 import { gradeMotion, gradeNight, gradeWarmth } from "./grade";
 
 // Desktop-only post chain (kart-racer pass): contact AO so nothing floats,
@@ -119,26 +120,37 @@ const GradeShader = {
 // reference grade, adapted to this game's radiances). Order inside:
 //   1. chromatic aberration gather (on linear — the offsets are sub-texel and
 //      capped, so the HDR fringe risk the sun disc poses is bounded by the cap)
-//   2. exposure (renderer.toneMappingExposure, via the day-night ramp)
-//   3. highlight shoulder — a power-law rolloff gated on max(rgb) BEFORE ACES
+//   2. radial rush zoom smear (linear side, so streaks carry radiance into the
+//      tone map): velocity = fromCentre * rush, quadratically edge-weighted so
+//      the vanishing point stays sharp, travel-capped, and multiplied by a
+//      WORLD-SPACE hold-out sphere around the player car (depth-reconstructed
+//      — a depth band would cut the car in half viewed end-on). High tier
+//      only; the whole gather is branch-skipped at rest.
+//   3. exposure (renderer.toneMappingExposure, via the day-night ramp)
+//   4. highlight shoulder — a power-law rolloff gated on max(rgb) BEFORE ACES
 //      so a 4x sky and a 20x glint still separate instead of both slamming
 //      into the ACES ceiling; includes highlight desaturation toward luma.
 //      Faded out at night: the night painting's emissive values are measured
 //      against plain ACES and must not soften.
-//   4. ACES fit (bit-for-bit three.js ACESFilmicToneMapping)
-//   5. midtone S-curve — smoothstep-toward-self keeps 0 and 1 pinned so it
+//   5. ACES fit (bit-for-bit three.js ACESFilmicToneMapping)
+//   6. midtone S-curve — smoothstep-toward-self keeps 0 and 1 pinned so it
 //      adds snap without crushing the shadow detail the AO pass paid for.
 //      Day-only: the night mid-tone dip already owns that range.
-//   6. teal-shadow / warm-highlight split tone. The cool axis is TEAL (G with
+//   7. teal-shadow / warm-highlight split tone. The cool axis is TEAL (G with
 //      B above unity), not blue — pure blue against a warm key reads violet.
 //      Day-weighted, and the warm side leans harder with uWarmth so golden
 //      hour reads gilded rather than merely bright.
-//   7. saturation lift with a highlight rolloff so bloomed glints go white,
+//   8. saturation lift with a highlight rolloff so bloomed glints go white,
 //      not neon.
-//   8. vignette — post-tonemap print-down; amount and inner edge close in
+//   9. speed-line combs — two angular value-noise combs (base + boost) in the
+//      outer radial band, composited display-referred with two safety terms:
+//      sceneLit (lines streak the light that is there — no tunnel/night
+//      starburst, which is also why they need no uNight weighting) and a
+//      headroom shoulder (bright frames take fewer lines, stacks asymptote).
+//  10. vignette — post-tonemap print-down; amount and inner edge close in
 //      with speed.
-//   9. monochrome grain, midtone-weighted, rolled off in shadows.
-//  10. sRGB encode (this pass writes the canvas — no OutputPass follows).
+//  11. monochrome grain, midtone-weighted, rolled off in shadows.
+//  12. sRGB encode (this pass writes the canvas — no OutputPass follows).
 const FinalGradeShader = {
   name: "WaymoFinalGradeShader",
   uniforms: {
@@ -155,6 +167,15 @@ const FinalGradeShader = {
     uTime: { value: 0 },
     uAspect: { value: 16 / 9 },
     uTexel: { value: new THREE.Vector2(1 / 1920, 1 / 1080) },
+    // Speed subject. uRush: x smear amount (0 = branch closed), y uv travel
+    // cap, z boost-comb strength. uStreak is the comb master gain, uKick the
+    // eased boost signal, uSubject the hero hold-out centre (world space).
+    uRush: { value: new THREE.Vector3() },
+    uStreak: { value: 0 },
+    uKick: { value: 0 },
+    uSubject: { value: new THREE.Vector3() },
+    uInvViewProj: { value: new THREE.Matrix4() },
+    tDepth: { value: null },
   },
   vertexShader: /* glsl */ `
     varying vec2 vUv;
@@ -176,14 +197,48 @@ const FinalGradeShader = {
     uniform float uTime;
     uniform float uAspect;
     uniform vec2 uTexel;
+    uniform vec3 uRush;
+    uniform float uStreak;
+    uniform float uKick;
+    uniform vec3 uSubject;
+    uniform mat4 uInvViewProj;
+    uniform sampler2D tDepth;
     varying vec2 vUv;
     const vec3 LUMA = vec3(0.2126, 0.7152, 0.0722);
+    const float TAU = 6.28318530718;
     // Shoulder: knee 0.9, exponent 0.72, desat 0.16 across a 30x span.
     const vec4 ROLLOFF = vec4(0.90, 0.72, 0.16, 30.0);
+    // Radial rush: fewer than ~11 taps bands visibly at the travel cap. The
+    // tap count is fixed; the High-tier gate lives CPU-side (uRush.x = 0).
+    const int SMEAR_TAPS = 11;
+    // Hero hold-out sphere, world units. The reference ran 2.05→3.40 around a
+    // ~2 u kart; rescaled for this SUV's ~2.8 u half-diagonal (subject sits
+    // SUBJECT_LIFT above the road-level car origin).
+    const float HOLDOUT_CORE = 3.4;
+    const float HOLDOUT_EDGE = 5.1;
+    // Comb lattice frequencies: INTEGER cells per revolution so the lattice
+    // wraps seam-free at the atan cut (reference authored per-radian: 26/63
+    // base, 47/111 boost — ×2π, rounded to integers).
+    const float BASE_COMB_A = 163.0;
+    const float BASE_COMB_B = 396.0;
+    const float BOOST_COMB_A = 295.0;
+    const float BOOST_COMB_B = 697.0;
+    const float BOOST_COMB_GAIN = 0.42;
     float hash12(vec2 p) {
       vec3 q = fract(vec3(p.x, p.y, p.x) * 0.1031);
       q += dot(q, q.yzx + 33.33);
       return fract((q.x + q.y) * q.z);
+    }
+    // 1D value noise on an angular lattice. The index wraps mod freq, so a
+    // comb has no seam where atan cuts; freq doubles as the hash seed so the
+    // four combs decorrelate.
+    float combNoise(float turns, float freq, float drift) {
+      float x = turns * freq + drift;
+      float i = floor(x);
+      float f = x - i;
+      float h0 = hash12(vec2(mod(i, freq), freq));
+      float h1 = hash12(vec2(mod(i + 1.0, freq), freq));
+      return mix(h0, h1, f * f * (3.0 - 2.0 * f));
     }
     vec3 shoulder(vec3 c) {
       float m = max(max(c.r, c.g), c.b);
@@ -233,6 +288,29 @@ const FinalGradeShader = {
           texture2D(tDiffuse, vUv).g,
           texture2D(tDiffuse, vUv - fringe).b);
       }
+      // Radial rush: edge-weighted zoom smear on the linear side, so streaks
+      // carry radiance into the tone map. Quadratic edge weighting keeps the
+      // vanishing point sharp; the hold-out multiplies the fragment's OWN
+      // velocity by a world-space sphere on the hero (never a depth band —
+      // that cuts the car in half viewed end-on). The smear taps skip the CA
+      // fringe: a sub-2-texel offset is invisible inside a 20+ px streak.
+      if (uRush.x > 0.0002) {
+        vec2 vel = fromCentre * (uRush.x * (0.30 + 0.70 * rad));
+        float travel = length(vel);
+        vel *= min(travel, uRush.y) / max(travel, 1e-6);
+        float sceneDepth = texture2D(tDepth, vUv).x;
+        vec4 wp = uInvViewProj * vec4(vUv * 2.0 - 1.0, sceneDepth * 2.0 - 1.0, 1.0);
+        vel *= smoothstep(HOLDOUT_CORE, HOLDOUT_EDGE, distance(wp.xyz / wp.w, uSubject));
+        if (length(vel) > 0.0004) {
+          float jitter = hash12(vUv / uTexel + fract(uTime) * 311.0) - 0.5;
+          vec3 acc = c;
+          for (int i = 1; i < SMEAR_TAPS; i++) {
+            float s = (float(i) + jitter) / float(SMEAR_TAPS) - 0.5;
+            acc += texture2D(tDiffuse, vUv + vel * s).rgb;
+          }
+          c = acc / float(SMEAR_TAPS);
+        }
+      }
       float dayW = 1.0 - uNight;
       c = mix(c, shoulder(c), dayW);
       c = acesToneMap(c);
@@ -242,7 +320,7 @@ const FinalGradeShader = {
       // a highlight tint — at this game's exposure most of a street frame
       // lives in the midtones, and warming only the highs left golden hour
       // reading dusky-blue.
-      c *= mix(vec3(1.0), vec3(1.05, 1.0, 0.93), uWarmth * dayW * 0.65);
+      c *= mix(vec3(1.0), vec3(1.12, 1.0, 0.82), uWarmth * dayW * 0.80);
       // Split tone. Teal shadows via a tiny additive lift (multiplies cannot
       // tint blacks) + a cool multiply — the cool side stands down as warmth
       // rises so the amber hour isn't fighting its own shadows; warm
@@ -261,6 +339,35 @@ const FinalGradeShader = {
       lum = dot(c, LUMA);
       float satAmt = 1.0 + (uSaturation - 1.0) * dayW;
       c = max(mix(vec3(lum), c, satAmt * (1.0 - 0.40 * smoothstep(0.70, 1.0, lum))), 0.0);
+      // Speed-line combs, display-referred (they paint on the finished image,
+      // so the exposure delta vs the reference does not apply). uStreak is a
+      // SWITCH driven from STREAK_REST = 0: a resting frame never enters.
+      if (uStreak > 0.002) {
+        vec2 p = fromCentre * a;
+        float turns = atan(p.y, p.x) / TAU + 0.5;
+        float baseN = combNoise(turns, BASE_COMB_A, uTime * 1.6) * 0.62
+                    + combNoise(turns, BASE_COMB_B, -uTime * 2.4) * 0.38;
+        // Outer third only; the inner edge walks in with boost.
+        float baseBand = smoothstep(mix(0.55, 0.44, uKick), 0.98, rad)
+                       * (1.0 - smoothstep(1.05, 1.50, rad));
+        float lines = smoothstep(0.55, 0.93, baseN) * baseBand * uStreak;
+        if (uRush.z > 0.004) {
+          float boostN = combNoise(turns, BOOST_COMB_A, -uTime * 7.5) * 0.58
+                       + combNoise(turns, BOOST_COMB_B, uTime * 11.0) * 0.42;
+          float boostBand = smoothstep(0.42, 0.90, rad)
+                          * (1.0 - smoothstep(1.10, 1.55, rad));
+          lines += smoothstep(0.66, 0.99, boostN) * boostBand * uKick * uRush.z * BOOST_COMB_GAIN;
+        }
+        lum = dot(c, LUMA);
+        // Safety 1: lines streak the light that is there — a tunnel or the
+        // night cannot grow a starburst out of black (and this is why the
+        // combs need no day-night weighting of their own).
+        lines *= 0.42 + 0.58 * smoothstep(0.04, 0.42, lum);
+        // Safety 2: headroom — bright frames take fewer lines, and the sum
+        // itself rolls off so stacked combs asymptote instead of clipping.
+        float head = 1.0 - 0.50 * smoothstep(0.60, 1.00, lum);
+        c += (lines / (1.0 + lines * 1.2)) * head * vec3(1.0, 0.972, 0.918);
+      }
       // Vignette: print-down on the finished image.
       c *= 1.0 - uVignette.x * smoothstep(uVignette.y, 1.02, rad);
       // Grain: monochrome, midtone-weighted, shadow-rolled-off.
@@ -273,56 +380,56 @@ const FinalGradeShader = {
   `,
 };
 
-// Bloom is a DAY setting and a NIGHT setting, not one setting. The cut has to
-// clear the lit sky by day (see the constructor note) — but that same 3.0 sits
-// far above every night emissive the game draws: a lit window peaks near 1.1
-// pre-tonemap, a lamp pool near 0.9, a headlight near 1.6. At a fixed 3.0
-// NOTHING blooms after dark, which is why the night frame had no glow in it at
-// all and every source read as a flat decal. Both numbers therefore ramp with
-// the cycle: after dark the cut drops under the emissives and the strength
-// comes up, so lamps, windows and headlights bleed the way a real night camera
-// makes them. `UnrealBloomPass.render` copies both fields into its uniforms
-// every frame, so writing the fields is the supported way to animate them.
-const DAY_BLOOM_STRENGTH = 0.22;
-// THE DAY CUT MUST CLEAR THE HORIZON, NOT JUST THE LIT SKY. Preetham's dome
-// saturates at grazing angles — measured pre-tonemap, the bottom ~8° of sky
-// sits at luminance 5.4 in EVERY azimuth at noon, well over the old 3.0 — so
-// the whole horizon ring was being harvested and blurred back over the far
-// city. That is the "milky mid-ground" in the Twin Peaks vista: with the cut
-// moved above the band, that frame's >=88%-luminance share falls 11.3% -> 8.3%
-// and its mean saturation RISES (16.2 -> 17.7), because what the veil was doing
-// was washing chroma out of everything behind it.
+// Bloom is a DAY setting and a NIGHT setting, not one setting. The two ends of
+// the ramp anchor to different budgets: the day gate to the sunlit-diffuse
+// ceiling (below), the night gate to the authored emissive budget — a lit
+// window peaks near 1.1 pre-tonemap, a lamp pool near 0.9, a headlight near
+// 1.6. Both fields ramp with the cycle. `UnrealBloomPass.render` copies
+// strength/threshold into its uniforms every frame, so writing the fields is
+// the supported way to animate them; the knee is a uniform the pass never
+// touches, written alongside them in render().
+const BLOOM_DAY_STRENGTH = 0.26;
+// THE DAY CUT SITS JUST ABOVE SUNLIT DIFFUSE WHITE. Pre-tonemap at this
+// game's exposure (0.62), the brightest lit-diffuse surfaces — a white kit
+// facade square to the noon key (1.85), sunlit kerb concrete, crosswalk
+// paint — land at ~1.5-1.9. The cut sits at the bottom of that band with the
+// knee reaching across it, so lit diffuse at most KISSES the pyramid while
+// everything authored as a SOURCE clears it outright: spark cores under their
+// per-emit gain, drift ribbons and boost flame near 2-3, the sun disc at 400
+// (day-night.ts SUN_DISC_RADIANCE). That is the glow identity: by day the FX
+// bloom, not the city.
 //
-// 6.5 clears the band with margin and still sits far under the sun disc
-// (day-night.ts SUN_DISC_RADIANCE, 400), which is the one thing that should
-// flare by day. Nothing else is lost: the additive FX (trails, boost rings,
-// sparks) peak near 1-2 over a lit road, so they never crossed 3.0 either.
-//
-// AND THERE IS NO CUT THAT GIVES THEM ONE — but not because a lower cut costs
-// anything. That was asserted from an analytic re-integration of the rolled-off
-// dome (noon peaks 2.76 in the aureole, 1.9 along the horizon; golden 1.92) and
-// the gate measured it instead: with the cut FORCED to 3.0 and then 2.5 at four
-// cameras, the >=88%-luminance share moves by at most +0.8pp (Ocean Beach
-// golden 9.68 -> 10.49, i.e. the sun's own glitter path) and by under 0.05pp at
-// Twin Peaks noon, skyline-from-bay noon and a Nob Hill golden chase — and the
-// same-camera pairs are indistinguishable. The veil does NOT come back at 2.5.
-//
-// The real reason is the arithmetic on the other side: the additive FX peak
-// near 1-2, so a cut at 2.5 cannot bloom them either. To glow a drift trail you
-// would need ~1.0, under the entire lit sky — THAT is where the veil lives. So
-// 6.5 -> 3.0 is close to free and close to pointless; the FX glow and the clean
-// horizon really are the same knob, just further apart than 3.0.
-//
-// If daytime FX glow is ever wanted, it is a second additive pass keyed off the
-// FX layer, not a move of this constant.
-const DAY_BLOOM_THRESHOLD = 6.5;
+// The Preetham horizon band (~5.4 pre-tonemap at noon) also crosses this cut,
+// and harvesting it is measured-cheap at this strength: forcing the cut from
+// 6.5 down to 2.5 across four cameras moved the >=88%-luminance share by at
+// most +0.8pp (Ocean Beach golden — the sun's own glitter path) and under
+// 0.05pp everywhere else, with same-camera pairs indistinguishable. The
+// milky-veil failure mode lives in the DISC, not the cut: an unbounded disc
+// hands the pyramid ~85,000 of headroom energy, and the disc is bounded at
+// the source.
+const BLOOM_DAY_THRESHOLD = 2.1;
+// Gate softness (the high-pass material's smoothWidth), in the same radiance
+// units as the cut. Day is a wide shoulder — the reference kart grade's shape
+// — so sunlit white fades INTO the pyramid instead of popping across a hard
+// edge as the camera swings. Night must stay near-hard: the lamp pools are
+// authored to ~0.9 against the 0.85 cut, and a day-width knee would
+// smoothstep them down to a few percent of their bloom, unlighting the night
+// the budget below exists to keep.
+const BLOOM_DAY_KNEE = 0.33;
+const BLOOM_NIGHT_KNEE = 0.02;
 // The night cut sits just under the dimmest thing that should glow — the lamp
 // pools, authored to ~0.9 at their core (fx/lamp-glow.ts POOL_GAIN) — and no
 // lower. Below ~0.7 it starts catching LIT SURFACES too, and the one surface
 // that is genuinely blown after dark (a wall 5 metres in front of the player's
 // 70-candela spot) turns into a frame-filling white blob.
-const NIGHT_BLOOM_STRENGTH = 0.5;
-const NIGHT_BLOOM_THRESHOLD = 0.85;
+const BLOOM_NIGHT_STRENGTH = 0.5;
+const BLOOM_NIGHT_THRESHOLD = 0.85;
+// Mip-composite spread. The night halo shape is insensitive to it (see the
+// spill experiments below: radius 0.3 -> 0 moved the facade mean not at all),
+// so one value serves both paintings; 0.55 widens the day glow toward the
+// reference look's soft halation.
+const BLOOM_RADIUS = 0.55;
+const BLOOM_NIGHT_RADIUS = 0.3;
 // THE NIGHT SPILL HAS NO SHAPE KNOB — four experiments, all measured on a FiDi
 // and a Market chase frame at midnight, kit-facade mean through a per-camera
 // stencil. Bloom does lift the facades it is supposed to be lighting: turning
@@ -346,9 +453,12 @@ const NIGHT_BLOOM_THRESHOLD = 0.85;
 // Speed-reactive bloom: the lens brightens with pace, never with the clock.
 // Additive on top of the day/night ramp; the transient ignite term buys the
 // boost-release frame a halo without building a sustained veil.
-const BLOOM_FAST_LIFT = 0.06;
-const BLOOM_KICK_LIFT = 0.14;
-const BLOOM_IGNITE_LIFT = 0.18;
+// Half the pre-port lifts: at the 1.6-2.1 day gate the golden-hour mie veil
+// already rides the bloom pyramid, and the old lift values pushed an into-sun
+// boost frame to a full milky white-out (measured, SUPER MINI-TURBO at 17:00).
+const BLOOM_FAST_LIFT = 0.03;
+const BLOOM_KICK_LIFT = 0.06;
+const BLOOM_IGNITE_LIFT = 0.09;
 
 // Chromatic aberration bounds (per-channel uv offset at |fromCentre| = 1).
 const CA_REST = 0.00045;
@@ -359,12 +469,57 @@ const VIGNETTE_SPEED = 0.12;
 const VIGNETTE_INNER_REST = 0.3;
 const VIGNETTE_INNER_FAST = 0.18;
 
+// Radial rush drive (uv-space smear amount). Geometric, display-side numbers
+// — ported verbatim from the reference grade; no exposure re-derivation
+// applies. The two families combine with max, not +: the fast term owns
+// full-throttle cruising, the speed²/kick pair owns boost, and ignite buys
+// the onset frame an overshoot.
+const RUSH_FAST = 0.0165;
+const RUSH_SPEED_SQ = 0.0125;
+const RUSH_KICK_SPEED = 0.015;
+const RUSH_IGNITE = 0.0085;
+// uv travel cap: base at gate-open, extra headroom under boost.
+const RUSH_CAP_BASE = 0.0125;
+const RUSH_CAP_BOOST = 0.0105;
+// Boost-comb strength: kick plus a slug of ignite, capped ABOVE 1 so the
+// ignition frame overshoots the sustained ceiling.
+const BOOST_COMB_MAX = 1.25;
+const BOOST_COMB_IGNITE = 0.55;
+// Speed-line master gain. REST MUST STAY 0 — the combs are a switch, not a
+// fade: a resting frame skips the branch and stays bit-identical to the
+// pre-port grade.
+const STREAK_REST = 0.0;
+const STREAK_BOOST = 0.46;
+// The comb gate opens across the first 42% of the eased fast signal.
+const STREAK_GATE_FAST = 0.42;
+
+// The ≥11-tap smear runs on the High tier only. The desktop governor encodes
+// its tier as the pixel ratio it hands setSize, so "High" = still at ≥75% of
+// native DPR; a machine stepped below that is already struggling and the rush
+// zeroes out (the combs stay — four noise evals, no extra taps).
+const SMEAR_TIER_RATIO = 0.75;
+
+// Hero hold-out subject. Until the scene pins the car via setSpeedSubject the
+// pipeline estimates it from the chase rig's FAST-end pose (rush only opens
+// near top speed, so the estimate is calibrated there: camera-rig.ts lerps
+// distance +1.5 and height -1.1 at speed). SUBJECT_LIFT raises the road-level
+// car origin to the body centre the sphere is measured from.
+const SUBJECT_EST_ARM = CAMERA.distance + 1.5;
+const SUBJECT_EST_DROP = CAMERA.height - 1.1;
+const SUBJECT_LIFT = 0.9;
+
 // N8AO: tight contact AO, cool-tinted, half-res. The radius stays SHORT —
 // large radii produce the flat grey haze that gives cheap AO away; the point
 // is the last metre where a wheel meets asphalt and a plinth meets pavement.
-const AO_RADIUS = 1.6;
-const AO_INTENSITY = 3.5;
+// The reference kart recipe: shorter radius + harder intensity + a NARROW
+// denoise — at radius*falloff the depth-rejection band sits under the car's
+// ride height, intensity is an exponent on visibility (5.0 is where the
+// under-chassis core reads), and a wide denoise blurs the contact band away,
+// which is what a soft 6-radius blur was doing to the wheel patches.
+const AO_RADIUS = 1.2;
+const AO_INTENSITY = 5.0;
 const AO_COLOR = 0x101c2a;
+const AO_DENOISE_RADIUS = 2;
 
 // The speed/boost signal easing (CPU side). `fast` is the eased top-speed
 // ramp; `kick` eases the boost flag with a fast attack and slow release (the
@@ -378,21 +533,45 @@ const KICK_RELEASE = 0.28;
 const IGNITE_TAU = 0.42;
 const IGNITE_GAIN = 2.1;
 
+// n8ao's beauty target carries the frame's only sampleable depth, which the
+// hold-out sphere needs for world reconstruction. It is not part of the
+// pass's typed surface (render/n8ao.d.ts), so probe structurally: a package
+// bump that moves the internal degrades to "no rush smear", never a crash.
+// Caching the texture once is safe — three resizes an attached depth texture
+// in place, the object identity survives setSize.
+function sceneDepthOf(pass: N8AOPass): THREE.DepthTexture | null {
+  const holder: object = pass;
+  if (!("beautyRenderTarget" in holder)) return null;
+  const target: unknown = holder.beautyRenderTarget;
+  if (!(target instanceof THREE.WebGLRenderTarget)) return null;
+  const depth = target.depthTexture;
+  return depth instanceof THREE.DepthTexture ? depth : null;
+}
+
 export class PostPipeline {
   private composer: EffectComposer;
   // DEV probes reach in to A/B the AO contribution (debug/dev-hooks.ts).
   readonly ao: N8AOPass;
   private bloom: UnrealBloomPass;
+  private bloomKnee: THREE.IUniform | undefined;
   private grade: ShaderPass;
   private finalGrade: ShaderPass;
   private renderer: THREE.WebGLRenderer;
+  private camera: THREE.Camera;
   private lastTime = 0;
   private fast = 0;
   private kick = 0;
   private kickSlow = 0;
+  private smearTier = true;
+  private smearDepthOk = false;
+  private subjectPinned = false;
+  private readonly subject = new THREE.Vector3();
+  private readonly camPos = new THREE.Vector3();
+  private readonly camDir = new THREE.Vector3();
 
   constructor(renderer: THREE.WebGLRenderer, scene: THREE.Scene, camera: THREE.Camera) {
     this.renderer = renderer;
+    this.camera = camera;
     // HDR target: bloom needs >8bit to find highlights. MSAA is intentionally
     // absent — N8AOPass renders the scene into its own half-float target with
     // a sampleable depth texture; SMAA at the end of the chain is the AA.
@@ -408,7 +587,8 @@ export class PostPipeline {
     ao.configuration.color = new THREE.Color(AO_COLOR);
     ao.configuration.aoSamples = 16;
     ao.configuration.denoiseSamples = 8;
-    ao.configuration.denoiseRadius = 6;
+    ao.configuration.denoiseRadius = AO_DENOISE_RADIUS;
+    ao.configuration.denoiseIterations = 1;
     ao.configuration.halfRes = true;
     ao.configuration.depthAwareUpsampling = true;
     ao.configuration.screenSpaceRadius = false;
@@ -418,18 +598,15 @@ export class PostPipeline {
     this.ao = ao;
     this.composer.addPass(ao);
     // Threshold sits in PRE-tonemap linear HDR, so every number here is a
-    // radiance, not a pixel value: keep the cut high and the strength gentle —
-    // bloom should kiss the emissives (lamps, windows, trails, sun glare), not
-    // flood the frame. The vignette/vibrance grade does the daytime "pop".
-    //
-    // The cut has been chased upward twice by the same class of bug, and both
-    // times the frame it ruined was a driver looking west into the sun: 2.2 put
-    // 30-32% of the frame over 92% luminance, and 3.0 — which does clear the
-    // LIT sky — still sat under the horizon ring and under a sun disc three
-    // orders of magnitude over it. See DAY_BLOOM_THRESHOLD for what 6.5 clears
-    // and day-night.ts SUN_DISC_RADIANCE for the disc that made the cut
-    // unwinnable at any value.
-    this.bloom = new UnrealBloomPass(size, DAY_BLOOM_STRENGTH, 0.3, DAY_BLOOM_THRESHOLD);
+    // radiance, not a pixel value: the gate is authored against what the scene
+    // draws (BLOOM_DAY_THRESHOLD / BLOOM_NIGHT_THRESHOLD above) and the sun
+    // disc is bounded at the source (day-night.ts SUN_DISC_RADIANCE) — an
+    // unbounded disc makes any cut unwinnable. The knee lives on the
+    // high-pass material; the pass re-copies only `threshold` per frame, so
+    // smoothWidth is safe to own from here.
+    this.bloom = new UnrealBloomPass(size, BLOOM_DAY_STRENGTH, BLOOM_RADIUS, BLOOM_DAY_THRESHOLD);
+    this.bloomKnee = this.bloom.materialHighPassFilter.uniforms.smoothWidth;
+    if (this.bloomKnee) this.bloomKnee.value = BLOOM_DAY_KNEE;
     this.composer.addPass(this.bloom);
     this.grade = new ShaderPass(GradeShader);
     this.composer.addPass(this.grade);
@@ -437,7 +614,25 @@ export class PostPipeline {
     this.composer.addPass(new SMAAPass());
     this.finalGrade = new ShaderPass(FinalGradeShader);
     this.composer.addPass(this.finalGrade);
+    const depth = sceneDepthOf(ao);
+    if (depth) {
+      const d = this.finalGrade.uniforms.tDepth;
+      if (d) d.value = depth;
+      this.smearDepthOk = true;
+    }
     this.syncViewportUniforms(size.x, size.y);
+  }
+
+  /**
+   * Pin the hero hold-out sphere to the player car (world position, road-level
+   * origin — the body-centre lift is applied here). Call once per frame from
+   * the scene; until wired, render() estimates the subject from the chase
+   * rig's fast-end pose.
+   */
+  setSpeedSubject(world: THREE.Vector3): void {
+    this.subject.copy(world);
+    this.subject.y += SUBJECT_LIFT;
+    this.subjectPinned = true;
   }
 
   private syncViewportUniforms(width: number, height: number): void {
@@ -454,6 +649,10 @@ export class PostPipeline {
     this.composer.setPixelRatio(pixelRatio);
     this.composer.setSize(width, height);
     this.syncViewportUniforms(width * pixelRatio, height * pixelRatio);
+    // The governor's tier reaches this pass only as the pixel ratio it picked
+    // (desktop tiers ARE resolution steps) — read the tier back from it.
+    const native = Math.min(window.devicePixelRatio || 1, 2);
+    this.smearTier = pixelRatio >= native * SMEAR_TIER_RATIO;
   }
 
   render(): void {
@@ -499,21 +698,79 @@ export class PostPipeline {
     const time = fu.uTime;
     if (time) time.value = now % 600;
 
+    // Speed subject: comb master + boost comb + radial rush + hold-out.
+    const gate = Math.max(
+      THREE.MathUtils.smoothstep(this.fast, 0, STREAK_GATE_FAST),
+      this.kick,
+      ignite,
+    );
+    const streak = fu.uStreak;
+    if (streak) streak.value = STREAK_REST + (STREAK_BOOST - STREAK_REST) * gate;
+    const kickU = fu.uKick;
+    if (kickU) kickU.value = this.kick;
+    const boostComb = Math.min(BOOST_COMB_MAX, this.kick + BOOST_COMB_IGNITE * ignite);
+    const speed = THREE.MathUtils.clamp(motion.speed, 0, 1);
+    const rushAmt =
+      Math.max(
+        RUSH_FAST * Math.pow(this.fast, 1.5),
+        RUSH_SPEED_SQ * speed * speed + RUSH_KICK_SPEED * this.kick * speed,
+      ) +
+      RUSH_IGNITE * ignite;
+    const smearOn = this.smearTier && this.smearDepthOk;
+    const rush = fu.uRush;
+    if (rush && rush.value instanceof THREE.Vector3) {
+      rush.value.set(smearOn ? rushAmt : 0, RUSH_CAP_BASE + RUSH_CAP_BOOST * boostComb, boostComb);
+    }
+    if (smearOn && rushAmt > 0.0002) {
+      // The smear reconstructs world positions, so the matrices must be
+      // current NOW — the composer's own render is too late. Camera's
+      // updateMatrixWorld also refreshes matrixWorldInverse.
+      this.camera.updateMatrixWorld();
+      const ivp = fu.uInvViewProj;
+      if (ivp && ivp.value instanceof THREE.Matrix4) {
+        ivp.value
+          .multiplyMatrices(this.camera.projectionMatrix, this.camera.matrixWorldInverse)
+          .invert();
+      }
+      if (!this.subjectPinned) {
+        this.camera.getWorldPosition(this.camPos);
+        this.camera.getWorldDirection(this.camDir);
+        const planar = Math.hypot(this.camDir.x, this.camDir.z);
+        if (planar > 1e-4) {
+          const arm = SUBJECT_EST_ARM / planar;
+          this.subject.set(
+            this.camPos.x + this.camDir.x * arm,
+            this.camPos.y - SUBJECT_EST_DROP + SUBJECT_LIFT,
+            this.camPos.z + this.camDir.z * arm,
+          );
+        }
+      }
+      const subj = fu.uSubject;
+      if (subj && subj.value instanceof THREE.Vector3) subj.value.copy(this.subject);
+    }
+
     // The cut falls on sqrt(night), not on night. `night` IS the lamp factor,
     // so at dusk it is still only ~0.6 when every streetlight in the city is
-    // already burning — and a linearly-interpolated cut is 3.0 there, above the
-    // 3.4 lamp halo it exists to catch. The day end of that lerp used to be
-    // 3.0, so the error was small; at 6.5 it would leave dusk with no glow at
-    // all. Square-rooting drops the cut early, in step with the lamps, and both
-    // ends of the ramp are unchanged.
+    // already burning. Square-rooting drops the gate toward the lamp budget
+    // early, in step with the lamps — at dusk the cut is ~1.0, under the lamp
+    // halos and the 1.6 headlights — and both ends of the ramp are unchanged.
+    // The knee rides the same ramp so the gate hardens as the emissive budget
+    // takes over from the sunlit-diffuse shoulder.
+    const gateRamp = Math.sqrt(night);
     this.bloom.threshold =
-      DAY_BLOOM_THRESHOLD + (NIGHT_BLOOM_THRESHOLD - DAY_BLOOM_THRESHOLD) * Math.sqrt(night);
+      BLOOM_DAY_THRESHOLD + (BLOOM_NIGHT_THRESHOLD - BLOOM_DAY_THRESHOLD) * gateRamp;
+    if (this.bloomKnee) {
+      this.bloomKnee.value = BLOOM_DAY_KNEE + (BLOOM_NIGHT_KNEE - BLOOM_DAY_KNEE) * gateRamp;
+    }
     this.bloom.strength =
-      DAY_BLOOM_STRENGTH +
-      (NIGHT_BLOOM_STRENGTH - DAY_BLOOM_STRENGTH) * night +
+      BLOOM_DAY_STRENGTH +
+      (BLOOM_NIGHT_STRENGTH - BLOOM_DAY_STRENGTH) * night +
       BLOOM_FAST_LIFT * this.fast +
       BLOOM_KICK_LIFT * this.kick +
       BLOOM_IGNITE_LIFT * ignite;
+    // The wide day radius smears the authored point emissives (stars, lamp
+    // pools) into cotton after dark — night keeps the pre-port tight kernel.
+    this.bloom.radius = BLOOM_RADIUS + (BLOOM_NIGHT_RADIUS - BLOOM_RADIUS) * night;
     this.composer.render();
   }
 }

--- a/games/crazy-waymo/src/render/sky.ts
+++ b/games/crazy-waymo/src/render/sky.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three";
 
 // VENDORED from three r0.185.1 — `examples/jsm/objects/Sky.js` (the Preetham
-// analytic daylight model). Everything outside the three marked patch blocks is
+// analytic daylight model). Everything outside the marked patch blocks is
 // the addon verbatim, ported to TypeScript: same uniform names, same defaults,
 // same vertex/fragment source, same cloud layer. Re-applying this on a three
 // upgrade is a matter of diffing the new addon against this file and moving the
-// three `>>> patch` blocks across; nothing else here is ours.
+// five `>>> patch` blocks across; nothing else here is ours.
 //
 // WHY WE OWN A COPY. Preetham's model saturates at grazing angles. The optical
 // path (`inverse` in the fragment shader) grows to ~36x the zenith's at the
@@ -42,6 +42,24 @@ const HORIZON_ROLLOFF_DEFAULT = 1.7;
 // or the "sky is the brightest band" read goes with it.
 const HORIZON_SCALE = 0.09;
 
+// Horizon weld band, in sin(elevation) (~3.2 degrees). Fogged geometry
+// converges on the scene fog color as it recedes; below this band the dome
+// converges onto the SAME color from its side, so at the horizon line the
+// sea/sky and hills/sky boundaries meet on one number and the seam has
+// nothing left to be. The band is narrow enough to read as the compressed
+// haze layer of a real horizon, and because the weld target is the LIVE fog
+// color (fed per render, see onBeforeRender) it lands at every hour of the
+// cycle without per-stop tuning.
+const HORIZON_WELD_BAND = 0.055;
+// Triangular-PDF dither on the dome's slow gradients — two uniform hashes
+// summed give the triangular distribution, applied once RELATIVE (the bright
+// end, where ACES compression narrows the display steps) and once ABSOLUTE
+// (the dark end: the dusk gradient is where the banding lives). The absolute
+// term is re-derived for this game's exposure (0.62) from the reference
+// grade's 0.002 at exposure 1.05.
+const DITHER_RELATIVE = 0.005;
+const DITHER_ABSOLUTE = 0.0034;
+
 type SkyUniforms = {
   readonly turbidity: THREE.IUniform<number>;
   readonly rayleigh: THREE.IUniform<number>;
@@ -56,10 +74,12 @@ type SkyUniforms = {
   readonly cloudElevation: THREE.IUniform<number>;
   readonly showSunDisc: THREE.IUniform<number>;
   readonly time: THREE.IUniform<number>;
-  // >>> vibedgames patch 1/3: the rolloff's strength, so the day-night rig can
-  // hold the sunset's low-sun glow while the noon dome gets the full cut.
+  // >>> vibedgames patch 1/5: the rolloff's strength, so the day-night rig can
+  // hold the sunset's low-sun glow while the noon dome gets the full cut; and
+  // the live scene fog color the horizon weld converges onto.
   readonly horizonRolloff: THREE.IUniform<number>;
-  // <<< end patch 1/3
+  readonly fogColor: THREE.IUniform<THREE.Color>;
+  // <<< end patch 1/5
 };
 
 const VERTEX = /* glsl */ `
@@ -151,10 +171,14 @@ const FRAGMENT = /* glsl */ `
   uniform float showSunDisc;
   uniform float time;
 
-  // >>> vibedgames patch 2/3
+  // >>> vibedgames patch 2/5
   uniform float horizonRolloff;
+  uniform vec3 fogColor;
   const float horizonScale = ${HORIZON_SCALE.toFixed(3)};
-  // <<< end patch 2/3
+  const float horizonWeldBand = ${HORIZON_WELD_BAND.toFixed(3)};
+  const float ditherRelative = ${DITHER_RELATIVE.toFixed(4)};
+  const float ditherAbsolute = ${DITHER_ABSOLUTE.toFixed(4)};
+  // <<< end patch 2/5
 
   // Cloud noise functions
   float hash( vec2 p ) {
@@ -236,7 +260,7 @@ const FRAGMENT = /* glsl */ `
     vec3 Lin = pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * ( 1.0 - Fex ), vec3( 1.5 ) );
     Lin *= mix( vec3( 1.0 ), pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * Fex, vec3( 1.0 / 2.0 ) ), clamp( pow( 1.0 - dot( up, vSunDirection ), 5.0 ), 0.0, 1.0 ) );
 
-    // >>> vibedgames patch 3/3: GRAZING-ANGLE ROLLOFF (see the file header).
+    // >>> vibedgames patch 3/5: GRAZING-ANGLE ROLLOFF (see the file header).
     //
     // Preetham carries no absorption: the model conserves every photon it
     // scatters, so along the ~36x path the horizon looks down it just keeps
@@ -263,7 +287,7 @@ const FRAGMENT = /* glsl */ `
     // line holds one constant value — matching the max( 0.0, ... ) the
     // zenith angle above is already clamped with.
     Lin *= exp( - horizonRolloff * exp( - max( direction.y, 0.0 ) / horizonScale ) );
-    // <<< end patch 3/3
+    // <<< end patch 3/5
 
     // nightsky
     float theta = acos( direction.y ); // elevation --> y-axis, [-pi/2, pi/2]
@@ -313,6 +337,18 @@ const FRAGMENT = /* glsl */ `
 
     }
 
+    // >>> vibedgames patch 4/5: HORIZON WELD + BANDING DITHER (constants at
+    // the top of the file). The weld runs on the final composed color so the
+    // low clouds and the setting disc converge with the sky; at
+    // direction.y <= 0 the dome IS the fog color, which also replaces the
+    // constant grazing value the clamped airmass term holds below the
+    // horizon line.
+    float weld = 1.0 - smoothstep( 0.0, horizonWeldBand, direction.y );
+    texColor = mix( texColor, fogColor, weld );
+    float dn = hash( gl_FragCoord.xy ) + hash( gl_FragCoord.xy + 17.31 ) - 1.0;
+    texColor = texColor * ( 1.0 + dn * ditherRelative ) + dn * ditherAbsolute;
+    // <<< end patch 4/5
+
     gl_FragColor = vec4( texColor, 1.0 );
 
     #include <tonemapping_fragment>
@@ -332,6 +368,15 @@ const FRAGMENT = /* glsl */ `
 export class Sky extends THREE.Mesh<THREE.BoxGeometry, THREE.ShaderMaterial> {
   readonly isSky = true;
 
+  // >>> vibedgames patch 5/5: the horizon weld's fog source. The dome renders
+  // in the live scene (which carries scene.fog, mutated in place by the
+  // day-night cycle) and in game-scene's sky-bake cube pass (a bare temp
+  // scene with none) — caching the Fog INSTANCE from the last fogged render
+  // keeps the bake welded to the cycle's current color too.
+  private sceneFog: THREE.Fog | THREE.FogExp2 | null = null;
+  private readonly fogColorUniform: THREE.IUniform<THREE.Color>;
+  // <<< end patch 5/5
+
   constructor() {
     const uniforms: SkyUniforms = {
       turbidity: { value: 2 },
@@ -348,6 +393,7 @@ export class Sky extends THREE.Mesh<THREE.BoxGeometry, THREE.ShaderMaterial> {
       showSunDisc: { value: 1 },
       time: { value: 0 },
       horizonRolloff: { value: HORIZON_ROLLOFF_DEFAULT },
+      fogColor: { value: new THREE.Color(0xbcd7ea) },
     };
     super(
       new THREE.BoxGeometry(1, 1, 1),
@@ -360,5 +406,11 @@ export class Sky extends THREE.Mesh<THREE.BoxGeometry, THREE.ShaderMaterial> {
         depthWrite: false,
       }),
     );
+    this.fogColorUniform = uniforms.fogColor;
+  }
+
+  override onBeforeRender(_renderer: THREE.WebGLRenderer, scene: THREE.Scene): void {
+    if (scene.fog) this.sceneFog = scene.fog;
+    if (this.sceneFog) this.fogColorUniform.value.copy(this.sceneFog.color);
   }
 }

--- a/games/crazy-waymo/src/scenes/game-scene.ts
+++ b/games/crazy-waymo/src/scenes/game-scene.ts
@@ -106,6 +106,50 @@ function buildShoreTexture(): THREE.DataTexture {
   tex.needsUpdate = true;
   return tex;
 }
+
+// --- Kart-royale ocean pass (see the ocean block in the constructor) --------
+// From a chase cam a few units up nearly ALL visible water is grazing
+// incidence, where uncapped Schlick Fresnel hands ~90% of every pixel to the
+// env reflection and the turquoise depth ramp cannot exist. Capping the
+// grazing response is what lets the body color survive at range.
+const OC_FRES_MAX = 0.6;
+/** Shallows give up a third of their reflectivity to stay turquoise. */
+const OC_SHALLOW_REFLECT = 0.62;
+// The sun path: hand-clamped lobes (a physical GGX D would detonate bloom).
+// `flatten01` ramps near -> far; the track CONE WIDENS toward the viewer —
+// narrow column at the horizon, fanning out near the camera.
+const OC_PATH_NEAR = 90;
+const OC_PATH_FAR = 1100;
+const OC_TRACK_EXP_NEAR = 3.5;
+const OC_TRACK_EXP_FAR = 15;
+const OC_TIGHT_GAIN = 7; // near lobe — rides the real Gerstner normals
+const OC_BROAD_EXP_NEAR = 400;
+const OC_BROAD_EXP_FAR = 30;
+const OC_BROAD_GAIN_FAR = 4.2; // far lobe stands in for the flattened wavelets
+const OC_OFF_AXIS_FLOOR = 0.15; // anti-solar sea dark but never black
+const OC_GLINT_GAIN = 3.6; // hash-grid far glitter riding the track
+// Path radiance vs the live sun (color x intensity). Kart-royale ran ~1.5x its
+// sun color at exposure 1.05; at waymo's 0.62 the same displayed lane needs
+// ~1.7x the radiance — peaks deliberately clear the day bloom cut.
+const OC_SUN_GAIN = 1.35;
+// Pre-saturation band: the fog drains chroma 1.85x faster than value
+// (render/aerial-fog.ts) — right for headlands, fatal for the bay, where hue
+// is the only "this is water" signal at range. Push back over exactly the
+// drained band, clamped so extrapolation never goes negative.
+const OC_SAT_NEAR = 60;
+const OC_SAT_FULL = 480;
+const OC_SAT_OUT = 900;
+const OC_SAT_GONE = 1900;
+const OC_PRESAT = 1.35;
+// Horizon dissolve: the fog caps at 0.92 (aerial-fog FOG_MAX) and 8% of a lit
+// sea is still a hard line — walk the water fully onto the haze it was
+// converging to, AFTER the fog mix so the two agree in the same color space.
+const OC_SKY_NEAR = 800;
+const OC_SKY_FAR = 2500;
+// Sun-keyed terms hold through sunset (lamp opens at 0.62 there) and die
+// across dusk, so the lane sweeps golden hour -> night without popping.
+const OC_SUN_FADE_LO = 0.62;
+const OC_SUN_FADE_HI = 1.0;
 // --- Ambient bed inputs (see updateAmbience) ---
 const AMBIENCE_HZ = 4;
 /** Ring of offsets the shore probe samples the land mask at, in world units. */
@@ -282,7 +326,9 @@ export class GameScene {
   private signalLights: SignalLights | null = null;
   private skids: SkidMarks | null = null;
   private debris: Debris | null = null;
-  private speedLines = new SpeedLines();
+  // World-space anime streaks are the PHONE speed read; on desktop the grade
+  // shader's speed-line combs replace them (two vocabularies would double up).
+  private speedLines = this.mobileUi ? new SpeedLines() : null;
   private clouds = new SkyClouds(this.mobileUi);
   private trails: DriftTrails | null = null;
   private vehicleFx = new VehicleFxRig(
@@ -529,6 +575,10 @@ export class GameScene {
     // turquoise shallow ramp and an animated lapping foam band along every
     // coast, and sparse hash twinkles pop as sun glints that ride the wave
     // crests. All fragment work — the plane stays one quad.
+    // The kart-royale pass on top (OC_* constants above the class): capped
+    // grazing Fresnel, a 3-lobe sun path driven by the live cycle, a
+    // pre-saturation band against the fog's chroma drain, and a horizon
+    // dissolve that closes the fog's 8% residual.
     const oceanMat = new THREE.MeshStandardMaterial({
       color: 0x2e7fc0,
       roughness: 0.32,
@@ -536,6 +586,11 @@ export class GameScene {
     });
     const oceanTime = this.oceanTime;
     const shoreTex = buildShoreTexture();
+    // Live sun feed for the sun path (written by the mesh's onBeforeRender
+    // below — the ocean draws every frame, so the uniforms are always fresh).
+    const oceanSunDir = { value: new THREE.Vector3(0, 1, 0) };
+    const oceanSunCol = { value: new THREE.Color(0x000000) };
+    const oceanDayW = { value: 1 };
     const spanX = (WORLD_W * SHORE_SPAN).toFixed(1);
     // Ocean Beach surf weight: full at the west shore (u 0.09), gone by the
     // middle of the Sunset (u 0.28).
@@ -545,6 +600,9 @@ export class GameScene {
     oceanMat.onBeforeCompile = (shader) => {
       shader.uniforms.uOceanTime = oceanTime;
       shader.uniforms.uShore = { value: shoreTex };
+      shader.uniforms.uOcSunDir = oceanSunDir;
+      shader.uniforms.uOcSunCol = oceanSunCol;
+      shader.uniforms.uOcDayW = oceanDayW;
       shader.vertexShader = shader.vertexShader
         .replace("#include <common>", "#include <common>\nvarying vec3 vOceanPos;")
         .replace(
@@ -557,7 +615,14 @@ export class GameScene {
           `#include <common>
 uniform float uOceanTime;
 uniform sampler2D uShore;
+uniform vec3 uOcSunDir;
+uniform vec3 uOcSunCol;
+uniform float uOcDayW;
 varying vec3 vOceanPos;
+// Cross-stage scratch: written in the color block, read by the Fresnel cap
+// and the sun-path/dissolve blocks further down the template.
+float ocShallowG = 0.0;
+float ocViewDistG = 0.0;
 float ocHash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
 float ocNoise(vec2 p) {
   vec2 i = floor(p);
@@ -609,6 +674,7 @@ vec3 ocGerstner(vec2 p, float t) {
           {
             vec2 wp = vOceanPos.xz;
             float t = uOceanTime;
+            ocViewDistG = length(vOceanPos - cameraPosition);
             vec2 suv = vec2(wp.x / ${spanX} + 0.5, wp.y / ${spanZ} + 0.5);
             float s = texture2D(uShore, suv).r;
             // Fade the shore treatment at the texture border: beyond it the
@@ -625,6 +691,7 @@ vec3 ocGerstner(vec2 p, float t) {
             diffuseColor.rgb *= 1.0 + (swell / 1.5 - 0.5) * 0.10;
             // Shallow-water turquoise ramp toward the coast.
             float shallow = smoothstep(0.10, 0.44, s);
+            ocShallowG = shallow;
             diffuseColor.rgb = mix(diffuseColor.rgb, vec3(0.36, 0.78, 0.72), shallow * 0.75);
             // Lapping foam: an animated band just off the waterline plus a
             // solid white line hugging it. The visible waterline sits near
@@ -673,15 +740,94 @@ vec3 ocGerstner(vec2 p, float t) {
             diffuseColor.rgb += vec3(glint * 3.2 * ocSharp);
             diffuseColor.rgb = mix(diffuseColor.rgb, vec3(0.93, 0.97, 0.98), clamp(foam, 0.0, 0.9));
           }`,
+        )
+        .replace(
+          "#include <lights_fragment_end>",
+          `#include <lights_fragment_end>
+          {
+            // FRESNEL CAP: scale the accumulated env reflection so the
+            // effective grazing response tops out at OC_FRES_MAX instead of
+            // the physical 1.0, and hand shallows back their body color.
+            float ocP5 = pow(1.0 - saturate(dot(geometryNormal, geometryViewDir)), 5.0);
+            float ocCap = (0.02 + ${OC_FRES_MAX.toFixed(2)} * ocP5) / (0.02 + 0.98 * ocP5);
+            reflectedLight.indirectSpecular *=
+              ocCap * mix(1.0, ${OC_SHALLOW_REFLECT.toFixed(2)}, ocShallowG);
+          }`,
+        )
+        .replace(
+          "#include <opaque_fragment>",
+          `{
+            // THE SUN PATH (kart-royale water, re-derived for exposure 0.62):
+            // three hand-clamped lobes stretched along the sun azimuth. The
+            // tight lobe rides the real Gerstner normals near the camera; the
+            // broad lobe stands in for the flattened far wavelets; the glint
+            // lobe is hash-grid sparkle so the far lane stays points of
+            // light, not airbrush. Cats-paw streaks modulate the whole lane.
+            vec3 ocV = normalize(cameraPosition - vOceanPos);
+            vec3 ocN = normalize((vec4(normal, 0.0) * viewMatrix).xyz);
+            float ocFlat01 = smoothstep(${OC_PATH_NEAR.toFixed(1)}, ${OC_PATH_FAR.toFixed(1)}, ocViewDistG);
+            float ocNdl = saturate(dot(ocN, uOcSunDir));
+            float ocNdh = saturate(dot(ocN, normalize(ocV + uOcSunDir)));
+            vec3 ocR = reflect(-ocV, ocN);
+            vec2 ocRxz = ocR.xz / max(length(ocR.xz), 1e-4);
+            vec2 ocSxz = uOcSunDir.xz / max(length(uOcSunDir.xz), 1e-4);
+            float ocTrack = pow(max(dot(ocRxz, ocSxz), 0.0),
+              mix(${OC_TRACK_EXP_NEAR.toFixed(1)}, ${OC_TRACK_EXP_FAR.toFixed(1)}, ocFlat01));
+            float ocStreak = 0.72
+              + 0.28 * sin(dot(vOceanPos.xz, vec2(0.86, 0.51)) * 0.013 + uOceanTime * 0.09)
+                     * sin(dot(vOceanPos.xz, vec2(-0.51, 0.86)) * 0.021 - uOceanTime * 0.05);
+            float ocTight = pow(ocNdh, 1500.0) * ocNdl * ${OC_TIGHT_GAIN.toFixed(1)} * (1.0 - ocFlat01);
+            float ocBroad = pow(ocNdh, mix(${OC_BROAD_EXP_NEAR.toFixed(1)}, ${OC_BROAD_EXP_FAR.toFixed(1)}, ocFlat01))
+              * ocNdl * mix(1.0, ${OC_BROAD_GAIN_FAR.toFixed(1)}, ocFlat01);
+            ocBroad *= (${OC_OFF_AXIS_FLOOR.toFixed(2)} + ${(1 - OC_OFF_AXIS_FLOOR).toFixed(2)} * ocTrack) * ocStreak;
+            float ocGlint = pow(ocNdh, mix(240.0, 70.0, ocFlat01))
+              * step(0.82, ocHash(floor(vOceanPos.xz * 0.06)))
+              * ${OC_GLINT_GAIN.toFixed(1)} * ocFlat01 * (0.12 + 0.88 * ocTrack);
+            outgoingLight += uOcSunCol * (ocTight + ocBroad + ocGlint);
+            // PRE-SATURATION against the fog's chroma drain, banded to the
+            // exact range the drain works over, then clamped: negative
+            // radiance from the extrapolation would detonate bloom.
+            float ocBand = smoothstep(${OC_SAT_NEAR.toFixed(1)}, ${OC_SAT_FULL.toFixed(1)}, ocViewDistG)
+              * (1.0 - smoothstep(${OC_SAT_OUT.toFixed(1)}, ${OC_SAT_GONE.toFixed(1)}, ocViewDistG));
+            float ocLum = dot(outgoingLight, vec3(0.2126, 0.7152, 0.0722));
+            outgoingLight = max(
+              mix(vec3(ocLum), outgoingLight, 1.0 + ${OC_PRESAT.toFixed(2)} * ocBand * uOcDayW),
+              vec3(0.0));
+          }
+          #include <opaque_fragment>`,
+        )
+        .replace(
+          "#include <fog_fragment>",
+          `#include <fog_fragment>
+          #ifdef USE_FOG
+            // HORIZON DISSOLVE: walk the last 8% (aerial-fog FOG_MAX residual)
+            // onto hazeColor — the exact asymptote the fog chunk above was
+            // converging to, marine layer included — so sea and sky meet on
+            // the same number and the seam has nothing left to be.
+            gl_FragColor.rgb = mix(gl_FragColor.rgb, hazeColor,
+              smoothstep(${OC_SKY_NEAR.toFixed(1)}, ${OC_SKY_FAR.toFixed(1)}, ocViewDistG));
+          #endif`,
         );
     };
     const ocean = new THREE.Mesh(new THREE.PlaneGeometry(9000, 9000), oceanMat);
     ocean.rotation.x = -HALF_PI;
     ocean.position.y = -0.5;
+    // The sun path rides the LIVE cycle: direction from the day-night rig,
+    // radiance from the key's color x intensity, held through sunset and
+    // killed across dusk (the lamp ramp) so it never paints a moon lane.
+    ocean.onBeforeRender = () => {
+      const dayW =
+        1 - THREE.MathUtils.smoothstep(this.dayNight.lamp, OC_SUN_FADE_LO, OC_SUN_FADE_HI);
+      oceanDayW.value = dayW;
+      oceanSunDir.value.copy(this.dayNight.sunOffset).normalize();
+      oceanSunCol.value
+        .copy(this.sun.color)
+        .multiplyScalar(this.sun.intensity * OC_SUN_GAIN * dayW);
+    };
     this.scene.add(ocean);
 
     this.fx.addTo(this.scene);
-    this.scene.add(this.speedLines.object3D);
+    if (this.speedLines) this.scene.add(this.speedLines.object3D);
     this.scene.add(this.clouds.group);
     this.scene.add(this.shocks.group);
     this.scene.add(this.impactStars.group);
@@ -1616,7 +1762,7 @@ vec3 ocGerstner(vec2 p, float t) {
       car.position.z + Math.sin(a) * r,
     );
     this.rig.camera.lookAt(car.position.x, car.position.y + 1.0, car.position.z);
-    this.speedLines.update(dt, this.rig.camera, 0); // fade out leftover streaks
+    this.speedLines?.update(dt, this.rig.camera, 0); // fade out leftover streaks
     setGradeMotion(0, false); // and drain the post lens the same way
   }
 
@@ -1725,11 +1871,7 @@ vec3 ocGerstner(vec2 p, float t) {
     // Mini-turbo tier tell (Mario Kart): a blip + spark flare each time the
     // charge steps up a tier — blue at tier 1, orange at tier 2.
     const tier = drifting ? car.driftTier : 0;
-    if (tier > this.lastDriftTier) {
-      this.sfx.driftArm();
-      const hue = tier === 2 ? 0.07 : 0.58;
-      this.fx.burst(car.position.x, 0.6, car.position.z, hue, 10, 5);
-    }
+    if (tier > this.lastDriftTier) this.sfx.driftArm();
     this.lastDriftTier = tier;
 
     // Drift-release mini-turbo — the signature skill move — pays by tier.
@@ -1740,7 +1882,6 @@ vec3 ocGerstner(vec2 p, float t) {
       this.sfx.boost();
       this.rig.addTrauma(superTurbo ? 0.26 : 0.18);
       this.hud.flash(superTurbo ? "#ffa726" : "#8fe8ff", 0.16);
-      this.exhaustFlash(superTurbo ? 0.07 : 0.55);
       this.hud.showCombo(superTurbo ? "SUPER MINI-TURBO!" : "MINI-TURBO!");
     }
 
@@ -1748,7 +1889,6 @@ vec3 ocGerstner(vec2 p, float t) {
     if (car.isBoosting && !this.wasBoosting) {
       this.sfx.boost();
       this.rig.addTrauma(0.12);
-      this.exhaustFlash(0.07);
     }
     this.wasBoosting = car.isBoosting;
     this.sfx.setBoostLoop(car.isBoosting);
@@ -1883,7 +2023,7 @@ vec3 ocGerstner(vec2 p, float t) {
     // Speed streaks are a first-person effect glued to the chase camera —
     // under freecam (trailer fixed shots, DEV) feed 0 so leftovers fade out
     // instead of rushing along a static camera's forward axis.
-    this.speedLines.update(dt, this.rig.camera, this.freecam ? 0 : car.speed / CAR.boostSpeed);
+    this.speedLines?.update(dt, this.rig.camera, this.freecam ? 0 : car.speed / CAR.boostSpeed);
     // The post lens (CA / vignette squeeze / bloom lift) reads the same
     // motion; freecam feeds 0 so staged shots stay clean.
     setGradeMotion(this.freecam ? 0 : car.speed / CAR.boostSpeed, !this.freecam && car.isBoosting);
@@ -2307,6 +2447,7 @@ vec3 ocGerstner(vec2 p, float t) {
     this.hud.setScore(this.state.displayScore);
     this.hud.setSpeed(car.speed * MPH_FACTOR);
     this.hud.setBoost(car.boostMeter / CAR.boostMax);
+    this.hud.setDrift(car.driftTier, car.driftCharge);
     this.hud.setCombo(this.state.combo, this.state.comboTimer / FARE.comboWindow);
 
     // The card only shows while CARRYING (destination + patience); while

--- a/games/crazy-waymo/src/ui/hud.ts
+++ b/games/crazy-waymo/src/ui/hud.ts
@@ -1,8 +1,70 @@
+import { TIER_COLORS, tierColor } from "../fx/tier";
+
 function el(id: string): HTMLElement {
   const node = document.getElementById(id);
   if (!node) throw new Error(`missing #${id}`);
   return node;
 }
+
+function damp(current: number, target: number, lambda: number, dt: number): number {
+  return current + (target - current) * (1 - Math.exp(-lambda * dt));
+}
+
+// ---- Drift rails (tuning knobs) -------------------------------------------
+// Rail fill is LADDER position, (tier + charge) / steps — never within-tier
+// charge, which resets to 0 at the exact moment of earning. A tier boundary
+// is a step; only opacity is eased.
+const RAIL_STEPS = 3;
+const RAIL_ON_BASE = 0.44;
+const RAIL_ON_FILL = 0.16;
+const RAIL_ON_TIER = 0.13;
+const RAIL_RISE_LAMBDA = 22;
+const RAIL_FALL_LAMBDA = 8;
+/** The earning (next-tier) rail cap per held tier; index 2 is the violet
+ *  release preview — never a holdable state, matching fx/tier.ts doctrine. */
+const RAIL_NEXT_COLOR: Record<0 | 1 | 2, string> = {
+  0: TIER_COLORS[0],
+  1: TIER_COLORS[1],
+  2: TIER_COLORS[2],
+};
+
+// ---- Speedometer paint (warm-ink cluster; every value is a tuning knob) ---
+const DIAL_W = 120;
+const DIAL_H = 84;
+const DIAL_CX = 60;
+const DIAL_CY = 42;
+const DIAL_R = 29;
+const DIAL_FACE_R = 38;
+// 240° sweep, symmetric about 12 o'clock, opening at the bottom (the digital
+// readout sits in the gap).
+const DIAL_A0 = Math.PI * (5 / 6);
+const DIAL_SWEEP = Math.PI * (4 / 3);
+const DIAL_MAX_MPH = 100;
+const REDLINE_FRAC = 0.85;
+const CHAN_W = 7; // channel groove width
+const CHAN_FILL_FRAC = 0.78; // fill/scale width inside the groove
+const CHAN_INK = "rgba(18, 10, 4, 0.64)";
+// ONE flat low value — a low-alpha ramp behind the fill reads as a fault.
+const CHAN_SCALE = "rgba(255, 232, 202, 0.15)";
+const DIAL_FILL_LO = "#fff4e2";
+const DIAL_FILL_MID = "#ffcf6b";
+const DIAL_FILL_HI = "#e0453f";
+const DIAL_FILL_GLOW = "rgba(255, 190, 110, 0.34)";
+const REDLINE_INK = "rgba(224, 69, 63, 0.55)";
+const REDLINE_OVER = "rgba(255, 150, 96, 0.92)";
+const TICK_OUT_R = 24;
+const TICK_MAJOR_IN_R = 17.5;
+const TICK_MINOR_IN_R = 21;
+const TICK_INK = "rgba(18, 10, 4, 0.82)";
+const TICK_CREAM_MAJOR = "rgba(255, 244, 226, 0.72)";
+const TICK_CREAM_MINOR = "rgba(255, 244, 226, 0.42)";
+const NEEDLE_TIP_R = DIAL_R - CHAN_W * 0.62;
+const NEEDLE_TAIL_R = DIAL_R * 0.3;
+const NEEDLE_HALF_W = DIAL_R * 0.078;
+const HUB_R = 4.5;
+const PAPER = "#fff4e2";
+const DIAL_INK = "rgba(18, 10, 4, 0.92)";
+const DIAL_FONT = '"Avenir Next Condensed", "Roboto Condensed", "Arial Narrow", sans-serif';
 
 function sub(selector: string): HTMLElement {
   const node = document.querySelector(selector);
@@ -50,6 +112,19 @@ export class Hud {
   private boostFill = el("boost-fill");
   private dial = el("dash-dial");
   private dialCtx: CanvasRenderingContext2D | null = null;
+  // Dial gradients cached at first draw — they never change frame to frame.
+  private dialFaceGrad: CanvasGradient | null = null;
+  private dialValueGrad: CanvasGradient | null = null;
+  private dialHubGrad: CanvasGradient | null = null;
+  private railL = el("rail-l");
+  private railR = el("rail-r");
+  private railBarL = sub("#rail-l > i");
+  private railBarR = sub("#rail-r > i");
+  private railOn = 0;
+  // Shown-value memos: a style write that changes nothing still dirties style.
+  private railOnShown = -1;
+  private railFillShown = -1;
+  private railTierShown = -1;
   private fareCard = el("fare-card");
   private fareWho = el("fare-card").querySelector<HTMLElement>(".who");
   private fareDist = el("fare-card").querySelector<HTMLElement>(".dist");
@@ -123,6 +198,55 @@ export class Hud {
         this.drawDial(Math.max(0, this.mphShown));
       }
     }
+    this.updateRails(dt);
+  }
+
+  /** Screen-edge drift rails: fill = ladder position, tier triple-encoded as
+   *  height + hue + pulse-rate (pulse lives in CSS via the .tN classes). One
+   *  composited translateY per frame; only opacity is eased. */
+  private updateRails(dt: number): void {
+    const charge = Math.max(0, Math.min(1, this.driftCharge));
+    const active = this.driftTier > 0 || charge > 0;
+    const fill = Math.min(1, (this.driftTier + charge) / RAIL_STEPS);
+    const want = active ? RAIL_ON_BASE + RAIL_ON_FILL * fill + RAIL_ON_TIER * this.driftTier : 0;
+    this.railOn = damp(
+      this.railOn,
+      want,
+      want > this.railOn ? RAIL_RISE_LAMBDA : RAIL_FALL_LAMBDA,
+      dt,
+    );
+    const on = this.railOn < 0.015 ? 0 : this.railOn;
+    if (Math.abs(on - this.railOnShown) > 0.005) {
+      this.railOnShown = on;
+      const o = on.toFixed(3);
+      this.railL.style.opacity = o;
+      this.railR.style.opacity = o;
+    }
+    if (Math.abs(fill - this.railFillShown) > 0.004) {
+      this.railFillShown = fill;
+      const t = `translateY(${((1 - fill) * 100).toFixed(2)}%)`;
+      this.railBarL.style.transform = t;
+      this.railBarR.style.transform = t;
+    }
+    const tier = this.driftTier;
+    if (tier !== this.railTierShown) {
+      // Promotion (not the first sync, not the post-drift reset) refires the
+      // flare; colors come from fx/tier.ts so rails and sparks agree.
+      const promoted = tier > this.railTierShown && this.railTierShown >= 0 && active;
+      this.railTierShown = tier;
+      const banked = tierColor(tier);
+      const next = RAIL_NEXT_COLOR[tier];
+      for (const rail of [this.railL, this.railR]) {
+        rail.classList.remove("t0", "t1", "t2", "pop");
+        rail.classList.add(`t${tier}`);
+        rail.style.setProperty("--cc", banked);
+        rail.style.setProperty("--cn", next);
+        if (promoted && !this.reduceMotion) {
+          void rail.offsetWidth;
+          rail.classList.add("pop");
+        }
+      }
+    }
   }
 
   setTimer(_seconds: number, _low: boolean): void {
@@ -193,117 +317,183 @@ export class Hud {
     }
   }
 
-  // Analogue gauge, kart-cluster style: dark face in a bevel + gold rim,
-  // 240° sweep, ticks every 10 (majors at 20), needle from the hub. The
-  // digital readout sits in the sweep's bottom gap under the hub.
+  // Warm-ink cluster instrument: channel groove, gradient value fill
+  // (cream → gold → kerb red), redline segment, ink-under-cream ticks, and a
+  // MOUNTED needle — counterweight + cast shadow + chrome hub are the three
+  // things that make a pointer look mounted. The digital readout sits in the
+  // sweep's bottom gap under the hub.
   private drawDial(mph: number): void {
     const canvas = this.dial;
     if (!(canvas instanceof HTMLCanvasElement)) return;
-    const W = 120;
-    const H = 84;
     if (!this.dialCtx) {
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      canvas.width = W * dpr;
-      canvas.height = H * dpr;
+      canvas.width = DIAL_W * dpr;
+      canvas.height = DIAL_H * dpr;
       this.dialCtx = canvas.getContext("2d");
       this.dialCtx?.scale(dpr, dpr);
     }
     const ctx = this.dialCtx;
     if (!ctx) return;
-    const DIAL_MAX = 100;
-    const cx = 60;
-    const cy = 42;
-    const r = 29;
-    // 240° sweep, symmetric about 12 o'clock, opening at the bottom.
-    const a0 = Math.PI * (5 / 6);
-    const sweep = Math.PI * (4 / 3);
-    const frac = Math.max(0, Math.min(1, mph / DIAL_MAX));
-    ctx.clearRect(0, 0, W, H);
-    // Face, warm bevel ring, gold rim — matches the .pill plate recipe.
+    const cx = DIAL_CX;
+    const cy = DIAL_CY;
+    const r = DIAL_R;
+    if (!this.dialValueGrad) {
+      const face = ctx.createLinearGradient(0, cy - DIAL_FACE_R, 0, cy + DIAL_FACE_R);
+      face.addColorStop(0, "#3a2a1d");
+      face.addColorStop(0.55, "#20140d");
+      face.addColorStop(1, "#170e0a");
+      this.dialFaceGrad = face;
+      const val = ctx.createLinearGradient(cx - r, cy + r * 0.35, cx + r, cy - r * 0.55);
+      val.addColorStop(0, DIAL_FILL_LO);
+      val.addColorStop(0.45, DIAL_FILL_MID);
+      val.addColorStop(1, DIAL_FILL_HI);
+      this.dialValueGrad = val;
+      // Chrome hub: metalness 1.0 reads as a vertical light-to-dark ramp.
+      const hub = ctx.createLinearGradient(0, cy - HUB_R, 0, cy + HUB_R);
+      hub.addColorStop(0, "#fff7ec");
+      hub.addColorStop(0.55, "#b29a80");
+      hub.addColorStop(1, "#443426");
+      this.dialHubGrad = hub;
+    }
+    const frac = Math.max(0, Math.min(1, mph / DIAL_MAX_MPH));
+    ctx.clearRect(0, 0, DIAL_W, DIAL_H);
+    // Face: top-lit warm-ink gradient, warm bevel, cream hairline rim.
     ctx.beginPath();
-    ctx.arc(cx, cy, 38, 0, Math.PI * 2);
-    ctx.fillStyle = "rgba(20, 16, 12, 0.96)";
+    ctx.arc(cx, cy, DIAL_FACE_R, 0, Math.PI * 2);
+    ctx.fillStyle = this.dialFaceGrad ?? "#170e0a";
     ctx.fill();
     ctx.lineWidth = 4;
-    ctx.strokeStyle = "#352a1e";
+    ctx.strokeStyle = "#54402f";
     ctx.beginPath();
     ctx.arc(cx, cy, 35.5, 0, Math.PI * 2);
     ctx.stroke();
-    ctx.lineWidth = 2;
-    ctx.strokeStyle = "rgba(255, 209, 71, 0.9)";
+    ctx.lineWidth = 1.5;
+    ctx.strokeStyle = "rgba(255, 226, 186, 0.35)";
     ctx.beginPath();
-    ctx.arc(cx, cy, 38, 0, Math.PI * 2);
+    ctx.arc(cx, cy, DIAL_FACE_R, 0, Math.PI * 2);
     ctx.stroke();
-    // Track, then the speed arc over it (color shifts toward the redline).
+    // Channel groove, then the unfilled scale over it at one flat value.
     ctx.lineCap = "butt";
-    ctx.lineWidth = 7;
-    ctx.strokeStyle = "rgba(255, 255, 255, 0.14)";
+    ctx.lineWidth = CHAN_W;
+    ctx.strokeStyle = CHAN_INK;
     ctx.beginPath();
-    ctx.arc(cx, cy, r, a0, a0 + sweep);
+    ctx.arc(cx, cy, r, DIAL_A0, DIAL_A0 + DIAL_SWEEP);
     ctx.stroke();
+    ctx.lineWidth = CHAN_W * CHAN_FILL_FRAC;
+    ctx.strokeStyle = CHAN_SCALE;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, DIAL_A0, DIAL_A0 + DIAL_SWEEP);
+    ctx.stroke();
+    // Redline segment, IN the channel.
+    ctx.strokeStyle = REDLINE_INK;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, DIAL_A0 + DIAL_SWEEP * REDLINE_FRAC, DIAL_A0 + DIAL_SWEEP);
+    ctx.stroke();
+    // Value fill: the cream→gold→red ramp with a soft warm glow; past the
+    // redline it re-lays hot so the needle's arc wins over the red band.
     if (frac > 0.005) {
-      ctx.strokeStyle = frac > 0.8 ? "#ff8a3c" : frac > 0.55 ? "#ffd147" : "#8fd9ff";
+      ctx.save();
+      ctx.shadowColor = DIAL_FILL_GLOW;
+      ctx.shadowBlur = DIAL_W * 0.02;
+      ctx.strokeStyle = this.dialValueGrad ?? DIAL_FILL_MID;
       ctx.beginPath();
-      ctx.arc(cx, cy, r, a0, a0 + sweep * frac);
+      ctx.arc(cx, cy, r, DIAL_A0, DIAL_A0 + DIAL_SWEEP * frac);
       ctx.stroke();
+      if (frac > REDLINE_FRAC) {
+        ctx.strokeStyle = REDLINE_OVER;
+        ctx.beginPath();
+        ctx.arc(cx, cy, r, DIAL_A0 + DIAL_SWEEP * REDLINE_FRAC, DIAL_A0 + DIAL_SWEEP * frac);
+        ctx.stroke();
+      }
+      ctx.restore();
     }
-    // Ticks inside the track: minors every 10 mph, longer majors every 20.
-    for (let m = 0; m <= DIAL_MAX; m += 10) {
+    // Ticks: minors every 10 mph, majors every 20 — each drawn twice, ink
+    // under then cream over (the same recipe as the text contour ring).
+    for (let m = 0; m <= DIAL_MAX_MPH; m += 10) {
       const major = m % 20 === 0;
-      const a = a0 + sweep * (m / DIAL_MAX);
-      const t1 = major ? 17.5 : 21;
-      ctx.strokeStyle = major ? "rgba(255, 255, 255, 0.7)" : "rgba(255, 255, 255, 0.32)";
-      ctx.lineWidth = major ? 2 : 1.5;
+      const a = DIAL_A0 + DIAL_SWEEP * (m / DIAL_MAX_MPH);
+      const ax = Math.cos(a);
+      const ay = Math.sin(a);
+      const rIn = major ? TICK_MAJOR_IN_R : TICK_MINOR_IN_R;
+      ctx.strokeStyle = TICK_INK;
+      ctx.lineWidth = major ? 2.6 : 1.8;
       ctx.beginPath();
-      ctx.moveTo(cx + Math.cos(a) * 24, cy + Math.sin(a) * 24);
-      ctx.lineTo(cx + Math.cos(a) * t1, cy + Math.sin(a) * t1);
+      ctx.moveTo(cx + ax * TICK_OUT_R, cy + ay * TICK_OUT_R);
+      ctx.lineTo(cx + ax * rIn, cy + ay * rIn);
+      ctx.stroke();
+      ctx.strokeStyle = major ? TICK_CREAM_MAJOR : TICK_CREAM_MINOR;
+      ctx.lineWidth = major ? 1.4 : 0.9;
+      ctx.beginPath();
+      ctx.moveTo(cx + ax * TICK_OUT_R, cy + ay * TICK_OUT_R);
+      ctx.lineTo(cx + ax * rIn, cy + ay * rIn);
       ctx.stroke();
     }
-    // Needle from the hub with a short counterweight tail; dark contour
-    // underneath so it survives crossing the bright arc colors.
-    const na = a0 + sweep * frac;
+    // Needle: cream polygon with a counterweight tail, cast shadow, ink edge.
+    const na = DIAL_A0 + DIAL_SWEEP * frac;
     const nx = Math.cos(na);
     const ny = Math.sin(na);
-    ctx.lineCap = "round";
-    ctx.strokeStyle = "rgba(10, 7, 4, 0.7)";
-    ctx.lineWidth = 5.5;
+    const px = -ny;
+    const py = nx;
+    const hw = NEEDLE_HALF_W;
+    const tailX = cx - nx * NEEDLE_TAIL_R;
+    const tailY = cy - ny * NEEDLE_TAIL_R;
     ctx.beginPath();
-    ctx.moveTo(cx - nx * 6, cy - ny * 6);
-    ctx.lineTo(cx + nx * 23, cy + ny * 23);
-    ctx.stroke();
-    ctx.strokeStyle = "#ff5a52";
-    ctx.lineWidth = 3;
-    ctx.beginPath();
-    ctx.moveTo(cx - nx * 6, cy - ny * 6);
-    ctx.lineTo(cx + nx * 23, cy + ny * 23);
-    ctx.stroke();
-    // Hub cap.
-    ctx.beginPath();
-    ctx.arc(cx, cy, 5, 0, Math.PI * 2);
-    ctx.fillStyle = "#241d16";
+    ctx.moveTo(cx + px * hw, cy + py * hw);
+    ctx.lineTo(cx + nx * NEEDLE_TIP_R, cy + ny * NEEDLE_TIP_R);
+    ctx.lineTo(cx - px * hw, cy - py * hw);
+    ctx.lineTo(tailX - px * hw * 0.9, tailY - py * hw * 0.9);
+    ctx.quadraticCurveTo(
+      tailX - nx * hw * 1.6,
+      tailY - ny * hw * 1.6,
+      tailX + px * hw * 0.9,
+      tailY + py * hw * 0.9,
+    );
+    ctx.closePath();
+    ctx.save();
+    ctx.shadowColor = "rgba(18, 10, 4, 0.68)";
+    ctx.shadowBlur = DIAL_W * 0.022;
+    ctx.shadowOffsetX = DIAL_W * 0.005;
+    ctx.shadowOffsetY = DIAL_W * 0.01;
+    ctx.fillStyle = PAPER;
     ctx.fill();
-    ctx.lineWidth = 2;
-    ctx.strokeStyle = "#ffd147";
-    ctx.stroke();
-    ctx.beginPath();
-    ctx.arc(cx, cy, 1.8, 0, Math.PI * 2);
-    ctx.fillStyle = "#ff5a52";
-    ctx.fill();
-    // Digital readout under the hub.
-    ctx.textAlign = "center";
+    ctx.restore();
     ctx.lineJoin = "round";
-    ctx.font = "800 19px ui-monospace, 'SF Mono', Menlo, monospace";
+    ctx.lineWidth = 1.4;
+    ctx.strokeStyle = DIAL_INK;
+    ctx.stroke();
+    // Chrome hub over the needle root.
+    ctx.beginPath();
+    ctx.arc(cx, cy, HUB_R, 0, Math.PI * 2);
+    ctx.fillStyle = this.dialHubGrad ?? "#b29a80";
+    ctx.fill();
+    ctx.lineWidth = 1.2;
+    ctx.strokeStyle = DIAL_INK;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(cx, cy, HUB_R * 0.4, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(18, 10, 4, 0.78)";
+    ctx.fill();
+    // Digital readout under the hub: ink stroke under cream fill.
+    ctx.textAlign = "center";
+    ctx.font = `900 19px ${DIAL_FONT}`;
     ctx.lineWidth = 3;
-    ctx.strokeStyle = "rgba(0, 0, 0, 0.75)";
+    ctx.strokeStyle = "rgba(18, 10, 4, 0.86)";
     ctx.strokeText(String(Math.round(mph)), cx, 69);
-    ctx.fillStyle = "#fff";
+    ctx.fillStyle = PAPER;
     ctx.fillText(String(Math.round(mph)), cx, 69);
-    ctx.font = "800 8px ui-monospace, 'SF Mono', Menlo, monospace";
-    ctx.fillStyle = "rgba(255, 209, 71, 0.85)";
+    ctx.font = `700 8px ${DIAL_FONT}`;
+    ctx.fillStyle = "rgba(255, 232, 202, 0.6)";
     ctx.fillText("MPH", cx, 78);
   }
   setBoost(frac: number): void {
     this.boostFill.style.width = `${Math.round(Math.max(0, Math.min(1, frac)) * 100)}%`;
+  }
+
+  driftTier: 0 | 1 | 2 = 0;
+  driftCharge = 0;
+  setDrift(tier: 0 | 1 | 2, charge: number): void {
+    this.driftTier = tier;
+    this.driftCharge = charge;
   }
   boostDenied(): void {
     this.boostPill.classList.remove("denied");
@@ -328,7 +518,7 @@ export class Hud {
     if (this.fareDist) this.fareDist.textContent = `${Math.round(distance)} m`;
     const f = Math.max(0, Math.min(1, patienceFrac));
     this.patienceFill.style.width = `${Math.round(f * 100)}%`;
-    this.patienceFill.style.background = f > 0.5 ? "#6bff8e" : f > 0.25 ? "#ffb64d" : "#ff5a52";
+    this.patienceFill.style.background = f > 0.5 ? "#7ef0a4" : f > 0.25 ? "#ffb64d" : "#e0453f";
   }
   hideFareCard(): void {
     this.fareCard.classList.remove("show");
@@ -353,8 +543,9 @@ export class Hud {
   // and brand color — swapping cars re-skins the meter.
   setOperator(label: string, accent: string): void {
     if (this.scoreLabel) this.scoreLabel.textContent = label;
-    if (this.scoreLabel) this.scoreLabel.style.color = accent;
-    this.scorePill.style.borderColor = accent;
+    // The plate's accent slot: rim-light gradient + label tint both key off
+    // --accent, so the brand color lands in one write.
+    this.scorePill.style.setProperty("--accent", accent);
   }
 
   announceMinor(text: string, color = "#aee3ff"): void {
@@ -394,6 +585,8 @@ export class Hud {
 
   showCountdown(text: string, big: boolean): void {
     this.countdown.textContent = text;
+    // GO! flips the gold display ramp to green (CSS .go).
+    this.countdown.classList.toggle("go", text.toUpperCase().startsWith("GO"));
     // Scale-settle: land past 1, snap back — the digit reads as slammed down.
     this.countdown.animate(
       [

--- a/games/crazy-waymo/src/ui/minimap.ts
+++ b/games/crazy-waymo/src/ui/minimap.ts
@@ -22,10 +22,12 @@ export type MinimapMarker = {
   readonly edgeClamp?: boolean;
 };
 
-const WATER = "#2e5f8a";
-const LAND = "#a3a49b";
-const PARK = "#6f9455";
-const ROAD = "#c9cdd2";
+// Dark-chart palette: navy ground, cream streets — the kart-cluster read
+// (light-grey paper made the map the brightest plate on screen at night).
+const WATER = "#1d3a57";
+const LAND = "#2a3140";
+const PARK = "#3d5a44";
+const ROAD = "#e8e0cc";
 const DECK = "#c0483c";
 
 // World units across the minimap window. The small box zooms in: it is ~2/3

--- a/games/crazy-waymo/src/vehicle/car.ts
+++ b/games/crazy-waymo/src/vehicle/car.ts
@@ -2,7 +2,10 @@ import * as THREE from "three";
 
 import type { ModelCache } from "../assets/loader";
 import { modelUrl, PLAYER_CAR } from "../assets/manifest";
+import { ContactShadow, SHADOW_LIFT } from "./contact-shadow";
+import { applyLacquer } from "./lacquer";
 import type { RaycastVehicle } from "./raycast-vehicle";
+import { applySunRim, applyTrafficSunRim, RIM_HERO } from "./sun-rim";
 import { radialGlowTexture } from "../fx/lamp-glow";
 import { CAR, ROAD_Y, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
 import type { Solid } from "../world/city";
@@ -56,6 +59,11 @@ const LIDAR_BLUE = new THREE.MeshStandardMaterial({
   emissiveIntensity: 0.4,
   roughness: 0.2,
 });
+// The sensor suite shares the hero rim so the signature rooftop silhouette
+// separates from bright sky/asphalt along with the paint.
+applySunRim(LIDAR_WHITE, RIM_HERO);
+applySunRim(LIDAR_DARK, RIM_HERO);
+applySunRim(LIDAR_BLUE, RIM_HERO);
 
 // Toy-car lacquer for player-class bodies: physical clearcoat over the kit
 // colormap. The loader dedups MeshStandardMaterial per kit, so this MUST
@@ -81,6 +89,7 @@ function lacquerMaterial(
     vertexColors: src.vertexColors,
   });
   if (tint) m.color.multiply(tint).lerp(tint, 0.55);
+  applyLacquer(m, RIM_HERO);
   return m;
 }
 
@@ -293,6 +302,14 @@ export function buildSkinBody(cache: ModelCache, skin: RobotaxiSkin): THREE.Obje
         c.material = lacquerMaterial(c.material, tint);
       }
     });
+  } else {
+    // Fitted GLBs keep their authored materials — those still get the hero
+    // rim (shared template materials; player-skin models only, idempotent).
+    body.traverse((c) => {
+      if (c instanceof THREE.Mesh && !Array.isArray(c.material)) {
+        if (c.material instanceof THREE.MeshStandardMaterial) applySunRim(c.material, RIM_HERO);
+      }
+    });
   }
   if (skin.lidar) body.add(buildWaymoSensors());
   if (skin.mustache) body.add(buildCarstache());
@@ -303,6 +320,7 @@ export function buildSkinBody(cache: ModelCache, skin: RobotaxiSkin): THREE.Obje
 // chunky center pair, drooping outer tips. Sedan nose sits at z ≈ 1.25,
 // grille height ≈ 0.55.
 const STACHE_PINK = new THREE.MeshStandardMaterial({ color: 0xff2db8, roughness: 0.55 });
+applySunRim(STACHE_PINK, RIM_HERO);
 export function buildCarstache(): THREE.Group {
   const g = new THREE.Group();
   const lobe = (x: number, y: number, sx: number, sy: number, roll: number): void => {
@@ -474,6 +492,11 @@ export class Car {
 
   private nightRig: NightRig;
   private nightFactor = -1; // last applied value; skip redundant writes
+  private contactShadow: ContactShadow;
+  // Traffic kit materials patch (sun rim): retried until the late-preload
+  // traffic GLBs exist. See sun-rim.ts applyTrafficSunRim.
+  private trafficRimDone = false;
+  private trafficRimTimer = 0;
   // Physics mode: when attached, a Rapier raycast-vehicle drives the car and
   // the kinematic sim below is bypassed entirely.
   private vehicle: RaycastVehicle | null = null;
@@ -502,10 +525,21 @@ export class Car {
     this.object3D.scale.setScalar(1.12);
     this.body = buildSkinBody(cache, skinById(skinId));
     this.collectWheels();
+    this.contactShadow = new ContactShadow();
+    this.contactShadow.setLayout(this.wheelLayout());
+    // The quad is a child of the hero-scaled group; lift is authored in world
+    // units so the drape-clearance budget holds.
+    this.contactShadow.mesh.position.y = SHADOW_LIFT / this.object3D.scale.y;
+    this.object3D.add(this.contactShadow.mesh);
     this.nightRig = buildNightRig();
     this.body.add(this.nightRig.group);
     this.setHeadlights(0);
     this.object3D.add(this.body);
+    this.trafficRimDone = applyTrafficSunRim(cache);
+  }
+
+  private wheelLayout(): { x: number; z: number }[] {
+    return this.wheels.map((w) => ({ x: w.node.position.x, z: w.node.position.z }));
   }
 
   private collectWheels(): void {
@@ -529,6 +563,7 @@ export class Car {
     this.object3D.remove(this.body);
     this.body = buildSkinBody(this.cache, skin);
     this.collectWheels();
+    this.contactShadow.setLayout(this.wheelLayout());
     this.body.add(this.nightRig.group);
     const nf = this.nightFactor;
     this.nightFactor = -1;
@@ -791,12 +826,16 @@ export class Car {
     const steerAngle = veh.wheelVisual(0).steering;
     const rest = veh.params.suspensionRestLength;
     const invScale = 1 / this.object3D.scale.y;
-    for (const w of this.wheels) {
+    for (let i = 0; i < this.wheels.length; i++) {
+      const w = this.wheels[i];
+      if (!w) continue;
       w.node.rotation.x = this.wheelSpin;
       if (w.front) w.node.rotation.y = steerAngle;
       const travel = rest - veh.wheelVisual(w.phys).suspension;
       w.node.position.y = w.restY + THREE.MathUtils.clamp(travel, -0.12, 0.2) * invScale;
+      this.contactShadow.setWheelTravel(i, travel);
     }
+    this.contactShadow.update(dt, !airborneNow);
     this.squash = Math.max(0, this.squash - dt * 5.5);
     const sq = this.squash;
     this.body.scale.set(1 + 0.12 * sq, 1 - 0.26 * sq, 1 + 0.12 * sq);
@@ -815,6 +854,13 @@ export class Car {
   }
 
   update(dt: number, input: CarInput, solids: SolidIndex): void {
+    if (!this.trafficRimDone) {
+      this.trafficRimTimer -= dt;
+      if (this.trafficRimTimer <= 0) {
+        this.trafficRimTimer = 1;
+        this.trafficRimDone = applyTrafficSunRim(this.cache);
+      }
+    }
     if (this.vehicle) {
       this.updatePhysicsControls(dt, input, solids);
       return;
@@ -990,6 +1036,9 @@ export class Car {
       w.node.rotation.x = this.wheelSpin;
       if (w.front) w.node.rotation.y = this.steerSmoothed * -0.42;
     }
+    // No per-wheel suspension in the kinematic fallback — travels stay at
+    // rest, only the airborne fade animates.
+    this.contactShadow.update(dt, !this.airborne);
 
     this.syncTransform(dt);
   }

--- a/games/crazy-waymo/src/vehicle/contact-shadow.ts
+++ b/games/crazy-waymo/src/vehicle/contact-shadow.ts
@@ -12,8 +12,8 @@ import { SKID_LIFT } from "../fx/skids";
 export const SHADOW_LOBE_R = 0.56; // lobe radius at rest
 export const SHADOW_DROOP = 0.1; // droop past which no contact patch remains
 export const SHADOW_LOAD = 0.09; // compression at which the patch is tightest
-export const SHADOW_LOBE_MAX = 0.66; // peak occlusion at contact
-export const SHADOW_BODY = 0.38; // chassis-ellipse occlusion
+export const SHADOW_LOBE_MAX = 0.78; // peak occlusion at contact
+export const SHADOW_BODY = 0.46; // chassis-ellipse occlusion
 // Never black, COOL — reads as sky occlusion, not a paint stain.
 export const SHADOW_TINT = 0x0c161c;
 // Clearance over the draped asphalt: same worst-case budget as skid marks

--- a/games/crazy-waymo/src/vehicle/contact-shadow.ts
+++ b/games/crazy-waymo/src/vehicle/contact-shadow.ts
@@ -1,0 +1,159 @@
+import * as THREE from "three";
+
+import { SKID_LIFT } from "../fx/skids";
+
+// Analytic contact shadow under the player: ONE quad whose fragment shader
+// evaluates a soft body ellipse plus four wheel lobes at the actual axle
+// positions, driven per-frame from suspension travel — a loaded wheel reads
+// as a small hard patch, a drooped one as a wide faint skirt. It runs at
+// every hour and on phones, so it is the grounding that survives the shadow
+// map's low-sun fade and the composer-less mobile path (no AO there at all).
+
+export const SHADOW_LOBE_R = 0.56; // lobe radius at rest
+export const SHADOW_DROOP = 0.1; // droop past which no contact patch remains
+export const SHADOW_LOAD = 0.09; // compression at which the patch is tightest
+export const SHADOW_LOBE_MAX = 0.66; // peak occlusion at contact
+export const SHADOW_BODY = 0.38; // chassis-ellipse occlusion
+// Never black, COOL — reads as sky occlusion, not a paint stain.
+export const SHADOW_TINT = 0x0c161c;
+// Clearance over the draped asphalt: same worst-case budget as skid marks
+// (asphalt lift + drape bow), plus a hair so the blob sits under fresh marks.
+// polygonOffset carries the rest at grazing angles, per the SKID_LIFT pattern.
+export const SHADOW_LIFT = SKID_LIFT + 0.02;
+// Whole-shadow fade when the car leaves the ground (the quad rides the car,
+// so airborne it must vanish instead of floating a dark plate mid-air).
+const AIR_FADE_RATE = 9;
+// Body-ellipse radii and quad half-extents derived from the wheel footprint
+// (the reference kart ran ellipse 0.76/0.96 over a 0.72/0.74 footprint).
+const BODY_RADIUS_X = 1.06;
+const BODY_RADIUS_Z = 1.3;
+const QUAD_MARGIN = 0.95;
+
+// Fitted GLB skins have their wheels baked in (no wheel nodes) — a nominal
+// sedan footprint stands in.
+const DEFAULT_LAYOUT: readonly { x: number; z: number }[] = [
+  { x: -0.62, z: 1.28 },
+  { x: 0.62, z: 1.28 },
+  { x: -0.62, z: -1.28 },
+  { x: 0.62, z: -1.28 },
+];
+
+const VERT = /* glsl */ `
+varying vec2 vP;
+void main() {
+	vP = position.xz;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`;
+
+const FRAG = /* glsl */ `
+uniform vec3 uTint;
+uniform float uBodyK;
+uniform vec2 uBodyRadii;
+uniform vec2 uHalf;
+uniform vec4 uLobe[ 4 ]; // xy = centre, z = radius, w = strength
+varying vec2 vP;
+
+float lobe( vec2 c, float r, float k ) {
+	float d = length( vP - c );
+	float t = clamp( d / max( r, 1e-3 ), 0.0, 1.0 );
+	float skirt = 1.0 - t * t * ( 3.0 - 2.0 * t ); // wide AO of a wheel-sized object
+	float u = clamp( d / max( r * 0.40, 1e-3 ), 0.0, 1.0 );
+	float core = 1.0 - u * u * ( 3.0 - 2.0 * u ); // the contact patch itself
+	return k * clamp( 0.45 * skirt + 0.55 * core, 0.0, 1.0 );
+}
+
+void main() {
+	float body = uBodyK * ( 1.0 - smoothstep( 0.55, 1.0, length( vP / uBodyRadii ) ) );
+	float occ = body;
+	for ( int i = 0; i < 4; i ++ ) {
+		float l = lobe( uLobe[ i ].xy, uLobe[ i ].z, uLobe[ i ].w );
+		occ = occ + l - occ * l; // screen blend: lobes can't stack to black
+	}
+	vec2 g = abs( vP ) / uHalf;
+	occ *= ( 1.0 - smoothstep( 0.74, 0.98, g.x ) ) * ( 1.0 - smoothstep( 0.74, 0.98, g.y ) );
+	if ( occ < 0.004 ) discard;
+	gl_FragColor = vec4( uTint, occ );
+}
+`;
+
+export class ContactShadow {
+  readonly mesh: THREE.Mesh;
+  private uBodyK = { value: SHADOW_BODY };
+  private uBodyRadii = { value: new THREE.Vector2(1, 1) };
+  private uHalf = { value: new THREE.Vector2(1, 1) };
+  private uLobe = {
+    value: [new THREE.Vector4(), new THREE.Vector4(), new THREE.Vector4(), new THREE.Vector4()],
+  };
+  // Suspension travel per lobe (+ = compressed past rest, - = drooping).
+  private travels = [0, 0, 0, 0];
+  private airFade = 1;
+
+  constructor() {
+    // Unit quad in XZ; footprint size lands in mesh.scale (setLayout) so the
+    // bounding sphere — and frustum culling — track it.
+    const geo = new THREE.PlaneGeometry(2, 2);
+    geo.rotateX(-Math.PI / 2);
+    const mat = new THREE.ShaderMaterial({
+      uniforms: {
+        uTint: { value: new THREE.Color(SHADOW_TINT) },
+        uBodyK: this.uBodyK,
+        uBodyRadii: this.uBodyRadii,
+        uHalf: this.uHalf,
+        uLobe: this.uLobe,
+      },
+      vertexShader: VERT,
+      fragmentShader: FRAG,
+      transparent: true,
+      depthWrite: false,
+      polygonOffset: true,
+      polygonOffsetFactor: -4,
+      polygonOffsetUnits: -16,
+    });
+    this.mesh = new THREE.Mesh(geo, mat);
+    this.mesh.renderOrder = -1; // under skids (0) and trails (2)
+    this.setLayout(DEFAULT_LAYOUT);
+  }
+
+  /** Wheel contact points in body space; falls back to a sedan footprint when
+   *  a skin has no wheel nodes. Call again on skin swap. */
+  setLayout(wheels: readonly { x: number; z: number }[]): void {
+    const pts = wheels.length >= 4 ? wheels : DEFAULT_LAYOUT;
+    let maxX = 0;
+    let maxZ = 0;
+    for (let i = 0; i < 4; i++) {
+      const p = pts[i];
+      if (!p) continue;
+      this.uLobe.value[i]?.set(p.x, p.z, SHADOW_LOBE_R, 0);
+      maxX = Math.max(maxX, Math.abs(p.x));
+      maxZ = Math.max(maxZ, Math.abs(p.z));
+    }
+    this.uBodyRadii.value.set(maxX * BODY_RADIUS_X, maxZ * BODY_RADIUS_Z);
+    const hx = maxX + QUAD_MARGIN;
+    const hz = maxZ + QUAD_MARGIN;
+    this.uHalf.value.set(hx, hz);
+    // Geometry spans [-1,1]; vP must be in body units, so scale does both.
+    this.mesh.scale.set(hx, 1, hz);
+  }
+
+  setWheelTravel(i: number, travel: number): void {
+    if (i >= 0 && i < 4) this.travels[i] = travel;
+  }
+
+  update(dt: number, grounded: boolean): void {
+    const target = grounded ? 1 : 0;
+    this.airFade += (target - this.airFade) * Math.min(1, dt * AIR_FADE_RATE);
+    this.uBodyK.value = SHADOW_BODY * this.airFade;
+    for (let i = 0; i < 4; i++) {
+      const travel = this.travels[i] ?? 0;
+      const planted = THREE.MathUtils.clamp((travel + SHADOW_DROOP) / SHADOW_DROOP, 0, 1);
+      const load = THREE.MathUtils.clamp(travel / SHADOW_LOAD, 0, 1);
+      const u = this.uLobe.value[i];
+      if (!u) continue;
+      // Loaded = the same darkness in a smaller lobe (reads as weight);
+      // drooped = wide and faint, then gone.
+      u.z = SHADOW_LOBE_R * (1 + 0.3 * (1 - planted) - 0.22 * load);
+      u.w = SHADOW_LOBE_MAX * planted * this.airFade;
+    }
+  }
+}

--- a/games/crazy-waymo/src/vehicle/lacquer.ts
+++ b/games/crazy-waymo/src/vehicle/lacquer.ts
@@ -1,0 +1,309 @@
+import * as THREE from "three";
+
+import { rimGlsl } from "./sun-rim";
+
+// Two-lobe lacquer for the player-class clearcoat bodies: the base coat
+// carries a fine 6mm-ish "dimple" normal field, the clearcoat carries its OWN
+// longer-wave orange-peel at an incommensurate tile — two disagreeing
+// highlights is what reads as lacquer instead of clay. A coat-roughness map
+// hazes the flanks while the crown stays near-mirror, and a chroma-clamped
+// env response keeps the paint hue in charge of its own reflections across
+// the whole day-night sweep.
+//
+// All maps are canvas-baked once at boot from a deterministic LCG, in a
+// single 256px tile per map (kit UVs are palette lookups, so the shader
+// samples these by an object-space box projection instead of mesh uv).
+
+// Tile sizes in body units (~metres). 0.167 and 0.588 share no small factor,
+// so the two peel fields never phase-lock.
+export const PAINT_TILE = 0.167;
+export const COAT_TILE = 0.588;
+// Tangent-space tilt applied to each sampled peel normal (base ~2 deg,
+// coat ~7 deg — the coat lobe is the visible one, by design).
+export const PAINT_NORMAL_SCALE = 0.1;
+export const COAT_NORMAL_SCALE = 0.12;
+// Coat roughness span. The reference ran 0.026..0.086; the floor is raised to
+// 0.04 because waymo's env cube is a 64px gradient and a nearer-mirror coat
+// resolves its banding.
+export const COAT_ROUGH_MIN = 0.04;
+export const COAT_ROUGH_MAX = 0.086;
+// Env response (dimensionless ratios — exposure-independent): energy dims
+// head-on and brightens at grazing (a real Fresnel ramp), while the
+// reflection keeps LUMINANCE and gives up CHROMA so a violet sunset cannot
+// out-vote the pigment. Fresnel direction matters: brightening at grazing is
+// lacquer, the inverse is terracotta.
+export const PAINT_ENV_FACE_SCALE = 0.82;
+export const PAINT_ENV_GRAZE_SCALE = 1.3;
+export const PAINT_ENV_FACE_CHROMA = 0.45;
+export const PAINT_ENV_GRAZE_CHROMA = 0.26;
+export const PAINT_ENV_POWER = 3.0;
+
+const TEX_SIZE = 256;
+// Slope gain applied when the height fields become normal maps — sets how
+// much of the [-1,1] tangent range each map uses before the *_NORMAL_SCALE.
+const BASE_SOBEL_GAIN = 3.0;
+const COAT_SOBEL_GAIN = 5.0;
+const SWIRL_COUNT = 46;
+const SWIRL_ALPHA = 0.13;
+
+function lcg(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+// Seamless value noise: bilinear-smoothstep interpolation of a wrapped random
+// lattice. `cells` must divide `size`.
+function addNoise(
+  field: Float32Array,
+  size: number,
+  cells: number,
+  amp: number,
+  rand: () => number,
+): void {
+  const lattice = new Float32Array(cells * cells);
+  for (let i = 0; i < lattice.length; i++) lattice[i] = rand() * 2 - 1;
+  const step = size / cells;
+  for (let y = 0; y < size; y++) {
+    const cy = Math.floor(y / step);
+    const fy = THREE.MathUtils.smoothstep((y - cy * step) / step, 0, 1);
+    const y0 = cy % cells;
+    const y1 = (cy + 1) % cells;
+    for (let x = 0; x < size; x++) {
+      const cx = Math.floor(x / step);
+      const fx = THREE.MathUtils.smoothstep((x - cx * step) / step, 0, 1);
+      const x0 = cx % cells;
+      const x1 = (cx + 1) % cells;
+      const a = lattice[y0 * cells + x0] ?? 0;
+      const b = lattice[y0 * cells + x1] ?? 0;
+      const c = lattice[y1 * cells + x0] ?? 0;
+      const d = lattice[y1 * cells + x1] ?? 0;
+      const v = a + (b - a) * fx + (c - a + (d - c) * fx - (b - a) * fx) * fy;
+      const idx = y * size + x;
+      field[idx] = (field[idx] ?? 0) + v * amp;
+    }
+  }
+}
+
+// Faint polish-swirl arc strokes composited into a height field via canvas.
+// Returns the field unchanged when no 2d context exists (headless boots).
+function addSwirls(field: Float32Array, size: number, rand: () => number): Float32Array {
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  if (!ctx) return field;
+  const img = ctx.createImageData(size, size);
+  for (let i = 0; i < field.length; i++) {
+    const v = Math.round(THREE.MathUtils.clamp((field[i] ?? 0) * 0.5 + 0.5, 0, 1) * 255);
+    img.data[i * 4] = v;
+    img.data[i * 4 + 1] = v;
+    img.data[i * 4 + 2] = v;
+    img.data[i * 4 + 3] = 255;
+  }
+  ctx.putImageData(img, 0, 0);
+  ctx.globalAlpha = SWIRL_ALPHA;
+  ctx.strokeStyle = "#ffffff";
+  for (let i = 0; i < SWIRL_COUNT; i++) {
+    ctx.lineWidth = 1.8 + rand() * 1.6;
+    const r = size * (0.1 + rand() * 0.45);
+    const a0 = rand() * Math.PI * 2;
+    ctx.beginPath();
+    ctx.arc(rand() * size, rand() * size, r, a0, a0 + 0.5 + rand() * 1.6);
+    ctx.stroke();
+  }
+  const out = ctx.getImageData(0, 0, size, size);
+  for (let i = 0; i < field.length; i++) {
+    field[i] = ((out.data[i * 4] ?? 128) / 255) * 2 - 1;
+  }
+  return field;
+}
+
+function makeTexture(data: Uint8Array, size: number): THREE.DataTexture {
+  const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.magFilter = THREE.LinearFilter;
+  tex.minFilter = THREE.LinearMipmapLinearFilter;
+  tex.generateMipmaps = true;
+  tex.needsUpdate = true;
+  return tex;
+}
+
+// Wrapped central-difference slopes -> tangent-space normal map.
+function normalMapFrom(field: Float32Array, size: number, gain: number): THREE.DataTexture {
+  const data = new Uint8Array(size * size * 4);
+  for (let y = 0; y < size; y++) {
+    const yn = (y + size - 1) % size;
+    const yp = (y + 1) % size;
+    for (let x = 0; x < size; x++) {
+      const xn = (x + size - 1) % size;
+      const xp = (x + 1) % size;
+      const dx = ((field[y * size + xp] ?? 0) - (field[y * size + xn] ?? 0)) * 0.5 * gain;
+      const dy = ((field[yp * size + x] ?? 0) - (field[yn * size + x] ?? 0)) * 0.5 * gain;
+      const inv = 1 / Math.hypot(dx, dy, 1);
+      const o = (y * size + x) * 4;
+      data[o] = Math.round((-dx * inv * 0.5 + 0.5) * 255);
+      data[o + 1] = Math.round((-dy * inv * 0.5 + 0.5) * 255);
+      data[o + 2] = Math.round((inv * 0.5 + 0.5) * 255);
+      data[o + 3] = 255;
+    }
+  }
+  return makeTexture(data, size);
+}
+
+function grayMapFrom(field: Float32Array, size: number): THREE.DataTexture {
+  const data = new Uint8Array(size * size * 4);
+  for (let i = 0; i < field.length; i++) {
+    const v = Math.round(THREE.MathUtils.clamp((field[i] ?? 0) * 0.5 + 0.5, 0, 1) * 255);
+    data[i * 4] = v;
+    data[i * 4 + 1] = v;
+    data[i * 4 + 2] = v;
+    data[i * 4 + 3] = 255;
+  }
+  return makeTexture(data, size);
+}
+
+type LacquerMaps = {
+  readonly baseNormal: THREE.DataTexture;
+  readonly coatNormal: THREE.DataTexture;
+  readonly coatRough: THREE.DataTexture;
+};
+
+let baked: LacquerMaps | null = null;
+
+function lacquerMaps(): LacquerMaps {
+  if (baked) return baked;
+  // Base coat: ~6mm dimple (8px at the 167mm tile) + a finer half-amp octave
+  // + polish swirls.
+  const rand = lcg(0x5eed_ca11);
+  const base = new Float32Array(TEX_SIZE * TEX_SIZE);
+  addNoise(base, TEX_SIZE, 32, 0.6, rand);
+  addNoise(base, TEX_SIZE, 64, 0.25, rand);
+  addSwirls(base, TEX_SIZE, rand);
+  // Clearcoat: long-wave spray flow plus a ~19mm orange-peel octave (8px at
+  // the 588mm tile), summed into ONE height so both share a slope field.
+  const coat = new Float32Array(TEX_SIZE * TEX_SIZE);
+  addNoise(coat, TEX_SIZE, 4, 0.36, rand);
+  addNoise(coat, TEX_SIZE, 32, 0.39, rand);
+  // Coat roughness: panel-sized sweeps, not grain — smaller cells read as a
+  // dirt map.
+  const rough = new Float32Array(TEX_SIZE * TEX_SIZE);
+  addNoise(rough, TEX_SIZE, 4, 0.8, rand);
+  addNoise(rough, TEX_SIZE, 8, 0.3, rand);
+  baked = {
+    baseNormal: normalMapFrom(base, TEX_SIZE, BASE_SOBEL_GAIN),
+    coatNormal: normalMapFrom(coat, TEX_SIZE, COAT_SOBEL_GAIN),
+    coatRough: grayMapFrom(rough, TEX_SIZE),
+  };
+  return baked;
+}
+
+const LUMA = "vec3( 0.2126, 0.7152, 0.0722 )";
+
+const LACQUER_PARS = /* glsl */ `
+#include <common>
+uniform sampler2D uPeelBase;
+uniform sampler2D uPeelCoat;
+uniform sampler2D uCoatRough;
+varying vec3 vLacquerPos;
+varying vec3 vLacquerN;
+vec2 lacquerUv( const in float tile ) {
+	vec3 a = abs( vLacquerN );
+	vec2 p = a.y > max( a.x, a.z ) ? vLacquerPos.xz : ( a.x > a.z ? vLacquerPos.zy : vLacquerPos.xy );
+	return p / tile;
+}
+mat3 lacquerTangentFrame( vec3 eye_pos, vec3 surf_norm, vec2 uv ) {
+	vec3 q0 = dFdx( eye_pos.xyz );
+	vec3 q1 = dFdy( eye_pos.xyz );
+	vec2 st0 = dFdx( uv.st );
+	vec2 st1 = dFdy( uv.st );
+	vec3 N = surf_norm;
+	vec3 q1perp = cross( q1, N );
+	vec3 q0perp = cross( N, q0 );
+	vec3 T = q1perp * st0.x + q0perp * st1.x;
+	vec3 B = q1perp * st0.y + q0perp * st1.y;
+	float det = max( dot( T, T ), dot( B, B ) );
+	float scale = ( det == 0.0 ) ? 0.0 : inversesqrt( det );
+	return mat3( T * scale, B * scale, N );
+}
+`;
+
+const BASE_PEEL = /* glsl */ `
+#include <normal_fragment_maps>
+{
+	vec2 peelUv = lacquerUv( ${PAINT_TILE.toFixed(4)} );
+	vec3 peelN = texture2D( uPeelBase, peelUv ).xyz * 2.0 - 1.0;
+	peelN.xy *= ${PAINT_NORMAL_SCALE.toFixed(4)};
+	normal = normalize( lacquerTangentFrame( - vViewPosition, normal, peelUv ) * peelN );
+}
+`;
+
+const COAT_PEEL = /* glsl */ `
+#include <clearcoat_normal_fragment_maps>
+#ifdef USE_CLEARCOAT
+{
+	vec2 coatUv = lacquerUv( ${COAT_TILE.toFixed(4)} );
+	vec3 coatN = texture2D( uPeelCoat, coatUv ).xyz * 2.0 - 1.0;
+	coatN.xy *= ${COAT_NORMAL_SCALE.toFixed(4)};
+	clearcoatNormal = normalize( lacquerTangentFrame( - vViewPosition, clearcoatNormal, coatUv ) * coatN );
+}
+#endif
+`;
+
+// Overrides the include's uniform clearcoatRoughness; geometryRoughness (the
+// derivative anti-alias term) is re-added because the assignment drops it.
+const COAT_ROUGH = /* glsl */ `
+#include <lights_physical_fragment>
+#ifdef USE_CLEARCOAT
+material.clearcoatRoughness = min( mix( ${COAT_ROUGH_MIN.toFixed(4)}, ${COAT_ROUGH_MAX.toFixed(4)}, texture2D( uCoatRough, lacquerUv( ${COAT_TILE.toFixed(4)} ) ).g ) + geometryRoughness, 1.0 );
+#endif
+`;
+
+const ENV_RESPONSE = /* glsl */ `
+{
+	float envF = pow( 1.0 - saturate( dot( geometryNormal, geometryViewDir ) ), ${PAINT_ENV_POWER.toFixed(2)} );
+	float envScale = mix( ${PAINT_ENV_FACE_SCALE.toFixed(2)}, ${PAINT_ENV_GRAZE_SCALE.toFixed(2)}, envF );
+	float envChroma = mix( ${PAINT_ENV_FACE_CHROMA.toFixed(2)}, ${PAINT_ENV_GRAZE_CHROMA.toFixed(2)}, envF );
+	radiance = mix( vec3( dot( radiance, ${LUMA} ) ), radiance, envChroma ) * envScale;
+	#ifdef USE_CLEARCOAT
+	clearcoatRadiance = mix( vec3( dot( clearcoatRadiance, ${LUMA} ) ), clearcoatRadiance, envChroma ) * envScale;
+	#endif
+}
+#include <lights_fragment_end>
+`;
+
+/**
+ * Inject the two-lobe lacquer + env response + sun rim into a fresh
+ * player-class clearcoat clone. The material's own clearcoatRoughness value
+ * becomes dead — the baked map drives it.
+ */
+export function applyLacquer(m: THREE.MeshPhysicalMaterial, rimStrength: number): void {
+  const maps = lacquerMaps();
+  m.onBeforeCompile = (shader) => {
+    shader.uniforms.uPeelBase = { value: maps.baseNormal };
+    shader.uniforms.uPeelCoat = { value: maps.coatNormal };
+    shader.uniforms.uCoatRough = { value: maps.coatRough };
+    shader.vertexShader = shader.vertexShader
+      .replace(
+        "#include <common>",
+        "#include <common>\nvarying vec3 vLacquerPos;\nvarying vec3 vLacquerN;",
+      )
+      .replace(
+        "#include <beginnormal_vertex>",
+        "#include <beginnormal_vertex>\n\tvLacquerN = objectNormal;",
+      )
+      .replace("#include <begin_vertex>", "#include <begin_vertex>\n\tvLacquerPos = transformed;");
+    shader.fragmentShader = shader.fragmentShader
+      .replace("#include <common>", LACQUER_PARS)
+      .replace("#include <normal_fragment_maps>", BASE_PEEL)
+      .replace("#include <clearcoat_normal_fragment_maps>", COAT_PEEL)
+      .replace("#include <lights_physical_fragment>", COAT_ROUGH)
+      .replace("#include <lights_fragment_end>", ENV_RESPONSE)
+      .replace("#include <opaque_fragment>", rimGlsl(rimStrength));
+  };
+  const key = `waymo-lacquer|rim:${rimStrength.toFixed(2)}`;
+  m.customProgramCacheKey = () => key;
+}

--- a/games/crazy-waymo/src/vehicle/sun-rim.ts
+++ b/games/crazy-waymo/src/vehicle/sun-rim.ts
@@ -1,0 +1,97 @@
+import * as THREE from "three";
+
+import type { ModelCache } from "../assets/loader";
+import { modelUrl, POLICE_CAR, SERVICE_CARS, TRAFFIC_CARS } from "../assets/manifest";
+
+// Sun-rim kicker: outgoingLight += sun * fresnel^4 * lit^2 * strength, gated
+// on the fragment's OWN lit luminance — needs no sun-direction uniform, can
+// never light the shadow side, and dies in tunnels/at night by itself. The
+// tint rides three's `directionalLights[0]` uniform (color x intensity, the
+// day-night cycle writes it every frame), so golden-hour rims come out warm
+// and the night moon (cool, 0.3-ish intensity) starves the rim before the
+// luminance gate even bites.
+//
+// Strengths re-derived for waymo's exposure: the reference ran a unit warm
+// tint (lum 0.73) at exposure 1.05; waymo's live sun uniform carries
+// intensity too (lum ~1.13 at the golden stop) at exposure 0.70, so the same
+// 0.72 lands within 2% of the reference's displayed rim.
+export const RIM_HERO = 0.72;
+export const RIM_TRAFFIC = 0.3;
+// clamp(luma(outgoingLight) * gain): saturates on any sunlit fragment, floors
+// out in shade — the gain sets where "lit" begins in pre-tonemap radiance.
+export const RIM_LIT_GAIN = 2.4;
+
+/**
+ * Fragment replacement for `#include <opaque_fragment>` (strength baked as a
+ * literal — pair every distinct strength with its own customProgramCacheKey).
+ */
+export function rimGlsl(strength: number): string {
+  return /* glsl */ `
+#if NUM_DIR_LIGHTS > 0
+{
+	float rimNdv = abs( dot( normalize( vViewPosition ), normal ) );
+	float rimFres = pow( 1.0 - clamp( rimNdv, 0.0, 1.0 ), 4.0 );
+	float rimLit = clamp( dot( outgoingLight, vec3( 0.2126, 0.7152, 0.0722 ) ) * ${RIM_LIT_GAIN.toFixed(2)}, 0.0, 1.0 );
+	outgoingLight += directionalLights[ 0 ].color * ( rimFres * rimLit * rimLit * ${strength.toFixed(2)} );
+}
+#endif
+#include <opaque_fragment>
+`;
+}
+
+const rimApplied = new WeakSet<THREE.Material>();
+
+/** Rim-only injection for materials that keep their own lighting model
+ *  (traffic kit materials, generated-GLB player skins). Idempotent, and it
+ *  chains any injection already on the shared material instead of clobbering
+ *  it (three can't see inside onBeforeCompile — the cache key chains too). */
+export function applySunRim(mat: THREE.MeshStandardMaterial, strength: number): void {
+  if (rimApplied.has(mat)) return;
+  rimApplied.add(mat);
+  const key = `waymo-sun-rim:${strength.toFixed(2)}`;
+  const prev = mat.onBeforeCompile;
+  const prevKey = Object.prototype.hasOwnProperty.call(mat, "customProgramCacheKey")
+    ? mat.customProgramCacheKey.bind(mat)
+    : null;
+  mat.onBeforeCompile = (shader, renderer) => {
+    prev(shader, renderer);
+    shader.fragmentShader = shader.fragmentShader.replace(
+      "#include <opaque_fragment>",
+      rimGlsl(strength),
+    );
+  };
+  mat.customProgramCacheKey = () => (prevKey ? `${prevKey()}|` : "") + key;
+  mat.needsUpdate = true;
+}
+
+// Traffic + parked cars share the deduped kit materials, so patching the
+// materials reachable from each traffic model rims every fleet/curb instance
+// at once. KayKit cars are deliberately absent: their colormap is shared with
+// KayKit BUILDINGS, and a rimmed facade is the leak this list exists to avoid.
+const TRAFFIC_RIM_MODELS: readonly string[] = [...TRAFFIC_CARS, ...SERVICE_CARS, POLICE_CAR];
+const rimmedModels = new Set<string>();
+
+/**
+ * Patch the shared traffic-kit materials. Traffic GLBs stream behind the
+ * title (late preload), so this is retried until every model resolves to a
+ * real template — returns true once all are patched.
+ */
+export function applyTrafficSunRim(cache: ModelCache): boolean {
+  for (const name of TRAFFIC_RIM_MODELS) {
+    if (rimmedModels.has(name)) continue;
+    const inst = cache.instance(modelUrl("cars", name));
+    let loaded = false;
+    inst.traverse((c) => {
+      // instance() tags real template meshes with userData.src; the magenta
+      // fallback box (model not loaded yet) carries no tag.
+      if (!(c instanceof THREE.Mesh) || !("src" in c.userData)) return;
+      loaded = true;
+      const m = c.material;
+      if (!Array.isArray(m) && m instanceof THREE.MeshStandardMaterial) {
+        applySunRim(m, RIM_TRAFFIC);
+      }
+    });
+    if (loaded) rimmedModels.add(name);
+  }
+  return rimmedModels.size === TRAFFIC_RIM_MODELS.length;
+}

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -14,6 +14,7 @@ import {
   GARAGE_MODEL,
 } from "../assets/manifest";
 import { registerBeacons } from "../fx/beacon-lights";
+import { applyMaterialBreakup, CITY_BREAKUP } from "../render/material-breakup";
 import { liveQuality } from "../render/quality";
 import {
   CHUNK,
@@ -681,6 +682,9 @@ function materialFactory(): (m: MatRec) => BakedMaterial {
             transparent: m.transparent,
             opacity: m.opacity,
           });
+      // Baked-path rebuilds of the live materials (plinths, seawall, prisms)
+      // must carry the same surface breakup the cold-gen path gets below.
+      applyMaterialBreakup(mat, CITY_BREAKUP);
       mats.set(k, mat);
     }
     return mat;
@@ -3405,6 +3409,10 @@ export class CityModel {
       await this.breathe();
       onProgress?.(batchN / batchBuckets.size);
       batchN++;
+      // Whole-city macro breakup + specular AA on every batched lit material
+      // (kit facades, plinths, prisms, props); idempotent across both load
+      // paths, and a no-op on unlit/transparent/decal buckets.
+      applyMaterialBreakup(bucket.material, CITY_BREAKUP);
       const batched = new THREE.BatchedMesh(
         bucket.items.length,
         bucket.verts,
@@ -3575,6 +3583,9 @@ export class CityModel {
         roughness: 0.95,
         vertexColors: true, // roof/wall split; the instance colour is the mean
       });
+      // The distant-facade tier is where flat speculars crawl the most — the
+      // imposters get the same drift + specular AA as the models they replace.
+      applyMaterialBreakup(boxMat, CITY_BREAKUP);
       const boxN = new Set(boxes.values()).size;
       const imp = new THREE.BatchedMesh(imposters.length, 24 * boxN, 36 * boxN, boxMat);
       imp.castShadow = false;

--- a/games/crazy-waymo/src/world/freeways.ts
+++ b/games/crazy-waymo/src/world/freeways.ts
@@ -2,6 +2,7 @@ import * as THREE from "three";
 
 import { WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
 import type { RoadNetwork } from "./network";
+import { applyMaterialBreakup, ROAD_BREAKUP } from "../render/material-breakup";
 import { WEATHER } from "./masonry";
 import { applyAsphaltSpeckle, lowDetailSurfaces } from "./roads";
 import { SF_FREEWAY_RAMPS, SF_FREEWAYS } from "./sf-freeways";
@@ -126,6 +127,7 @@ applyConcreteWeathering(MAT_CONCRETE);
 // speckle) so ramp mouths merge into the roadway with no material seam.
 const MAT_DECK = new THREE.MeshStandardMaterial({ color: 0x555b68, roughness: 1 });
 applyAsphaltSpeckle(MAT_DECK);
+applyMaterialBreakup(MAT_DECK, ROAD_BREAKUP);
 const MAT_PAINT_WHITE = new THREE.MeshStandardMaterial({
   color: 0xf4f7f4,
   roughness: 0.9,

--- a/games/crazy-waymo/src/world/roads.ts
+++ b/games/crazy-waymo/src/world/roads.ts
@@ -12,6 +12,7 @@ import {
 } from "./conform";
 import { junctionControl } from "./junction-control";
 import type { NetEdge, RoadNetwork } from "./network";
+import { applyMaterialBreakup, ROAD_BREAKUP } from "../render/material-breakup";
 import { busLoadAt, SF_TRANSIT } from "./sf-transit";
 
 // PLANAR-MAP street geometry. Every edge sweep and junction patch is built as
@@ -706,6 +707,9 @@ roughnessFactor *= 1.0 - roadPolish * 0.10;`,
   };
 }
 applyAsphaltSpeckle(MAT_ROAD_BASE);
+// After the speckle so the macro drift chains onto it (shader-side only —
+// never the colour, which is the bin round-trip's identity key).
+applyMaterialBreakup(MAT_ROAD_BASE, ROAD_BREAKUP);
 ROAD_MATERIALS.roadbase = MAT_ROAD_BASE;
 const MAT_ROAD_MARK = new THREE.MeshStandardMaterial({
   color: 0xffffff,


### PR DESCRIPTION
Ports the full [kart-royale](https://github.com/ryancampbell/kart-royale) visual identity onto crazy-waymo, on top of PR #279's grade/AO base. Driven by an 8-reader gap analysis of both codebases; all changes runtime-only (no world rebake, `WORLD_REV` untouched).

## What changed

**Atmosphere / post**
- Day bloom cut 6.5 → 2.1 with a knee drive + radius 0.55 by day; night keeps the tight 0.3 kernel so lamps/stars don't smear. Speed lifts halved — into-sun boost no longer whites out against the new golden veil.
- Fog chroma-drain (hue converges 1.85× faster than value, cap 0.92) + sky↔fog horizon weld below ~3° — the horizon seam can't exist at any hour. Triangular-PDF dither on sky + night dome.
- Golden hour re-authored: SKY_GOLDEN turbidity/mie veil, warmth 1.0 at the 0.40 stop, deeper warm white balance. N8AO to the kart recipe (radius 1.2, intensity 5.0, denoise 2/1).

**Car** (`vehicle/sun-rim.ts`, `contact-shadow.ts`, `lacquer.ts` — new)
- Luminance-gated sun-rim kicker (hero 0.72, traffic 0.3; self-gates at night)
- Analytic 4-lobe contact shadow driven from suspension — grounds the car at night and on phones where AO/shadow map are absent
- Two-lobe lacquer peel normals + chroma-clamped env response

**FX** (`fx/boost-plume.ts` new; tier contracts in `fx/tier.ts` + `fx/reinhard.ts`)
- Boost plume as crossed camera-pivoting ribbons + 3-ring ignition stack
- Drift tier ladder (blue → orange → violet): shape-not-hue escalation, live in-flight recolor, ember jet + 6.5 Hz pulse at top tier, one-frame promotion bursts
- Skids move to MultiplyBlending with tier-tinted scorch; max-channel Reinhard shoulder on every additive shader; retired the ×3.5 spark bloom-gain hack and the legacy `driftPuff` charged-spark emission (it stacked ~300 sprites/s under the new shower and fused into a fireball)
- Grade-side speed combs + edge-weighted radial rush + world-space hero hold-out; world-space speedlines demoted to the phone path

**World / HUD**
- World-space macro breakup + specular AA on batched city/road/freeway-deck materials (decal color identities untouched)
- Ocean 3-lobe sun path + Fresnel cap + horizon dissolve; far-terrain value ladder + azimuth tint; massed cumulus clusters + silver lining
- Warm-ink HUD: rim-light plates, chamfer clips, contour rings, condensed stack, screen-edge drift rails (`hud.setDrift` plumbed), channel-groove speedo

## Verification
- `pnpm typecheck`, `pnpm test` (33/33 world invariants), oxlint/oxfmt clean on touched files
- Same-camera before/after pairs at pinned `?time=` stops (golden/noon/sunset/night) + live drift/boost/mini-turbo drives against the kart-royale reference frames

## Known follow-ups
- Phone tier needs a real device pass (breakup + contact shadow reach the no-composer path)
- Rails show no within-tier-2 progress until `driftCharge01` reports next-tier progress (gameplay seam)
- Night clouds read slightly brighter with the new massing — one tint knob if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVJPnCVQvwtSGKarAVaztj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the full kart-royale visual style to crazy-waymo: atmosphere, car materials, FX, ocean/terrain, and HUD. Adds a parity polish pass for warmer golden hour, AO speckle fixes, tuned drift/boost FX and speed lens, stronger world breakup, and a dark-chart minimap.

- **New Features**
  - Post/bloom: lower day bloom gate with knee/radius tuning; edge-weighted radial rush and angular speed combs; max-channel Reinhard shoulder across additive FX; fast gate now opens at 45% of boost top speed.
  - Sky/fog: chroma-drain fog with sky↔fog horizon weld; golden-hour turbidity/mie veil warmed and exposure tuned; night dome dither; cloud clusters with randomized satellite bearings.
  - Car: luminance-gated sun-rim (hero + traffic), analytic 4-lobe contact shadow (darkened for clearer grounding), two-lobe lacquer with chroma-clamped env.
  - FX: mesh boost plume + ignition rings (speed-scaled); drift tier ladder with live recolor, ember jet + pulse, promotion bursts; skid marks on Multiply with tier scorch; discrete drift sparks with smaller halos and higher throw/rate.
  - World: world-space material breakup + specular AA on city/roads/freeway decks (runtime shader injects, no extra draws), amplitude increased ~1.5×.
  - Ocean/terrain/clouds: 3‑lobe sun path with capped Fresnel and horizon dissolve; far‑terrain value ladder + azimuth tint; clustered cumulus with silver lining.
  - HUD: warm-ink plates, contour rings, screen-edge drift rails, channel-groove speedo; minimap switched to a dark-chart palette.

- **Refactors**
  - Shared tier palette in `fx/tier.ts` used by FX, skids, trails, and HUD; additive shaders use `fx/reinhard.ts`.
  - AO and post tuned to the kart recipe; `n8ao` d.ts extended for denoise iterations and AO denoise increased (radius 4, 2 iterations) to fix paint-speckle fringe.
  - Removed legacy charged-spark `driftPuff`; consolidated FX emission and intensity handling.

<sup>Written for commit 4fb6e5c7113197b55ea74f340784683d83ff213d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

