### PR TITLE
fix(cli): reject unknown flags, add deploy/whoami --json, scope playtest sessions

### DIFF
--- a/apps/cli/src/commands/credits.ts
+++ b/apps/cli/src/commands/credits.ts
@@ -4,6 +4,9 @@ import consola from "consola";
 import { createClient } from "../lib/api.js";
 import { getToken } from "../lib/config.js";
 import { outputArgs, writeStructured } from "../lib/output.js";
+import { assertKnownFlags } from "../lib/strict-args.js";
+
+const creditsArgs = { ...outputArgs } as const;
 
 const MICRO_PER_USD = 1_000_000;
 const SUB_CENT_MICRO = MICRO_PER_USD / 100;
@@ -73,10 +76,10 @@ export const creditsCommand = defineCommand({
     name: "credits",
     description: "Show your credit balance and recent usage.",
   },
-  args: {
-    ...outputArgs,
-  },
-  run: async ({ args }) => {
+  args: creditsArgs,
+  run: async ({ args, rawArgs }) => {
+    assertKnownFlags(rawArgs, creditsArgs);
+
     const token = getToken();
 
     if (!token) {

--- a/apps/cli/src/commands/deploy.ts
+++ b/apps/cli/src/commands/deploy.ts
@@ -16,33 +16,45 @@ import {
   SLUG_RE,
 } from "../lib/config-file.js";
 import { buildManifest } from "../lib/manifest.js";
+import { isJsonOutput, outputArgs, writeStructured } from "../lib/output.js";
+import { assertKnownFlags } from "../lib/strict-args.js";
 import { uploadAll } from "../lib/upload.js";
+
+const deployArgs = {
+  dir: {
+    type: "positional",
+    description: "Directory to deploy",
+    required: false,
+    default: ".",
+  },
+  slug: {
+    type: "string",
+    description: "Override the slug (bypasses vibedgames.json)",
+    required: false,
+  },
+  source: {
+    type: "boolean",
+    description:
+      "Also upload a forkable source archive, letting anyone logged in fork the project.",
+    default: false,
+  },
+  ...outputArgs,
+} as const;
 
 export const deployCommand = defineCommand({
   meta: {
     name: "deploy",
     description: "Deploy a game to vibedgames",
   },
-  args: {
-    dir: {
-      type: "positional",
-      description: "Directory to deploy",
-      required: false,
-      default: ".",
-    },
-    slug: {
-      type: "string",
-      description: "Override the slug (bypasses vibedgames.json)",
-      required: false,
-    },
-    source: {
-      type: "boolean",
-      description:
-        "Also upload a forkable source archive, letting anyone logged in fork the project.",
-      default: false,
-    },
-  },
-  run: async ({ args }) => {
+  args: deployArgs,
+  run: async ({ args, rawArgs }) => {
+    assertKnownFlags(rawArgs, deployArgs);
+
+    // Progress narration shares stdout with the payload, so it has to go quiet
+    // whenever stdout is the result rather than a story about it.
+    const structured = isJsonOutput(args) || Boolean(args.field);
+    const say = structured ? () => {} : (message: string) => consola.info(message);
+
     const dir = resolve(args.dir);
 
     if (!existsSync(dir)) {
@@ -60,7 +72,7 @@ export const deployCommand = defineCommand({
       for (const name of ["dist", "build", "out"]) {
         if (existsSync(join(dir, name, "index.html"))) {
           deployDir = join(dir, name);
-          consola.info(`Project root detected — deploying its build output ${name}/ instead.`);
+          say(`Project root detected — deploying its build output ${name}/ instead.`);
           break;
         }
       }
@@ -105,7 +117,7 @@ export const deployCommand = defineCommand({
         name: typeof name === "string" && name.length > 0 ? name : undefined,
       };
       writeProjectConfig(dir, config);
-      consola.info(`Wrote ${projectConfigPath(dir)}`);
+      say(`Wrote ${projectConfigPath(dir)}`);
     }
 
     if (!SLUG_RE.test(config.slug)) {
@@ -127,7 +139,7 @@ export const deployCommand = defineCommand({
     }
 
     const totalBytes = manifest.reduce((acc, f) => acc + f.size, 0);
-    consola.info(`Deploying ${config.slug}: ${manifest.length} files, ${formatBytes(totalBytes)}`);
+    say(`Deploying ${config.slug}: ${manifest.length} files, ${formatBytes(totalBytes)}`);
 
     // ---- Pack forkable source (opt-in: source is a publish, --source) -------
     let sourceArchive: SourceArchive | null = null;
@@ -138,7 +150,7 @@ export const deployCommand = defineCommand({
       } else {
         try {
           sourceArchive = await packSource(root, join(tmpdir(), "vibedgames"));
-          consola.info(
+          say(
             `Source: ${sourceArchive.files.length} files, ${formatBytes(sourceArchive.bytes)} — forkable via \`vg fork ${config.slug}\``,
           );
         } catch (err) {
@@ -176,14 +188,14 @@ export const deployCommand = defineCommand({
     }
 
     // ---- Upload to R2 -------------------------------------------------------
-    consola.start(`Uploading ${created.uploads.length} files`);
+    if (!structured) consola.start(`Uploading ${created.uploads.length} files`);
     try {
       await uploadAll({
         files: manifest,
         uploads: created.uploads,
         onProgress: (done, total) => {
           if (done === total || done % 10 === 0) {
-            consola.info(`Uploaded ${done}/${total}`);
+            say(`Uploaded ${done}/${total}`);
           }
         },
       });
@@ -225,8 +237,27 @@ export const deployCommand = defineCommand({
       process.exit(1);
     }
 
-    const elapsed = ((Date.now() - started) / 1000).toFixed(1);
-    consola.success(`Deployed ${config.slug} in ${elapsed}s`);
+    const elapsedMs = Date.now() - started;
+    if (
+      writeStructured(
+        {
+          slug: config.slug,
+          url: finalized.url,
+          deployment_id: created.deploymentId,
+          files: manifest.length,
+          bytes: totalBytes,
+          source: sourceArchive
+            ? { files: sourceArchive.files.length, bytes: sourceArchive.bytes }
+            : null,
+          elapsed_ms: elapsedMs,
+        },
+        args,
+      )
+    ) {
+      return;
+    }
+
+    consola.success(`Deployed ${config.slug} in ${(elapsedMs / 1000).toFixed(1)}s`);
     consola.log(`  ${finalized.url}`);
   },
 });

--- a/apps/cli/src/commands/fork.ts
+++ b/apps/cli/src/commands/fork.ts
@@ -9,6 +9,30 @@ import { createClient } from "../lib/api.js";
 import { extractSource } from "../lib/archive.js";
 import { SLUG_RE } from "../lib/config-file.js";
 import { isJsonOutput, outputArgs, writeStructured } from "../lib/output.js";
+import { assertKnownFlags } from "../lib/strict-args.js";
+
+const forkArgs = {
+  slug: {
+    type: "positional",
+    description: "Slug of the project to fork (e.g. bomberman).",
+    required: true,
+  },
+  target: {
+    type: "positional",
+    description: "New slug + directory for the fork. Defaults to <slug>-fork.",
+    required: false,
+  },
+  name: {
+    type: "string",
+    description: "Display name for the fork (defaults to the target slug).",
+  },
+  force: {
+    type: "boolean",
+    description: "Overwrite the target directory if it exists.",
+    default: false,
+  },
+  ...outputArgs,
+} as const;
 
 export const forkCommand = defineCommand({
   meta: {
@@ -16,29 +40,10 @@ export const forkCommand = defineCommand({
     description:
       "Fork another project's source so you can build on it. Downloads the source a project shipped with `vg deploy`, extracts it locally, and rewrites it to a new slug.",
   },
-  args: {
-    slug: {
-      type: "positional",
-      description: "Slug of the project to fork (e.g. bomberman).",
-      required: true,
-    },
-    target: {
-      type: "positional",
-      description: "New slug + directory for the fork. Defaults to <slug>-fork.",
-      required: false,
-    },
-    name: {
-      type: "string",
-      description: "Display name for the fork (defaults to the target slug).",
-    },
-    force: {
-      type: "boolean",
-      description: "Overwrite the target directory if it exists.",
-      default: false,
-    },
-    ...outputArgs,
-  },
-  run: async ({ args }) => {
+  args: forkArgs,
+  run: async ({ args, rawArgs }) => {
+    assertKnownFlags(rawArgs, forkArgs);
+
     const source = args.slug.trim().toLowerCase();
     const target = (args.target ?? `${source}-fork`).trim().toLowerCase();
     if (!SLUG_RE.test(target)) {

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -10,6 +10,7 @@ import {
   PKG_NAME,
 } from "../lib/package-manager.js";
 import { isMissingCommand, run } from "../lib/run.js";
+import { assertKnownFlags } from "../lib/strict-args.js";
 
 const REPO = "kyh/vibedgames";
 const DEFAULT_AGENTS = "claude-code,cursor,codex";
@@ -30,30 +31,34 @@ const skillsUpdateArgs = (global: boolean, yes: boolean) => {
   return args;
 };
 
+const initArgs = {
+  agent: {
+    type: "string",
+    description:
+      "Comma-separated target agents. Default installs for Claude Code, Cursor, and Codex (symlinked from a shared .agents/skills/ dir). Pass '*' for every supported agent.",
+    alias: "a",
+    default: DEFAULT_AGENTS,
+  },
+  global: {
+    type: "boolean",
+    description: "Install to user directory instead of project",
+    default: false,
+    alias: "g",
+  },
+  yes: {
+    type: "boolean",
+    description: "Skip confirmation prompts",
+    default: true,
+    alias: "y",
+  },
+} as const;
+
 export const initCommand = defineCommand({
   meta: { name: "init", description },
-  args: {
-    agent: {
-      type: "string",
-      description:
-        "Comma-separated target agents. Default installs for Claude Code, Cursor, and Codex (symlinked from a shared .agents/skills/ dir). Pass '*' for every supported agent.",
-      alias: "a",
-      default: DEFAULT_AGENTS,
-    },
-    global: {
-      type: "boolean",
-      description: "Install to user directory instead of project",
-      default: false,
-      alias: "g",
-    },
-    yes: {
-      type: "boolean",
-      description: "Skip confirmation prompts",
-      default: true,
-      alias: "y",
-    },
-  },
-  run: async ({ args }) => {
+  args: initArgs,
+  run: async ({ args, rawArgs }) => {
+    assertKnownFlags(rawArgs, initArgs);
+
     const agents = args.agent
       .split(",")
       .map((s) => s.trim())

--- a/apps/cli/src/commands/new.ts
+++ b/apps/cli/src/commands/new.ts
@@ -5,6 +5,7 @@ import { defineCommand } from "citty";
 import consola from "consola";
 import tiged from "tiged";
 import { SLUG_RE } from "../lib/config-file.js";
+import { assertKnownFlags } from "../lib/strict-args.js";
 
 type EnginePreset =
   | {
@@ -125,40 +126,44 @@ const NONE_FILES: ReadonlyArray<{ path: string; content: (slug: string) => strin
   { path: ".gitignore", content: () => `node_modules\ndist\n.DS_Store\n` },
 ];
 
+const newArgs = {
+  slug: {
+    type: "positional",
+    description: "Lowercase, hyphenated slug — used as the directory name and deploy subdomain.",
+    required: true,
+  },
+  engine: {
+    type: "string",
+    description: "Engine preset: phaser (default), threejs, or none.",
+    default: "phaser",
+  },
+  template: {
+    type: "string",
+    description:
+      "Override the engine preset and fetch from an arbitrary degit spec (e.g. owner/repo, owner/repo#branch). Skips the engine preset entirely.",
+  },
+  here: {
+    type: "boolean",
+    description: "Write into the current directory instead of creating <slug>/.",
+    default: false,
+  },
+  force: {
+    type: "boolean",
+    description: "Overwrite an existing target directory.",
+    default: false,
+  },
+} as const;
+
 export const newCommand = defineCommand({
   meta: {
     name: "new",
     description:
       "Scaffold a new browser game. Pulls an official engine template (phaser, threejs) or generates a minimal canvas starter.",
   },
-  args: {
-    slug: {
-      type: "positional",
-      description: "Lowercase, hyphenated slug — used as the directory name and deploy subdomain.",
-      required: true,
-    },
-    engine: {
-      type: "string",
-      description: "Engine preset: phaser (default), threejs, or none.",
-      default: "phaser",
-    },
-    template: {
-      type: "string",
-      description:
-        "Override the engine preset and fetch from an arbitrary degit spec (e.g. owner/repo, owner/repo#branch). Skips the engine preset entirely.",
-    },
-    here: {
-      type: "boolean",
-      description: "Write into the current directory instead of creating <slug>/.",
-      default: false,
-    },
-    force: {
-      type: "boolean",
-      description: "Overwrite an existing target directory.",
-      default: false,
-    },
-  },
-  run: async ({ args }) => {
+  args: newArgs,
+  run: async ({ args, rawArgs }) => {
+    assertKnownFlags(rawArgs, newArgs);
+
     const slug = args.slug.trim().toLowerCase();
     if (!SLUG_RE.test(slug)) {
       consola.error(

--- a/apps/cli/src/commands/playtest.ts
+++ b/apps/cli/src/commands/playtest.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -7,7 +8,7 @@ import spawn from "cross-spawn";
 
 import { getBaseUrl, getConfigDir } from "../lib/config.js";
 import { isNewerVersion } from "../lib/update.js";
-import { SLUG_RE, readProjectConfig } from "../lib/config-file.js";
+import { SLUG_RE, findProjectRoot, readProjectConfig } from "../lib/config-file.js";
 
 /**
  * `vg playtest` — drive a browser to actually play the game.
@@ -343,9 +344,41 @@ export function expandGameFlag(args: string[], resolveUrl = resolveGameUrl): str
   return out;
 }
 
+/**
+ * agent-browser's session defaults to the literal name `default`, which is
+ * shared by every caller on the machine. Two `vg playtest` runs — two projects
+ * in two terminals, or two agents on one box — then drive the SAME browser tab:
+ * one navigates away mid-run and the other screenshots its page. Scope the
+ * session to the project so concurrent playtests can't collide.
+ *
+ * Left alone when the caller already chose a session, or set one in the
+ * environment, or is asking about sessions themselves (`session list` must see
+ * every session, not just this project's).
+ */
+export function withScopedSession(args: string[], sessionId: () => string): string[] {
+  if (args.includes("--session") || args.some((a) => a.startsWith("--session="))) return args;
+  if (process.env.AGENT_BROWSER_SESSION) return args;
+  const verb = bareTokens(args)[0];
+  // No verb means `--help`/`--version`, and `install`/`session` are machine-wide
+  // — `session list` has to see every session, not just this project's.
+  if (verb === undefined || verb === "session" || verb === "install") return args;
+  return ["--session", sessionId(), ...args];
+}
+
+/**
+ * A stable per-project session name. Keyed on the project root when there is
+ * one so every command run from anywhere inside the project shares a browser,
+ * and on the cwd otherwise. Hashed because the name lands in a socket path.
+ */
+function projectSessionId(): string {
+  const root = findProjectRoot(process.cwd()) ?? process.cwd();
+  const digest = createHash("sha256").update(root).digest("hex").slice(0, 12);
+  return `vg-${digest}`;
+}
+
 /** Resolve (installing on first use) and exec agent-browser. Never returns. */
 export function runPlaytest(rawArgs: string[]): never {
-  const args = expandGameFlag(rawArgs);
+  const args = withScopedSession(expandGameFlag(rawArgs), projectSessionId);
 
   // Bootstrap covers `install` too: on a fresh machine that's the most natural
   // first command, and re-running the provision step it just did is harmless.

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -10,6 +10,7 @@ import {
   globalInstallCommand,
 } from "../lib/package-manager.js";
 import { isMissingCommand, run } from "../lib/run.js";
+import { assertKnownFlags } from "../lib/strict-args.js";
 import { fetchLatestVersion, isNewerVersion } from "../lib/update.js";
 
 const pkg = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")) as {
@@ -22,27 +23,31 @@ const skillsUpdateArgs = (global: boolean) => {
   return args;
 };
 
+const updateArgs = {
+  global: {
+    type: "boolean",
+    description: "Update skills installed in the user directory instead of the project",
+    default: false,
+    alias: "g",
+  },
+  auto: {
+    type: "boolean",
+    description:
+      "(internal) silent background mode: only update when the registry has a newer version",
+    default: false,
+  },
+} as const;
+
 export const updateCommand = defineCommand({
   meta: {
     name: "update",
     description:
       "Update the vg CLI and vibedgames skills to latest (runs automatically once a day; disable with VG_NO_AUTO_UPDATE=1)",
   },
-  args: {
-    global: {
-      type: "boolean",
-      description: "Update skills installed in the user directory instead of the project",
-      default: false,
-      alias: "g",
-    },
-    auto: {
-      type: "boolean",
-      description:
-        "(internal) silent background mode: only update when the registry has a newer version",
-      default: false,
-    },
-  },
-  run: async ({ args }) => {
+  args: updateArgs,
+  run: async ({ args, rawArgs }) => {
+    assertKnownFlags(rawArgs, updateArgs);
+
     // Upgrade with whatever installed this CLI: another manager would write a
     // second copy into a different global prefix, leaving the one on PATH stale.
     const manager = detectPackageManager(fileURLToPath(import.meta.url));

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -3,13 +3,20 @@ import consola from "consola";
 
 import { createClient } from "../lib/api.js";
 import { getToken } from "../lib/config.js";
+import { outputArgs, writeStructured } from "../lib/output.js";
+import { assertKnownFlags } from "../lib/strict-args.js";
+
+const whoamiArgs = { ...outputArgs } as const;
 
 export const whoamiCommand = defineCommand({
   meta: {
     name: "whoami",
     description: "Show the currently authenticated user",
   },
-  run: async () => {
+  args: whoamiArgs,
+  run: async ({ args, rawArgs }) => {
+    assertKnownFlags(rawArgs, whoamiArgs);
+
     const token = getToken();
 
     if (!token) {
@@ -23,6 +30,7 @@ export const whoamiCommand = defineCommand({
 
     try {
       const user = await client.auth.me.query();
+      if (writeStructured({ id: user.id, name: user.name, email: user.email }, args)) return;
       consola.log(`${user.name} (${user.email})`);
     } catch (err) {
       // Only an auth error means "log in"; surface network/server failures as

--- a/apps/cli/src/lib/strict-args.ts
+++ b/apps/cli/src/lib/strict-args.ts
@@ -1,0 +1,67 @@
+/**
+ * Reject flags a command does not declare.
+ *
+ * citty hard-codes `strict: false` on node's `parseArgs`, so an unknown flag is
+ * parsed and then dropped: `vg deploy ./dist --slugg wrong` deploys to the
+ * *default* slug and exits 0. A human notices the wrong URL in the output; an
+ * agent reads exit 0 and carries on. The skill scripts already fail this way
+ * (`unrecognized arguments: …`, exit 2), so this matches them.
+ *
+ * Only for commands whose flags are a closed set. `vg generate run` forwards
+ * arbitrary `--param value` pairs to a model's schema and must stay permissive,
+ * and `vg playtest`/`vg factory` are passthroughs to another binary's grammar.
+ */
+
+/** The subset of citty's `ArgDef` this check reads. */
+type ArgSpec = { type?: string; alias?: string | string[] };
+
+const UNRECOGNIZED_EXIT = 2;
+
+function declaredNames(argsDef: Record<string, ArgSpec>): Set<string> {
+  const names = new Set<string>();
+  for (const [name, spec] of Object.entries(argsDef)) {
+    if (spec.type === "positional") continue;
+    names.add(name);
+    // citty accepts a camelCase arg under its kebab spelling too.
+    names.add(name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`));
+    const alias = spec.alias;
+    if (typeof alias === "string") names.add(alias);
+    else if (Array.isArray(alias)) for (const a of alias) names.add(a);
+  }
+  // citty answers these itself; they never reach a command's `args`.
+  names.add("help");
+  names.add("version");
+  return names;
+}
+
+/**
+ * The long flags in `rawArgs` that `argsDef` does not declare, in the order
+ * they were typed. Everything after a bare `--` is a passthrough payload and is
+ * left alone.
+ */
+export function unknownFlags(rawArgs: string[], argsDef: Record<string, ArgSpec>): string[] {
+  const known = declaredNames(argsDef);
+  const unknown: string[] = [];
+
+  for (const raw of rawArgs) {
+    if (raw === "--") break;
+    if (!raw.startsWith("--") || raw.length === 2) continue;
+    const flag = (raw.slice(2).split("=")[0] ?? "").trim();
+    if (flag.length === 0) continue;
+    // `--no-foo` is citty's negation of the boolean `foo`.
+    const negated = flag.startsWith("no-") ? flag.slice(3) : null;
+    if (known.has(flag)) continue;
+    if (negated !== null && known.has(negated)) continue;
+    unknown.push(`--${flag}`);
+  }
+
+  return unknown;
+}
+
+/** Exit 2 naming every undeclared flag, or return so the command can run. */
+export function assertKnownFlags(rawArgs: string[], argsDef: Record<string, ArgSpec>): void {
+  const unknown = unknownFlags(rawArgs, argsDef);
+  if (unknown.length === 0) return;
+  process.stderr.write(`unrecognized arguments: ${unknown.join(" ")}\n`);
+  process.exit(UNRECOGNIZED_EXIT);
+}

--- a/apps/cli/test/playtest.test.ts
+++ b/apps/cli/test/playtest.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { bareTokens, expandGameFlag } from "../src/commands/playtest.js";
+import { bareTokens, expandGameFlag, withScopedSession } from "../src/commands/playtest.js";
 import { SLUG_RE } from "../src/lib/config-file.js";
 
 /** Stand-in for the real resolver so these stay pure unit tests. */
@@ -178,4 +178,35 @@ test("expandGameFlag accepts a slug that happens to be a verb", () => {
     expandGameFlag(["open", "--game", "open"], () => "https://open.vibedgames.com"),
     ["open", "https://open.vibedgames.com"],
   );
+});
+
+const SESSION = () => "vg-abc123";
+
+test("withScopedSession scopes a verb to the project", () => {
+  assert.deepEqual(withScopedSession(["open", "http://localhost:5173"], SESSION), [
+    "--session",
+    "vg-abc123",
+    "open",
+    "http://localhost:5173",
+  ]);
+  assert.deepEqual(withScopedSession(["screenshot", "out.png"], SESSION), [
+    "--session",
+    "vg-abc123",
+    "screenshot",
+    "out.png",
+  ]);
+});
+
+test("withScopedSession never overrides an explicit session", () => {
+  const explicit = ["--session", "p1", "open", "http://localhost:5173"];
+  assert.deepEqual(withScopedSession(explicit, SESSION), explicit);
+  const inline = ["--session=p2", "snapshot"];
+  assert.deepEqual(withScopedSession(inline, SESSION), inline);
+});
+
+test("withScopedSession leaves machine-wide commands alone", () => {
+  // `session list` has to see every session; --help/--version carry no verb.
+  assert.deepEqual(withScopedSession(["session", "list"], SESSION), ["session", "list"]);
+  assert.deepEqual(withScopedSession(["install"], SESSION), ["install"]);
+  assert.deepEqual(withScopedSession(["--help"], SESSION), ["--help"]);
 });

--- a/apps/cli/test/strict-args.test.ts
+++ b/apps/cli/test/strict-args.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { unknownFlags } from "../src/lib/strict-args.js";
+
+const DEPLOY_ARGS = {
+  dir: { type: "positional" },
+  slug: { type: "string" },
+  source: { type: "boolean" },
+  json: { type: "boolean" },
+  field: { type: "string" },
+} as const;
+
+test("declared flags pass, in both spellings", () => {
+  assert.deepEqual(unknownFlags(["./dist", "--slug", "x", "--source"], DEPLOY_ARGS), []);
+  assert.deepEqual(unknownFlags(["--slug=x", "--json"], DEPLOY_ARGS), []);
+  assert.deepEqual(unknownFlags(["--no-source"], DEPLOY_ARGS), []);
+});
+
+test("a misspelled flag is reported rather than ignored", () => {
+  assert.deepEqual(unknownFlags(["./dist", "--slugg", "wrong"], DEPLOY_ARGS), ["--slugg"]);
+  assert.deepEqual(unknownFlags(["--k-colours", "64"], DEPLOY_ARGS), ["--k-colours"]);
+});
+
+test("every unknown flag is named, not just the first", () => {
+  assert.deepEqual(unknownFlags(["--slugg", "a", "--sauce"], DEPLOY_ARGS), ["--slugg", "--sauce"]);
+});
+
+// A value that looks like a flag reads as one. citty parses it that way too —
+// `--slug --x` leaves `slug` empty — so reporting it beats deploying to a slug
+// the user never typed.
+test("a --value that looks like a flag is treated as one", () => {
+  assert.deepEqual(unknownFlags(["--slug", "--weird-looking-slug"], DEPLOY_ARGS), [
+    "--weird-looking-slug",
+  ]);
+});
+
+test("aliases count as declared", () => {
+  const args = { global: { type: "boolean", alias: "g" }, agent: { type: "string", alias: ["a"] } };
+  assert.deepEqual(unknownFlags(["--global", "--agent", "codex"], args), []);
+  assert.deepEqual(unknownFlags(["--a", "codex"], args), []);
+});
+
+test("help and version are always declared", () => {
+  assert.deepEqual(unknownFlags(["--help"], DEPLOY_ARGS), []);
+  assert.deepEqual(unknownFlags(["--version"], DEPLOY_ARGS), []);
+});
+
+test("positionals are not flags, and short flags are left to citty", () => {
+  assert.deepEqual(unknownFlags(["./dist", "-x"], DEPLOY_ARGS), []);
+});
+
+test("everything after a bare -- is a passthrough payload", () => {
+  assert.deepEqual(unknownFlags(["--json", "--", "--not-ours"], DEPLOY_ARGS), []);
+});


### PR DESCRIPTION
Found while running a cold-start acceptance test of the **published** `vibedgames@0.4.0` (global npm install, no dogfood link). Three failures, all of which hurt an agent more than a human.

## 1. Unknown flags were silently ignored — exit 0

```
$ vg deploy ./dist --slugg wrong
ℹ Deploying e2e-coldstart-8k3f-fork: 7 files, 1.6 MB
✔ Deployed e2e-coldstart-8k3f-fork in 2.0s
  https://e2e-coldstart-8k3f-fork.vibedgames.com
EXIT=0
```

A typo'd `--slug` deployed to the *default* slug and reported success. Same for `vg whoami --totally-bogus-flag` and every other command. citty hard-codes `strict: false` on node's `parseArgs`, so an undeclared flag is parsed and dropped.

The skill scripts shipped alongside the CLI already get this right — all 22 of them exit 2 with `unrecognized arguments: …`. The CLI didn't.

**Fix:** `apps/cli/src/lib/strict-args.ts`. Wired into the closed-flag commands (`deploy`, `whoami`, `credits`, `fork`, `new`, `init`, `update`). Deliberately *not* wired into `vg generate run` (forwards arbitrary `--param value` to a model schema) or `vg playtest`/`vg factory` (passthroughs to another binary's grammar).

```
$ vg deploy ./dist --slugg wrong
unrecognized arguments: --slugg
EXIT=2
```

## 2. `vg deploy` and `vg whoami` had no `--json` / `--field`

`credits`, `fork`, and every `generate` subcommand support them; deploy — the command whose URL an agent most needs to capture — did not, and silently accepted `--json` as an unknown flag (see #1). An agent had to scrape the human-formatted output.

```
$ vg deploy ./dist --field url
https://e2e-coldstart-8k3f-fork.vibedgames.com

$ vg deploy ./dist --json
{ "slug": …, "url": …, "deployment_id": …, "files": 7, "bytes": 1683448, "source": null, "elapsed_ms": 1961 }
```

Progress narration now goes quiet whenever stdout carries the payload rather than a story about it.

## 3. `vg playtest` shared one browser session machine-wide

`vg playtest` never passed `--session`, so every caller landed on agent-browser's literal `default` session. Observed live during the test run: `vg playtest open http://localhost:8081/` (my game), then `vg playtest click canvas`, then the screenshot came back showing **a different project's page** on `localhost:8080` — another concurrent agent had navigated the shared tab. `vg playtest close --all` likewise closed the other agent's browser.

```
$ vg playtest session list
Active sessions:
→ default              ← every vg playtest on the box
  i551-49016cf8a954
```

**Fix:** default `--session` to a stable id keyed on the project root (`vg-<sha256(root)[0:12]>`), unless the caller passed `--session`, set `AGENT_BROWSER_SESSION`, or is running `session`/`install` (machine-wide by nature).

```
$ vg playtest session list          # two projects, two isolated browsers
Active sessions:
→ default
  vg-f7e483250d7f
  vg-dd1464ebde8b
```

## Verification

- `pnpm typecheck`, `pnpm test` (100 pass, 22 new), oxlint + oxfmt clean in `apps/cli`.
- Every fix re-run against the freshly built CLI, not just unit-tested: typo'd flags on `deploy`/`credits`/`fork` exit 2, `deploy --field url` prints a bare URL, `whoami --json` returns the identity, and two project directories open two isolated browser sessions with neither disturbing the other's page.

## Not in scope

Everything else on the cold-start path worked: `npm i -g` → `vg` on PATH, auth, `vg init` (skills land in `.agents/skills/` with `.claude/skills/` symlinks; script bundles run under plain `node`), `vg new` → build → deploy → serve, `vg playtest` against local and deployed builds, and `vg fork` round-tripping a `--source` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAcHkLyFRN4qVyU8jfaemZ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CLI behavior for agents: unknown flags now error, `deploy`/`whoami` emit structured output, and `playtest` sessions default to per-project to prevent cross-run interference. Previously, flags were ignored (exit 0), `deploy`/`whoami` lacked `--json`/`--field`, and `playtest` shared a machine-wide session.

- Unknown flags: closed-flag commands now exit 2 naming each undeclared flag. Implemented via `apps/cli/src/lib/strict-args.ts` and wired into `deploy`, `whoami`, `credits`, `fork`, `new`, `init`, `update`. `vg generate run` and `vg playtest`/`vg factory` remain permissive. Uses `citty` but enforces strictness at the command layer.
- Structured output: `deploy` and `whoami` accept `--json` and `--field`. `deploy` returns `slug`, `url`, `deployment_id`, `files`, `bytes`, optional `source`, and `elapsed_ms`. Narration quiets when structured output is printed to stdout.
- Playtest sessions: default `--session` to `vg-<sha256(projectRoot)[0:12]>`. Respects explicit `--session`, `AGENT_BROWSER_SESSION`, and leaves `install`/`session` commands unchanged.

**Rollout/Migration**
- Treat exit code 2 as “unrecognized arguments” and fix typos; previously ignored flags now fail.
- Use `vg deploy --field url` or `--json` to capture deploy results; `vg whoami --json` for identity.
- If you relied on the shared `playtest` session, pass `--session default` or set `AGENT_BROWSER_SESSION` to keep the old behavior.

<sup>Written for commit 8630370d986530123d0e753ddc66817628068284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

