### PR TITLE
fix: four agent-facing defects found in an end-to-end game build

### DIFF
--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -64,10 +64,12 @@ export const initCommand = defineCommand({
     // even be looking at, so `vg --version` would not move.
     const manager = detectPackageManager(fileURLToPath(import.meta.url));
 
-    consola.start("Installing/updating vibedgames skills and the vg CLI...");
+    consola.start(
+      "Installing/updating vibedgames skills and the vg CLI (this takes a few minutes — `skills` fetches the repo once per skill)...",
+    );
 
     const [add, cli] = await Promise.all([
-      run("npx", skillsAddArgs(agents, args.global, args.yes)),
+      run("npx", skillsAddArgs(agents, args.global, args.yes), { stream: true }),
       run(manager, globalInstallArgs(manager)),
     ]);
 
@@ -84,7 +86,9 @@ export const initCommand = defineCommand({
     }
     consola.success(`Installed vibedgames skills for ${agents.join(", ")}`);
 
-    const update = await run("npx", skillsUpdateArgs(args.global, args.yes));
+    const update = await run("npx", skillsUpdateArgs(args.global, args.yes), {
+      stream: true,
+    });
     if (update.code !== 0) {
       if (update.output.trim()) consola.warn(update.output.trim());
       consola.warn(

--- a/apps/cli/src/commands/new.ts
+++ b/apps/cli/src/commands/new.ts
@@ -62,6 +62,9 @@ const ENGINES: Record<string, EnginePreset> = {
   },
 };
 
+// Derived so `--help` and the error message can't drift from the presets again.
+const ENGINE_IDS = Object.keys(ENGINES);
+
 const NONE_FILES: ReadonlyArray<{ path: string; content: (slug: string) => string }> = [
   {
     path: "package.json",
@@ -129,7 +132,7 @@ export const newCommand = defineCommand({
   meta: {
     name: "new",
     description:
-      "Scaffold a new browser game. Pulls an official engine template (phaser, threejs) or generates a minimal canvas starter.",
+      "Scaffold a new browser game. Pulls an engine template (phaser, threejs, react-r3f) or generates a minimal canvas starter.",
   },
   args: {
     slug: {
@@ -139,7 +142,7 @@ export const newCommand = defineCommand({
     },
     engine: {
       type: "string",
-      description: "Engine preset: phaser (default), threejs, or none.",
+      description: `Engine preset: ${ENGINE_IDS.join(", ")} (default: phaser).`,
       default: "phaser",
     },
     template: {
@@ -175,9 +178,7 @@ export const newCommand = defineCommand({
         } as EnginePreset)
       : ENGINES[args.engine];
     if (!preset) {
-      consola.error(
-        `Unknown engine: ${args.engine}. Use one of: ${Object.keys(ENGINES).join(", ")}.`,
-      );
+      consola.error(`Unknown engine: ${args.engine}. Use one of: ${ENGINE_IDS.join(", ")}.`);
       process.exit(1);
     }
 

--- a/apps/cli/src/lib/run.ts
+++ b/apps/cli/src/lib/run.ts
@@ -2,6 +2,15 @@ import spawn from "cross-spawn";
 
 export type RunResult = { code: number; output: string };
 
+export type RunOptions = {
+  /**
+   * Mirror the child's output to this process as it arrives. Long steps
+   * (`npx skills add` clones a repo per skill) otherwise look hung: the
+   * buffered output is only readable once the child has already exited.
+   */
+  stream?: boolean;
+};
+
 /**
  * True when the command never started, as opposed to running and failing.
  * `run` turns a spawn error into an exit code, so the message is the only
@@ -10,12 +19,16 @@ export type RunResult = { code: number; output: string };
 export const isMissingCommand = (result: RunResult): boolean =>
   result.code !== 0 && /ENOENT|not found|not recognized/i.test(result.output);
 
-export const run = (cmd: string, args: string[]): Promise<RunResult> =>
+export const run = (cmd: string, args: string[], options: RunOptions = {}): Promise<RunResult> =>
   new Promise((resolve) => {
     const chunks: Buffer[] = [];
     const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
-    child.stdout?.on("data", (c: Buffer) => chunks.push(c));
-    child.stderr?.on("data", (c: Buffer) => chunks.push(c));
+    const collect = (stream: NodeJS.WriteStream) => (c: Buffer) => {
+      chunks.push(c);
+      if (options.stream) stream.write(c);
+    };
+    child.stdout?.on("data", collect(process.stderr));
+    child.stderr?.on("data", collect(process.stderr));
     child.on("error", (err) => resolve({ code: 1, output: `${err.message}\n` }));
     child.on("close", (code) =>
       resolve({ code: code ?? 1, output: Buffer.concat(chunks).toString("utf8") }),

--- a/packages/asset-tools/src/sprite/prompt.ts
+++ b/packages/asset-tools/src/sprite/prompt.ts
@@ -397,12 +397,14 @@ export function renderAnchorPrompt(
     anchorRole?: string;
     anchorContext?: string | null;
     chroma?: string;
+    guideImage?: boolean;
   } = {},
 ): string {
   const {
     gameView = "platformer",
     anchorRole = "character",
     anchorContext = null,
+    guideImage = false,
     // The matte the anchor is generated on has to be the one the keyer is later
     // told to remove; `--chroma` used to be accepted here and dropped, so asking
     // for magenta produced a green board that `chroma_clean` could not key.
@@ -417,8 +419,11 @@ Game view: ${ANCHOR_GAME_VIEWS[resolvedView]}.
 Asset role: ${ANCHOR_ROLES[resolvedRole]}.
 ${anchorContextGuidance(anchorContext)}
 
-Image 1 role: identity anchor. Preserve the exact approved asset identity, silhouette, proportions, palette blocks, and pixel-art readability from this reference image.
-Image 2 role: pixel-style guide. Use this only to reinforce the crisp pixelated treatment, chunky pixel texture, square canvas discipline, and sprite readability. Do not copy guide pixels, checker patterns, borders, labels, or layout marks into the output.
+Image 1 role: identity anchor. Preserve the exact approved asset identity, silhouette, proportions, palette blocks, and pixel-art readability from this reference image.${
+    guideImage
+      ? "\nImage 2 role: pixel-style guide. Use this only to reinforce the crisp pixelated treatment, chunky pixel texture, square canvas discipline, and sprite readability. Do not copy guide pixels, checker patterns, borders, labels, or layout marks into the output."
+      : ""
+  }
 
 Primary request: generate a single-frame ${direction.promptName} anchor sprite.
 
@@ -754,17 +759,26 @@ export function renderPoseBoardPrompt(
     poseBoard?: PoseBoardPreset | null;
     framePromptStyle?: string;
     chroma?: string;
+    guideImage?: boolean;
   } = {},
 ): string {
-  const { poseBoard = null, framePromptStyle = "specific", chroma = "#00FF00" } = options;
+  const {
+    poseBoard = null,
+    framePromptStyle = "specific",
+    chroma = "#00FF00",
+    guideImage = false,
+  } = options;
   const board = poseBoard ?? resolvePoseBoardPreset("standard");
   const phrase = chromaPhrase(chroma);
   const frameLines = renderFrameGuidance(actionId, frameCount, framePromptStyle);
 
   return `Intended use: a reusable ${actionId} animation spritesheet for a 2D game.
 
-Image 1 role: identity anchor. Preserve the exact approved anchor sprite identity.
-Image 2 role: black-and-white alternating-pixel pose-board geometry guide at the exact target size. Use it only to preserve the output aspect ratio, full-board composition, pixel texture, and implied ${board.columns} column x ${board.rows} row pose-board layout. It is not a background, style, contact-sheet, border, or grid-line reference. Do not copy its black pixels, white pixels, checker pattern, grid lines, borders, labels, or presentation-sheet look into the final output.
+Image 1 role: identity anchor. Preserve the exact approved anchor sprite identity.${
+    guideImage
+      ? `\nImage 2 role: black-and-white alternating-pixel pose-board geometry guide at the exact target size. Use it only to preserve the output aspect ratio, full-board composition, pixel texture, and implied ${board.columns} column x ${board.rows} row pose-board layout. It is not a background, style, contact-sheet, border, or grid-line reference. Do not copy its black pixels, white pixels, checker pattern, grid lines, borders, labels, or presentation-sheet look into the final output.`
+      : ""
+  }
 
 Subject:
 - Same already-approved sprite character.

--- a/plugins/asset-pipeline/skills/animated-spritesheets/scripts/_lib/asset-tools.mjs
+++ b/plugins/asset-pipeline/skills/animated-spritesheets/scripts/_lib/asset-tools.mjs
@@ -3003,6 +3003,7 @@ function renderAnchorPrompt(direction, options = {}) {
     gameView = "platformer",
     anchorRole = "character",
     anchorContext = null,
+    guideImage = false,
     // The matte the anchor is generated on has to be the one the keyer is later
     // told to remove; `--chroma` used to be accepted here and dropped, so asking
     // for magenta produced a green board that `chroma_clean` could not key.
@@ -3016,8 +3017,7 @@ Game view: ${ANCHOR_GAME_VIEWS[resolvedView]}.
 Asset role: ${ANCHOR_ROLES[resolvedRole]}.
 ${anchorContextGuidance(anchorContext)}
 
-Image 1 role: identity anchor. Preserve the exact approved asset identity, silhouette, proportions, palette blocks, and pixel-art readability from this reference image.
-Image 2 role: pixel-style guide. Use this only to reinforce the crisp pixelated treatment, chunky pixel texture, square canvas discipline, and sprite readability. Do not copy guide pixels, checker patterns, borders, labels, or layout marks into the output.
+Image 1 role: identity anchor. Preserve the exact approved asset identity, silhouette, proportions, palette blocks, and pixel-art readability from this reference image.${guideImage ? "\nImage 2 role: pixel-style guide. Use this only to reinforce the crisp pixelated treatment, chunky pixel texture, square canvas discipline, and sprite readability. Do not copy guide pixels, checker patterns, borders, labels, or layout marks into the output." : ""}
 
 Primary request: generate a single-frame ${direction.promptName} anchor sprite.
 
@@ -3295,14 +3295,19 @@ function poseBoardFacingLock(direction) {
   return base;
 }
 function renderPoseBoardPrompt(actionId, direction, frameCount, options = {}) {
-  const { poseBoard = null, framePromptStyle = "specific", chroma = "#00FF00" } = options;
+  const {
+    poseBoard = null,
+    framePromptStyle = "specific",
+    chroma = "#00FF00",
+    guideImage = false
+  } = options;
   const board = poseBoard ?? resolvePoseBoardPreset("standard");
   const phrase = chromaPhrase(chroma);
   const frameLines = renderFrameGuidance(actionId, frameCount, framePromptStyle);
   return `Intended use: a reusable ${actionId} animation spritesheet for a 2D game.
 
-Image 1 role: identity anchor. Preserve the exact approved anchor sprite identity.
-Image 2 role: black-and-white alternating-pixel pose-board geometry guide at the exact target size. Use it only to preserve the output aspect ratio, full-board composition, pixel texture, and implied ${board.columns} column x ${board.rows} row pose-board layout. It is not a background, style, contact-sheet, border, or grid-line reference. Do not copy its black pixels, white pixels, checker pattern, grid lines, borders, labels, or presentation-sheet look into the final output.
+Image 1 role: identity anchor. Preserve the exact approved anchor sprite identity.${guideImage ? `
+Image 2 role: black-and-white alternating-pixel pose-board geometry guide at the exact target size. Use it only to preserve the output aspect ratio, full-board composition, pixel texture, and implied ${board.columns} column x ${board.rows} row pose-board layout. It is not a background, style, contact-sheet, border, or grid-line reference. Do not copy its black pixels, white pixels, checker pattern, grid lines, borders, labels, or presentation-sheet look into the final output.` : ""}
 
 Subject:
 - Same already-approved sprite character.

--- a/plugins/asset-pipeline/skills/animated-spritesheets/scripts/sprite_prompt.mjs
+++ b/plugins/asset-pipeline/skills/animated-spritesheets/scripts/sprite_prompt.mjs
@@ -8,11 +8,15 @@
  * Examples:
  *   node sprite_prompt.mjs anchor --direction e --chroma '#00FF00'
  *   node sprite_prompt.mjs pose-board --action attack --direction e --frames 8
+ *
+ * Pass --guide-image only when you actually send a second reference image
+ * alongside the anchor; it adds the "Image 2 role" clause to the prompt.
  */
 import {
   fail,
   failUsage,
   getDirection,
+  getFlag,
   getInt,
   getString,
   main,
@@ -46,6 +50,7 @@ const COMMANDS = {
       anchorRole: getString(args, "role") ?? "character",
       anchorContext: getString(args, "anchor-context") ?? null,
       chroma: getString(args, "chroma") ?? "#00FF00",
+      guideImage: getFlag(args, "guide-image"),
     });
     console.log(withStyle(prompt, styleOf(args)));
   },
@@ -80,6 +85,7 @@ const COMMANDS = {
         poseBoard: board,
         framePromptStyle,
         chroma: getString(args, "chroma") ?? "#00FF00",
+        guideImage: getFlag(args, "guide-image"),
       },
     );
     console.log(withStyle(prompt, styleOf(args)));
@@ -88,6 +94,7 @@ const COMMANDS = {
 
 main(() => {
   const args = parseArgs(process.argv.slice(2), {
+    booleans: ["guide-image"],
     values: [
       "action",
       "anchor-context",

--- a/plugins/generate/skills/pixel-art/SKILL.md
+++ b/plugins/generate/skills/pixel-art/SKILL.md
@@ -38,7 +38,12 @@ vg generate status fal-ai/nano-banana-pro/edit <walk_request_id> --result --down
 vg generate status fal-ai/nano-banana-pro/edit <idle_request_id> --result --download ./idle.png --json
 ```
 
-3. **URL source**: always read `downloaded_files[0].url` from the tool result JSON. This is the correct path for all models (nano, gpt, Bria).
+3. **URL source**: read the CDN url from `result.images[0].url` in the tool result JSON. This is the correct path for all image models (nano, gpt, Bria) and it is what you pass to the next step's `--image_urls`. `downloaded_files` is a sibling array of **local file paths (plain strings)**, not objects — `downloaded_files[0].url` is `undefined` and will silently poison every chained call.
+
+   ```bash
+   # quote the path — an unquoted [0] is a glob in zsh
+   vg generate run <endpoint> ... --download ./out.png --field "result.images[0].url"
+   ```
 
 4. **Bria sync**: Bria (`fal-ai/bria/background/remove`) has no queue endpoint and does not support `--async`. Run it sync. It completes in seconds.
 
@@ -115,7 +120,7 @@ vg generate run fal-ai/nano-banana-pro/edit \
  --download ./game-assets/<slug>/character.png --json
 ```
 
-Read `downloaded_files[0].url` from the tool result, this is `CHARACTER_URL`, needed for all sprite sheet recipes.
+Read `result.images[0].url` from the tool result — that is `CHARACTER_URL`, needed for all sprite sheet recipes. (`downloaded_files` holds local paths, not urls.)
 
 ---
 

--- a/plugins/tooling/skills/deploy/SKILL.md
+++ b/plugins/tooling/skills/deploy/SKILL.md
@@ -63,8 +63,8 @@ vg login
 ```
 
 This auto-opens the user's browser to a device-code confirmation page
-and prints an 8-character code in the terminal. Tell the user:
-"I opened a browser — confirm code `XXXXXXXX`." Wait for the CLI to
+and prints a 6-character code in the terminal. Tell the user:
+"I opened a browser — confirm code `XXXXXX`." Wait for the CLI to
 print `Logged in successfully` before continuing. If the browser
 didn't open (remote shell, headless env), read the URL from the CLI
 output and give it to the user to open manually.


### PR DESCRIPTION
Four defects found while building and shipping a game end-to-end as a real user would: `npm install -g vibedgames@latest` (0.4.0), `vg init` → `npx skills add kyh/vibedgames`, `vg new`, asset skills, `vg deploy`, `vg playtest`. No `pnpm dogfood`, no local CLI.

Result of the run: <https://e2e-game-lujvmw.vibedgames.com> — bot playtest PASSED against the deployed build (2022 frames, score 2, first score at step 1, zero console/page errors).

---

## 1. `pixel-art` documents a result path that is always `undefined`

`plugins/generate/skills/pixel-art/SKILL.md` said, twice:

> **URL source**: always read `downloaded_files[0].url` from the tool result JSON.

But `downloaded_files` is an array of **local path strings**:

```json
"downloaded_files": [
  "/…/game-assets/ember-tender/character.png"
]
```

So `downloaded_files[0].url` is `undefined`. The CDN url — the thing every chained recipe feeds to the next step's `--image_urls` — is at `result.images[0].url`.

This is the worst one: it fails *silently*. An agent following the skill literally passes `undefined` as the identity anchor and the sprite-sheet chain degrades without erroring. Fixed, and added the verified `--field` form (quoted, since an unquoted `[0]` is a glob in zsh):

```sh
vg generate run <endpoint> ... --field "result.images[0].url"
```

## 2. `animated-spritesheets` promises the model an "Image 2" that is never sent

`sprite_prompt.mjs pose-board` unconditionally emits:

> Image 2 role: black-and-white alternating-pixel pose-board geometry guide at the exact target size…

The skill's own happy path passes exactly one image (`--image_urls '["<anchor_url>"]'`), and **no script in the repo produces a guide image** — `grep -ri "alternating-pixel"` only hits the prompt builder itself. Same bug in `renderAnchorPrompt`.

Gated behind `guideImage` (default `false`, matching the documented command) and exposed as `--guide-image` for callers that really do send a second reference. Verified both branches.

## 3. `vg new --help` hides a working engine preset

`--engine react-r3f` works and `plugins/tooling/skills/deploy/SKILL.md` documents it, but the help text hardcoded `phaser (default), threejs, or none`. An agent that trusts `--help` over the skill never finds it. Now derived from `ENGINES` so help and the unknown-engine error can't drift again.

## 4. `vg init` runs for minutes with zero output

Measured: **~5 minutes, exit 0, zero bytes on stdout+stderr.**

`run()` buffers the child's output and only surfaces it on failure, so the long pole — `npx skills add`, which fetches the repo once per skill (~34 of them), then `skills update` does it again — is silent by construction. An agent cannot distinguish that from a hang; the natural response is to retry, which makes it worse.

`run()` now takes an opt-in `stream` option (mirrored to **stderr**, so stdout stays clean for machine-readable output), and `init` says up front that it takes minutes. The clone-per-skill cost is upstream in the `skills` CLI and is not addressed here.

## 5. Device-code length was wrong

`deploy/SKILL.md` said "8-character code" and told the agent to show `XXXXXXXX`. `generateShortCode()` uses `INVITE_CODE_LENGTH = 6`.

---

## Verification

`pnpm typecheck`, `pnpm lint` (exit 0), `pnpm format --check`, `pnpm test` — all green. Only the two files I touched needed formatting; the repo-wide `format:fix` was deliberately not run.

## Reported separately, not fixed here

- `vg playtest errors` prints one blank `✗` per error in human mode; the message only appears under `--json`. Looks like agent-browser 0.34 formatting, not vg.
- `bot-playtest.mjs` intermittently exits 2 on the contract wait (~1 in 4 identical invocations), and its `pageErrors` buffer carries stale errors across runs against a warm daemon — a fixed game still reports FAILED until `vg playtest close`.
- `--expect-progress` compares score across the whole run, so any game whose fail→retry resets the score reports "the run never progressed the objective" even after scoring repeatedly.
- Nothing in `game-playbook` or the `vg new` template mentions the `__GAME_DIAGNOSTICS__` / `__GAME_TEST_HOOKS__` contract, which `playtest` calls "a prerequisite, not an optional extra". A game built by following the playbook alone cannot be playtested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAcHkLyFRN4qVyU8jfaemZ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four agent-facing defects found in an end-to-end build so asset generation chains, engine discovery, and init UX behave as documented. Old behavior included a bad CDN url path, prompts referencing a missing “Image 2,” hidden `react-r3f` in help, silent `vg init`, and an 8‑char device code; new behavior corrects the url field, gates the “Image 2” clause behind a flag, lists all engine presets, streams init progress to stderr, and shows a 6‑char code.

**Behavior changes**
- Pixel-art skill: read the CDN url from `result.images[0].url` instead of `downloaded_files[0].url` (which was always `undefined`); docs now show the verified `--field "result.images[0].url"`.
- Animated spritesheets prompts: stop promising a second reference image by default; add `--guide-image` to opt in when callers actually send a guide image.
- `vg new --help`: list every preset derived from `ENGINES` (now includes `react-r3f`) and unify the unknown-engine error with help.
- `vg init`: stream long-running subcommand output to stderr via `run(..., { stream: true })` and state that it takes minutes.
- Deploy docs: correct device code length to 6 characters.

**Rollout/migration**
- Update any scripts reading `downloaded_files[0].url` to use `result.images[0].url`; when chaining, pass that value to `--image_urls` and quote `--field "result.images[0].url"`.
- Only pass `--guide-image` (and a second image) if you rely on the “Image 2” guide; otherwise default prompts stay single-image.
- If you parse CLI output, expect `vg init` progress on stderr; stdout remains machine-readable.
- Update any user-facing copy that mentions an 8-character device code to 6.

<sup>Written for commit 7b83e0e000f3c3c9428f059c77248315df2c598a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

