### PR TITLE
fix(skills): four silent-wrong-output bugs found testing the published asset skills

### DIFF
--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -140,6 +140,9 @@ const runCommand = defineCommand({
       ...(downloaded && downloaded.failed.length > 0
         ? { download_failures: downloaded.failed }
         : {}),
+      ...(downloaded && downloaded.mislabeled.length > 0
+        ? { download_format_mismatches: downloaded.mislabeled }
+        : {}),
     };
 
     if (!writeStructured(payload, args)) {
@@ -147,6 +150,7 @@ const runCommand = defineCommand({
       if (downloaded) {
         for (const path of downloaded.downloaded) consola.log(`  ${path}`);
         for (const f of downloaded.failed) consola.warn(`  failed: ${f.url} (${f.error})`);
+        warnMislabeled(downloaded.mislabeled);
       }
       if (!downloaded?.downloaded.length) {
         for (const url of extractMediaUrls(completed.result)) consola.log(`  ${url}`);
@@ -158,6 +162,20 @@ const runCommand = defineCommand({
     }
   },
 });
+
+/**
+ * A downloaded file whose extension does not match the bytes inside it.
+ *
+ * The model, not the CLI, picks the output format, so asking for `board.png`
+ * from an endpoint that returns JPEG produces a `.png` full of JPEG. The next
+ * tool in the pipeline reports "bad signature" with no hint of where it came
+ * from, so name it here while the cause is still on screen.
+ */
+function warnMislabeled(mislabeled: { path: string; actual: string }[]): void {
+  for (const m of mislabeled) {
+    consola.warn(`  ${m.path} holds ${m.actual.toUpperCase()} data, not what its extension says`);
+  }
+}
 
 // Delegate image generation to the local Codex CLI instead of the
 // vibedgames model runner. Produces local files directly (Codex writes
@@ -313,6 +331,9 @@ const statusCommand = defineCommand({
       ...(downloaded && downloaded.failed.length > 0
         ? { download_failures: downloaded.failed }
         : {}),
+      ...(downloaded && downloaded.mislabeled.length > 0
+        ? { download_format_mismatches: downloaded.mislabeled }
+        : {}),
     };
 
     if (!writeStructured(payload, args)) {
@@ -327,6 +348,7 @@ const statusCommand = defineCommand({
         if (downloaded) {
           for (const p of downloaded.downloaded) consola.log(`  ${p}`);
           for (const f of downloaded.failed) consola.warn(`  failed: ${f.url} (${f.error})`);
+          warnMislabeled(downloaded.mislabeled);
         }
         if (action === "result" && !downloaded?.downloaded.length) {
           for (const url of extractMediaUrls(data)) consola.log(`  ${url}`);

--- a/apps/cli/src/lib/media-download.ts
+++ b/apps/cli/src/lib/media-download.ts
@@ -108,7 +108,50 @@ function extFromUrl(url: string): string {
 type DownloadResult = {
   downloaded: string[];
   failed: { url: string; error: string }[];
+  mislabeled: { path: string; actual: string }[];
 };
+
+// The extension each content type genuinely is. Only formats an agent is
+// likely to hand to a decoder afterwards need an entry; anything absent is
+// left alone rather than guessed at.
+const EXT_FOR_CONTENT_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/avif": "avif",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+  "audio/mpeg": "mp3",
+  "audio/wav": "wav",
+  "audio/ogg": "ogg",
+};
+
+// Extensions that name the same format, so `.jpg` for `image/jpeg` is not a lie.
+const EXT_ALIASES: Record<string, string> = {
+  jpeg: "jpg",
+  tif: "tiff",
+  htm: "html",
+};
+
+const canonicalExt = (ext: string) => EXT_ALIASES[ext] ?? ext;
+
+/**
+ * The extension the caller asked for versus the bytes actually served.
+ *
+ * `--download board.png` is honoured literally — renaming the path the caller
+ * chose would break whatever they wired it into — so when a model returns JPEG
+ * the file is a `.png` holding JPEG bytes. Downstream decoders reject it with
+ * "bad signature" and nothing points back here, hence the explicit report.
+ */
+function mislabelOf(target: string, ref: MediaRef): { path: string; actual: string } | null {
+  const asked = canonicalExt(extname(target).slice(1).toLowerCase());
+  if (!asked) return null;
+  const actual = ref.contentType ? EXT_FOR_CONTENT_TYPE[ref.contentType] : undefined;
+  if (!actual || canonicalExt(actual) === asked) return null;
+  return { path: target, actual };
+}
 
 /**
  * Download all extracted media refs to disk, materializing the path from
@@ -134,7 +177,9 @@ export async function downloadMedia(opts: {
   // Fetch all refs in parallel; fal CDN handles the concurrency fine and
   // multi-image runs (`--num_images N`) become N× faster than the old
   // sequential loop. Results stay in ref order via mapped Promise.all.
-  type Outcome = { ok: true; target: string } | { ok: false; url: string; error: string };
+  type Outcome =
+    | { ok: true; target: string; mislabel: { path: string; actual: string } | null }
+    | { ok: false; url: string; error: string };
 
   const outcomes: Outcome[] = await Promise.all(
     opts.refs.map(async (ref, i): Promise<Outcome> => {
@@ -146,7 +191,7 @@ export async function downloadMedia(opts: {
         }
         const bytes = new Uint8Array(await res.arrayBuffer());
         writeFileSync(target, bytes);
-        return { ok: true, target };
+        return { ok: true, target, mislabel: mislabelOf(target, ref) };
       } catch (err) {
         return {
           ok: false,
@@ -159,11 +204,16 @@ export async function downloadMedia(opts: {
 
   const downloaded: string[] = [];
   const failed: { url: string; error: string }[] = [];
+  const mislabeled: { path: string; actual: string }[] = [];
   for (const o of outcomes) {
-    if (o.ok) downloaded.push(o.target);
-    else failed.push({ url: o.url, error: o.error });
+    if (!o.ok) {
+      failed.push({ url: o.url, error: o.error });
+      continue;
+    }
+    downloaded.push(o.target);
+    if (o.mislabel) mislabeled.push(o.mislabel);
   }
-  return { downloaded, failed };
+  return { downloaded, failed, mislabeled };
 }
 
 // Strip any directory components from a fal-provided file_name so a

--- a/apps/cli/test/media-download.test.ts
+++ b/apps/cli/test/media-download.test.ts
@@ -183,6 +183,50 @@ test("downloadMedia writes to a file template literally (not as a directory)", a
   assert.deepEqual(result.downloaded, [resolve(target)]);
 });
 
+test("downloadMedia reports a download whose bytes contradict its extension", async () => {
+  // A model picks its own output format, so `--download board.png` against an
+  // endpoint that answers JPEG writes JPEG into a `.png`. The path is honoured
+  // as asked; the mismatch is reported so the "bad signature" a PNG decoder
+  // raises three steps later is traceable.
+  const port = await makeTestServer(cleanups, (_, res) => {
+    res.setHeader("content-type", "image/jpeg");
+    res.end(Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
+  });
+  const dir = tmpDir();
+  const target = join(dir, "board.png");
+  const ref = {
+    url: `http://127.0.0.1:${port}/source.jpg`,
+    filename: "source.jpg",
+    contentType: "image/jpeg" as const,
+  };
+
+  const result = await downloadMedia({ refs: [ref], template: target, requestId: "rid" });
+  assert.deepEqual(result.downloaded, [resolve(target)], "the requested path is still honoured");
+  assert.deepEqual(result.mislabeled, [{ path: resolve(target), actual: "jpg" }]);
+});
+
+test("downloadMedia stays quiet when the extension matches, aliases included", async () => {
+  const port = await makeTestServer(cleanups, (_, res) => {
+    res.setHeader("content-type", "image/jpeg");
+    res.end(Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
+  });
+  const dir = tmpDir();
+  const ref = {
+    url: `http://127.0.0.1:${port}/source.jpg`,
+    filename: "source.jpg",
+    contentType: "image/jpeg" as const,
+  };
+
+  for (const name of ["board.jpg", "board.jpeg"]) {
+    const result = await downloadMedia({
+      refs: [ref],
+      template: join(dir, name),
+      requestId: "rid",
+    });
+    assert.deepEqual(result.mislabeled, [], `${name} names the same format`);
+  }
+});
+
 test("downloadMedia suffixes colliding targets so multi-output runs don't overwrite", async () => {
   // extractMediaRefs gives every ref the default filename `output.png`
   // when fal omits `file_name`. Without disambiguation, all N downloads

--- a/packages/asset-tools/src/asset/manifest.ts
+++ b/packages/asset-tools/src/asset/manifest.ts
@@ -22,9 +22,24 @@ export const MANIFEST_CANDIDATES = [
 // the check works against manifests this repo has never seen.
 const LUA_PATH_RE = /path\s*=\s*"([^"]+\.png)"/g;
 
-function resolveManifestPath(raw: string, manifestDir: string, jsonRoot: string | null): string {
+// `meta = { version = 1, root = "assets", ... }`. Read with a regex rather than
+// the Lua parser for the same reason as LUA_PATH_RE: a manifest this repo has
+// never seen must still be checkable, and a parse error here would take the
+// whole check down.
+const LUA_META_ROOT_RE = /meta\s*=\s*\{[^}]*\broot\s*=\s*"([^"]*)"/;
+
+function resolveManifestPath(raw: string, manifestDir: string, root: string | null): string {
   if (isAbsolute(raw)) return resolve(raw);
-  return jsonRoot ? resolve(manifestDir, jsonRoot, raw) : resolve(manifestDir, raw);
+  return root ? resolve(manifestDir, root, raw) : resolve(manifestDir, raw);
+}
+
+/** `meta.root` — the folder every relative `path` in the manifest hangs off. */
+function metaRootOf(payload: unknown): string | null {
+  if (payload === null || typeof payload !== "object") return null;
+  const meta = (payload as Record<string, unknown>).meta;
+  if (meta === null || typeof meta !== "object") return null;
+  const root = (meta as Record<string, unknown>).root;
+  return typeof root === "string" && root ? root : null;
 }
 
 /** Collect every `.png` value stored under a `path` key, at any depth. */
@@ -57,22 +72,17 @@ export function extractManifestPaths(manifestPath: string): Set<string> {
     if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
       throw new Error("JSON manifest must be an object at top-level.");
     }
-    const meta = (payload as Record<string, unknown>).meta;
-    const jsonRoot =
-      meta !== null &&
-      typeof meta === "object" &&
-      typeof (meta as Record<string, unknown>).root === "string"
-        ? ((meta as Record<string, unknown>).root as string)
-        : null;
+    const jsonRoot = metaRootOf(payload);
     return new Set(
       collectJsonPaths(payload).map((p) => resolveManifestPath(p, manifestDir, jsonRoot)),
     );
   }
 
   const text = readFileSync(manifestPath, "utf8");
+  const luaRoot = LUA_META_ROOT_RE.exec(text)?.[1] ?? null;
   const out = new Set<string>();
   for (const match of text.matchAll(LUA_PATH_RE)) {
-    out.add(resolveManifestPath(match[1]!, manifestDir, null));
+    out.add(resolveManifestPath(match[1]!, manifestDir, luaRoot));
   }
   return out;
 }
@@ -132,28 +142,46 @@ function renameKeys(value: LuaValue): LuaValue {
   return out;
 }
 
-/** Rewrite every `path` to be relative to the manifest's own folder. */
-function rewritePaths(base: string, value: LuaValue): LuaValue {
-  if (Array.isArray(value)) return value.map((item) => rewritePaths(base, item));
+/**
+ * Rewrite every `path` so it reads relative to `base`.
+ *
+ * `sourceRoot` is where the manifest's own relative paths point (its folder
+ * joined with `meta.root`) — resolving against the process cwd instead would
+ * make the export depend on where the command happened to be run from.
+ *
+ * A `../` result is emitted rather than suppressed: a path that escapes `base`
+ * is still a true path, whereas leaving the original in place next to
+ * `meta.root = "."` silently points the manifest at files that aren't there.
+ */
+function rewritePaths(base: string, sourceRoot: string, value: LuaValue): LuaValue {
+  if (Array.isArray(value)) return value.map((item) => rewritePaths(base, sourceRoot, item));
   if (value === null || typeof value !== "object") return value;
 
   const out: Record<string, LuaValue> = {};
   for (const [key, nested] of Object.entries(value)) {
     if (key === "path" && typeof nested === "string" && nested.toLowerCase().endsWith(".png")) {
-      const absolute = isAbsolute(nested) ? resolve(nested) : resolve(process.cwd(), nested);
+      const absolute = isAbsolute(nested) ? resolve(nested) : resolve(sourceRoot, nested);
       const rel = relative(resolve(base), absolute);
-      // Leaving the path alone beats emitting a `../..` escape hatch when the
-      // asset lives outside the manifest's folder.
-      out[key] = rel && !rel.startsWith("..") ? rel.split(/[/\\]/).join("/") : nested;
+      out[key] = rel ? rel.split(/[/\\]/).join("/") : nested;
     } else {
-      out[key] = rewritePaths(base, nested);
+      out[key] = rewritePaths(base, sourceRoot, nested);
     }
   }
   return out;
 }
 
-/** Load a manifest and normalise it into the portable JSON shape. */
-export function exportManifest(manifestPath: string, packRelative: boolean): LuaValue {
+/**
+ * Load a manifest and normalise it into the portable JSON shape.
+ *
+ * `outPath` is where the JSON will be written; paths are rebased onto its
+ * folder so the exported file works from where it lands. Without it they are
+ * rebased onto the manifest's own folder.
+ */
+export function exportManifest(
+  manifestPath: string,
+  packRelative: boolean,
+  outPath?: string,
+): LuaValue {
   if (manifestPath.toLowerCase().endsWith(".json")) {
     const payload: unknown = JSON.parse(readFileSync(manifestPath, "utf8"));
     if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
@@ -169,10 +197,10 @@ export function exportManifest(manifestPath: string, packRelative: boolean): Lua
 
   let normalized = renameKeys(parsed) as Record<string, LuaValue>;
   if (packRelative) {
-    normalized = rewritePaths(resolve(dirname(manifestPath)), normalized) as Record<
-      string,
-      LuaValue
-    >;
+    const manifestDir = resolve(dirname(manifestPath));
+    const sourceRoot = resolve(manifestDir, metaRootOf(normalized) ?? ".");
+    const base = outPath ? resolve(dirname(outPath)) : manifestDir;
+    normalized = rewritePaths(base, sourceRoot, normalized) as Record<string, LuaValue>;
     const meta = normalized.meta;
     if (meta !== null && typeof meta === "object" && !Array.isArray(meta)) {
       (meta as Record<string, LuaValue>).root = ".";

--- a/packages/asset-tools/src/index.ts
+++ b/packages/asset-tools/src/index.ts
@@ -176,6 +176,7 @@ export {
   type SheetSnapInfo,
   snapImage,
   snapSheet,
+  snapWarning,
   walk,
 } from "./sprite/pixel-snap.js";
 export {

--- a/packages/asset-tools/src/sprite/pixel-snap.ts
+++ b/packages/asset-tools/src/sprite/pixel-snap.ts
@@ -364,6 +364,40 @@ export function snapImage(inputPath: string, config: SnapConfig): Bitmap {
   return resample(quantized, colCuts, rowCuts);
 }
 
+/**
+ * Below this the "recovered grid" is not a sprite. It happens when the image is
+ * mostly flat — a lone figure on an unkeyed matte, say — and the only strong
+ * edges are the few the background contributes, so the walker finds two or three
+ * cuts across the whole picture.
+ */
+const DEGENERATE_SIDE = 8;
+
+/**
+ * Why the caller should distrust a snap result, or null when it looks sane.
+ *
+ * The snapper cannot fail loudly on its own — a 2x2 output is a legal image and
+ * writing it is a legal outcome — so the judgement has to live next to the
+ * dimensions rather than inside the pipeline.
+ */
+export function snapWarning(input: Bitmap, output: Bitmap, config: SnapConfig): string | null {
+  if (output.width < DEGENERATE_SIDE || output.height < DEGENERATE_SIDE) {
+    return (
+      `recovered grid collapsed to ${output.width}x${output.height} from ` +
+      `${input.width}x${input.height} — there was no pixel grid to find. Key the ` +
+      `background out first (a flat matte hides the grid), or the source is not ` +
+      `upscaled pixel art at all`
+    );
+  }
+  const fallback = config.fallbackTargetSegments;
+  if (output.width === fallback && output.height === fallback) {
+    return (
+      `output is exactly ${fallback}x${fallback}: step detection found no structure ` +
+      `and fell back to a fixed segment count, so these are not the source's own pixels`
+    );
+  }
+  return null;
+}
+
 export type SheetSnapInfo = {
   inputDims: [number, number];
   inputFrameDims: [number, number];

--- a/packages/asset-tools/src/sprite/qc.ts
+++ b/packages/asset-tools/src/sprite/qc.ts
@@ -16,6 +16,13 @@ import { median } from "./frames.js";
  *  - FACING FLIP — one cell (often the first) is mirrored, so the character
  *    faces the wrong way for part of the animation.
  *
+ *  - DRAWN GRID — the board comes back with the cell outlines actually inked,
+ *    despite the prompt forbidding them, so the uniform slice bakes a straight
+ *    black rule into the frames. Left unflagged it is the worst failure of the
+ *    three: the rule joins the alpha bounding box, so size, baseline and facing
+ *    are all measured against the rectangle instead of the character and every
+ *    other check goes quiet.
+ *
  * Plus the always-checkable ones: empty cells, frames clipping the cell edge,
  * and a foot baseline that wanders. Everything is measured from the alpha
  * channel.
@@ -35,6 +42,17 @@ const BASELINE_TOL = 0.12;
 const SIZE_DRIFT_TOL = 0.35;
 const FACING_CX_TOL = 0.18;
 
+// A bounding-box edge this opaque is a ruled line, not a silhouette: no
+// character fills an entire edge of its own bbox to the last pixel.
+const RULE_EDGE_FRAC = 0.95;
+// ...as long as it is thin. A genuinely solid shape (a crate, a slab) is opaque
+// this far inside too, and must not be mistaken for a drawn border.
+const RULE_INNER_FRAC = 0.5;
+const RULE_INNER_OFFSET = 3;
+// Below this the bbox is too small for "the whole edge is opaque" to mean
+// anything — a 4px-wide sprite fills its own edges by accident.
+const RULE_MIN_SPAN = 12;
+
 export type FrameMetrics = {
   empty: boolean;
   area_frac: number;
@@ -43,10 +61,11 @@ export type FrameMetrics = {
   cx_frac: number;
   baseline_frac: number;
   border_frac: number;
+  rule_edges: number;
 };
 
 export type QcCheck = {
-  check: "empty" | "clip" | "baseline" | "size" | "facing";
+  check: "empty" | "clip" | "grid" | "baseline" | "size" | "facing";
   severity: "warn" | "hint";
   frames: number[];
   detail: string;
@@ -196,6 +215,7 @@ export function frameMetrics(
       cx_frac: 0,
       baseline_frac: 1,
       border_frac: 0,
+      rule_edges: 0,
     };
   }
 
@@ -219,6 +239,37 @@ export function frameMetrics(
     sample(fw - 1, y);
   }
 
+  // Ruled edges of the bounding box — the fingerprint of a drawn cell outline.
+  // Measured on the bbox rather than the cell border, because `normalize_canvas`
+  // insets the frame and the rule travels inwards with it, out of reach of the
+  // `clip` check.
+  const on = (x: number, y: number) =>
+    sheet.contains(originX + x, originY + y) &&
+    sheet.data[sheet.index(originX + x, originY + y) + 3]! > ALPHA_ON;
+  const spanX = maxX - minX + 1;
+  const spanY = maxY - minY + 1;
+  const rowFrac = (y: number) => {
+    let n = 0;
+    for (let x = minX; x <= maxX; x += 1) if (on(x, y)) n += 1;
+    return n / spanX;
+  };
+  const colFrac = (x: number) => {
+    let n = 0;
+    for (let y = minY; y <= maxY; y += 1) if (on(x, y)) n += 1;
+    return n / spanY;
+  };
+  const ruled = (outer: number, inner: number) =>
+    outer >= RULE_EDGE_FRAC && inner <= RULE_INNER_FRAC;
+  const clamp = (value: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, value));
+  let ruleEdges = 0;
+  if (spanX >= RULE_MIN_SPAN && spanY >= RULE_MIN_SPAN) {
+    const inset = RULE_INNER_OFFSET;
+    if (ruled(rowFrac(minY), rowFrac(clamp(minY + inset, minY, maxY)))) ruleEdges += 1;
+    if (ruled(rowFrac(maxY), rowFrac(clamp(maxY - inset, minY, maxY)))) ruleEdges += 1;
+    if (ruled(colFrac(minX), colFrac(clamp(minX + inset, minX, maxX)))) ruleEdges += 1;
+    if (ruled(colFrac(maxX), colFrac(clamp(maxX - inset, minX, maxX)))) ruleEdges += 1;
+  }
+
   const meanX = xs.reduce((sum, v) => sum + v, 0) / xs.length;
   return {
     empty: false,
@@ -230,6 +281,7 @@ export function frameMetrics(
     // Foot baseline: bottom of the figure as a fraction from the top.
     baseline_frac: roundTo((maxY + 1) / fh, 4),
     border_frac: roundTo(borderOpaque / borderTotal, 4),
+    rule_edges: ruleEdges,
   };
 }
 
@@ -272,6 +324,21 @@ export function qc(metrics: FrameMetrics[]): QcCheck[] {
       severity: "warn",
       frames: clipped,
       detail: `${clipped.length} frame(s) touch the cell border (likely cut off)`,
+    });
+  }
+
+  const ruled = metrics.map((m, i) => (m.rule_edges > 0 ? i + 1 : 0)).filter(Boolean);
+  if (ruled.length > 0) {
+    checks.push({
+      check: "grid",
+      severity: "warn",
+      frames: ruled,
+      detail:
+        `${ruled.length} frame(s) contain a straight ruled line spanning the whole ` +
+        `bounding box — the model inked the pose-board cell outlines and the slice ` +
+        `baked them in. The rule also skews every size/baseline/facing measurement, ` +
+        `so regenerate the board (restate "no grid lines, cell outlines or borders") ` +
+        `rather than trusting the rest of this report`,
     });
   }
 

--- a/packages/asset-tools/test/asset.test.ts
+++ b/packages/asset-tools/test/asset.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { globSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { globSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { test } from "node:test";
@@ -255,6 +255,66 @@ test("manifest-check reads JSON manifests and honours meta.root", () => {
   const report = checkManifest(manifest, dir);
   assert.deepEqual(report.missing, []);
   assert.deepEqual(report.extra, []);
+});
+
+test("manifest-check honours meta.root in Lua manifests too", () => {
+  const dir = workspace();
+  mkdirSync(join(dir, "assets"), { recursive: true });
+  buildSheet(join(dir, "assets", "hero.png"), 1, 1, 8);
+  const manifest = join(dir, "assets_index.lua");
+  writeFileSync(
+    manifest,
+    `return {
+       meta = { version = 1, root = "assets", defaultFps = 10 },
+       sprites = { { path = "hero.png" } },
+     }`,
+  );
+
+  const report = checkManifest(manifest, join(dir, "assets"));
+  assert.deepEqual(report.extra, [], "hero.png is declared and present, not absent");
+  assert.deepEqual(report.missing, [], "hero.png is on disk and declared, not undeclared");
+});
+
+test("manifest-export resolves relative paths through meta.root, not the cwd", () => {
+  const dir = workspace();
+  mkdirSync(join(dir, "assets", "Tilesets"), { recursive: true });
+  buildSheet(join(dir, "assets", "Tilesets", "desert.png"), 1, 1, 8);
+  const manifest = join(dir, "assets_index.lua");
+  writeFileSync(
+    manifest,
+    `return {
+       meta = { root = "assets" },
+       tilesets = { desert = { path = "Tilesets/desert.png" } },
+     }`,
+  );
+
+  const exported = exportManifest(manifest, true) as Record<string, unknown>;
+  const desert = (exported.tilesets as Record<string, Record<string, unknown>>).desert!;
+  assert.equal(
+    desert.path,
+    "assets/Tilesets/desert.png",
+    "meta.root is folded into the path, so root can become '.'",
+  );
+  assert.equal((exported.meta as Record<string, unknown>).root, ".");
+});
+
+test("manifest-export rebases onto the output folder when one is given", () => {
+  const dir = workspace();
+  mkdirSync(join(dir, "assets"), { recursive: true });
+  mkdirSync(join(dir, "tmp"), { recursive: true });
+  buildSheet(join(dir, "assets", "hero.png"), 1, 1, 8);
+  const manifest = join(dir, "assets_index.lua");
+  writeFileSync(
+    manifest,
+    `return { meta = { root = "assets" }, sprites = { { path = "hero.png" } } }`,
+  );
+
+  const exported = exportManifest(manifest, true, join(dir, "tmp", "assets_index.json")) as Record<
+    string,
+    unknown
+  >;
+  const sprite = (exported.sprites as Record<string, unknown>[])[0]!;
+  assert.equal(sprite.path, "../assets/hero.png", "relative to the output folder, as documented");
 });
 
 test("written PNGs are readable by the decoder that wrote them", () => {

--- a/packages/asset-tools/test/asset.test.ts
+++ b/packages/asset-tools/test/asset.test.ts
@@ -13,7 +13,7 @@ import { analyzeBaseline, probeSheet } from "../src/asset/sheet.js";
 import { collectSizes, sizesToCsv } from "../src/asset/sizes.js";
 import { Bitmap } from "../src/image/raster.js";
 import { createZip } from "../src/skill/zip.js";
-import { frameGeometry } from "../src/sprite/qc.js";
+import { frameGeometry, runQc } from "../src/sprite/qc.js";
 import {
   cellSizeOf,
   FRAME_HEIGHT,
@@ -62,6 +62,81 @@ function buildSheet(
   }
   sheet.toFile(path);
 }
+
+/**
+ * A blobby figure per cell — nothing about it fills a whole bounding-box edge,
+ * which is what separates real art from a drawn cell outline.
+ */
+function buildFigureSheet(path: string, count: number, frame: number): Bitmap {
+  const sheet = Bitmap.create(count * frame, frame);
+  for (let i = 0; i < count; i += 1) {
+    const cx = i * frame + frame / 2;
+    const cy = frame * 0.6;
+    for (let y = -Math.floor(frame * 0.3); y <= Math.floor(frame * 0.3); y += 1) {
+      const halfWidth = Math.round(frame * 0.18 * Math.cos((y / (frame * 0.35)) * 1.2));
+      for (let x = -halfWidth; x <= halfWidth; x += 1) {
+        sheet.putPixel(cx + x, cy + y, [200, 60, 60, 255]);
+      }
+    }
+  }
+  sheet.toFile(path);
+  return sheet;
+}
+
+/** Ink the cell outlines, exactly as a pose-board model does when it ignores the prompt. */
+function inkCellOutlines(sheet: Bitmap, count: number, frame: number, path: string): void {
+  for (let i = 0; i < count; i += 1) {
+    const x0 = i * frame + 8;
+    const x1 = i * frame + frame - 9;
+    const y0 = 8;
+    const y1 = frame - 9;
+    for (let x = x0; x <= x1; x += 1) {
+      for (let t = 0; t < 2; t += 1) {
+        sheet.putPixel(x, y0 + t, [0, 0, 0, 255]);
+        sheet.putPixel(x, y1 - t, [0, 0, 0, 255]);
+      }
+    }
+    for (let y = y0; y <= y1; y += 1) {
+      for (let t = 0; t < 2; t += 1) {
+        sheet.putPixel(x0 + t, y, [0, 0, 0, 255]);
+        sheet.putPixel(x1 - t, y, [0, 0, 0, 255]);
+      }
+    }
+  }
+  sheet.toFile(path);
+}
+
+test("sheet-qc flags an inked cell outline, and leaves clean art alone", () => {
+  const dir = workspace();
+  const clean = join(dir, "clean.png");
+  const sheet = buildFigureSheet(clean, 4, 64);
+  const before = runQc(clean, 64, 64);
+  assert.equal(
+    before.checks.find((c) => c.check === "grid"),
+    undefined,
+    "figures do not fill a whole bbox edge, so nothing looks ruled",
+  );
+
+  const ruled = join(dir, "ruled.png");
+  inkCellOutlines(sheet, 4, 64, ruled);
+  const after = runQc(ruled, 64, 64);
+  const grid = after.checks.find((c) => c.check === "grid");
+  assert.ok(grid, "a straight rule spanning the bbox is the drawn-grid fingerprint");
+  assert.deepEqual(grid.frames, [1, 2, 3, 4]);
+  assert.equal(after.verdict, "warn", "a baked-in grid is a hard defect, not a hint");
+});
+
+test("sheet-qc does not mistake a solid rectangular sprite for a drawn grid", () => {
+  const dir = workspace();
+  const sheet = join(dir, "blocks.png");
+  buildSheet(sheet, 4, 1, 32);
+  const report = runQc(sheet, 32, 32);
+  assert.equal(
+    report.checks.find((c) => c.check === "grid"),
+    undefined,
+    "a filled square is opaque well inside its edge; a ruled line is not",
+  );
+});
 
 test("parseFrame accepts WxH and rejects anything else", () => {
   assert.deepEqual(parseFrame("32x32"), { width: 32, height: 32 });

--- a/plugins/asset-pipeline/skills/animated-spritesheets/SKILL.md
+++ b/plugins/asset-pipeline/skills/animated-spritesheets/SKILL.md
@@ -88,10 +88,16 @@ this.anims.create({
 6. `sheet_qc.mjs` — QC the packed sheet and report a verdict (same token in the
    `--json` `qc` field and the human badge, just uppercased there): **`clean`** /
    **`review`** (soft hints to eyeball — size outliers, possible facing flips) /
-   **`warn`** (hard defects — empty cells, edge-clipping, foot-baseline wander).
-   Runs automatically; `--no-qc` skips it. **Read the verdict:** regenerate the board
-   on `warn`; eyeball `review/<action>.gif` on `review`. Run it standalone too:
-   `sheet_qc.mjs sheet.png [--json] [--strict]`.
+   **`warn`** (hard defects — empty cells, edge-clipping, foot-baseline wander,
+   an inked cell grid). Runs automatically; `--no-qc` skips it. **Read the
+   verdict:** regenerate the board on `warn`; eyeball `review/<action>.gif` on
+   `review`. Run it standalone too: `sheet_qc.mjs sheet.png [--json] [--strict]`.
+   The `grid` check deserves special attention: models routinely ink the cell
+   outlines despite the prompt forbidding them, and the uniform slice bakes a
+   black rule into every frame. That rule then joins each frame's bounding box,
+   so size/baseline/facing get measured against the rectangle rather than the
+   character — a `grid` warn makes the rest of the report meaningless, so
+   regenerate rather than reading past it.
 
 ## Craft
 

--- a/plugins/asset-pipeline/skills/animated-spritesheets/SKILL.md
+++ b/plugins/asset-pipeline/skills/animated-spritesheets/SKILL.md
@@ -49,6 +49,15 @@ vg generate run fal-ai/nano-banana-pro/edit --prompt "<from step 2>" \
 node .claude/skills/animated-spritesheets/scripts/process_sheet.mjs attack-board.png --action attack --rows 3 --cols 4 --frames 8 --out-dir runs/hero-attack
 ```
 
+> **`--download x.png` does not make the file a PNG.** The model chooses the
+> output format, so an endpoint that answers JPEG writes JPEG bytes into the
+> `.png` you named, and every script here — they read PNG only, by design —
+> rejects it with `Not a PNG file (bad signature)`. `vg generate` warns when
+> the bytes contradict the extension; when it does, pick an endpoint that
+> returns PNG rather than trying to convert (there is no converter in this
+> toolkit, and no ImageMagick/ffmpeg to fall back on). `nano-banana-pro/edit`
+> returns PNG; `flux/dev` returns JPEG.
+
 The deliverable is `<out-dir>/spritesheet.png` + `spritesheet.json`, with
 `runtime/` frames and `review/<action>.gif`. Load it:
 

--- a/plugins/asset-pipeline/skills/animated-spritesheets/scripts/_lib/asset-tools.mjs
+++ b/plugins/asset-pipeline/skills/animated-spritesheets/scripts/_lib/asset-tools.mjs
@@ -1852,6 +1852,10 @@ var CLIP_BORDER_FRAC = 0.01;
 var BASELINE_TOL = 0.12;
 var SIZE_DRIFT_TOL = 0.35;
 var FACING_CX_TOL = 0.18;
+var RULE_EDGE_FRAC = 0.95;
+var RULE_INNER_FRAC = 0.5;
+var RULE_INNER_OFFSET = 3;
+var RULE_MIN_SPAN = 12;
 function roundTo(value, digits) {
   const factor = 10 ** digits;
   return roundHalfToEven(value * factor) / factor;
@@ -1946,7 +1950,8 @@ function frameMetrics(sheet, index, geometry) {
       width: 0,
       cx_frac: 0,
       baseline_frac: 1,
-      border_frac: 0
+      border_frac: 0,
+      rule_edges: 0
     };
   }
   let borderOpaque = 0;
@@ -1966,6 +1971,29 @@ function frameMetrics(sheet, index, geometry) {
     sample(0, y);
     sample(fw - 1, y);
   }
+  const on = (x, y) => sheet.contains(originX + x, originY + y) && sheet.data[sheet.index(originX + x, originY + y) + 3] > ALPHA_ON;
+  const spanX = maxX - minX + 1;
+  const spanY = maxY - minY + 1;
+  const rowFrac = (y) => {
+    let n = 0;
+    for (let x = minX; x <= maxX; x += 1) if (on(x, y)) n += 1;
+    return n / spanX;
+  };
+  const colFrac = (x) => {
+    let n = 0;
+    for (let y = minY; y <= maxY; y += 1) if (on(x, y)) n += 1;
+    return n / spanY;
+  };
+  const ruled = (outer, inner) => outer >= RULE_EDGE_FRAC && inner <= RULE_INNER_FRAC;
+  const clamp = (value, lo, hi) => Math.min(hi, Math.max(lo, value));
+  let ruleEdges = 0;
+  if (spanX >= RULE_MIN_SPAN && spanY >= RULE_MIN_SPAN) {
+    const inset = RULE_INNER_OFFSET;
+    if (ruled(rowFrac(minY), rowFrac(clamp(minY + inset, minY, maxY)))) ruleEdges += 1;
+    if (ruled(rowFrac(maxY), rowFrac(clamp(maxY - inset, minY, maxY)))) ruleEdges += 1;
+    if (ruled(colFrac(minX), colFrac(clamp(minX + inset, minX, maxX)))) ruleEdges += 1;
+    if (ruled(colFrac(maxX), colFrac(clamp(maxX - inset, minX, maxX)))) ruleEdges += 1;
+  }
   const meanX = xs.reduce((sum, v) => sum + v, 0) / xs.length;
   return {
     empty: false,
@@ -1976,7 +2004,8 @@ function frameMetrics(sheet, index, geometry) {
     cx_frac: roundTo((meanX - fw / 2) / fw, 4),
     // Foot baseline: bottom of the figure as a fraction from the top.
     baseline_frac: roundTo((maxY + 1) / fh, 4),
-    border_frac: roundTo(borderOpaque / borderTotal, 4)
+    border_frac: roundTo(borderOpaque / borderTotal, 4),
+    rule_edges: ruleEdges
   };
 }
 function isLocalExtremum(values, i) {
@@ -2005,6 +2034,15 @@ function qc(metrics) {
       severity: "warn",
       frames: clipped,
       detail: `${clipped.length} frame(s) touch the cell border (likely cut off)`
+    });
+  }
+  const ruled = metrics.map((m, i) => m.rule_edges > 0 ? i + 1 : 0).filter(Boolean);
+  if (ruled.length > 0) {
+    checks.push({
+      check: "grid",
+      severity: "warn",
+      frames: ruled,
+      detail: `${ruled.length} frame(s) contain a straight ruled line spanning the whole bounding box \u2014 the model inked the pose-board cell outlines and the slice baked them in. The rule also skews every size/baseline/facing measurement, so regenerate the board (restate "no grid lines, cell outlines or borders") rather than trusting the rest of this report`
     });
   }
   if (live.length >= 2) {
@@ -2336,6 +2374,17 @@ function snapImage(inputPath, config) {
   const colCuts = sanitizeCuts(walk(columns, stepX, image.width, config), image.width);
   const rowCuts = sanitizeCuts(walk(rows, stepY, image.height, config), image.height);
   return resample(quantized, colCuts, rowCuts);
+}
+var DEGENERATE_SIDE = 8;
+function snapWarning(input, output, config) {
+  if (output.width < DEGENERATE_SIDE || output.height < DEGENERATE_SIDE) {
+    return `recovered grid collapsed to ${output.width}x${output.height} from ${input.width}x${input.height} \u2014 there was no pixel grid to find. Key the background out first (a flat matte hides the grid), or the source is not upscaled pixel art at all`;
+  }
+  const fallback = config.fallbackTargetSegments;
+  if (output.width === fallback && output.height === fallback) {
+    return `output is exactly ${fallback}x${fallback}: step detection found no structure and fell back to a fixed segment count, so these are not the source's own pixels`;
+  }
+  return null;
 }
 
 // src/sprite/size-contract.ts
@@ -3454,6 +3503,7 @@ export {
   resolveProfile,
   runQc,
   snapImage,
+  snapWarning,
   toPythonJson,
   totalCells,
   withStyle,

--- a/plugins/asset-pipeline/skills/animated-spritesheets/scripts/chroma_clean.mjs
+++ b/plugins/asset-pipeline/skills/animated-spritesheets/scripts/chroma_clean.mjs
@@ -12,6 +12,15 @@
  *   key       key the matte out to transparency
  *   fringe    sweep matte-tinted fringe pixels
  *   despill   neutralise matte tint without deleting pixels
+ *
+ * --input takes a file or a directory (--glob picks the members). Output is
+ * --out for a single file, --out-dir for a batch; omit both and each result
+ * lands beside its source.
+ *
+ * Examples:
+ *   node chroma_clean.mjs clean --input sprite.png --out sprite-clean.png
+ *   node chroma_clean.mjs clean --input cells/ --out-dir keyed/ --chroma '#FF00FF'
+ *   node chroma_clean.mjs key --input sprite.png --tolerance 60 --keep-largest
  */
 import { existsSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";

--- a/plugins/asset-pipeline/skills/animated-spritesheets/scripts/pixel_snapper.mjs
+++ b/plugins/asset-pipeline/skills/animated-spritesheets/scripts/pixel_snapper.mjs
@@ -3,22 +3,31 @@
  * Recover the underlying low-resolution pixel-art grid from an upscaled or
  * AI-generated image. Port of Hugo-Dz/spritefusion-pixel-snapper.
  *
+ * Output resolution is discovered, not requested, so the only signal that the
+ * run went wrong is the dimensions — which is why an implausible result is
+ * reported here instead of being left for the caller to notice.
+ *
  * Usage:
  *   node pixel_snapper.mjs input.png output.png [--k-colors 256] [--seed 42]
+ *   node pixel_snapper.mjs input.png output.png --strict   # exit 1 on a bad snap
  */
 import {
+  Bitmap,
   DEFAULT_SNAP_CONFIG,
   fail,
   failUsage,
+  getFlag,
   getInt,
   main,
   parseArgs,
   snapImage,
+  snapWarning,
 } from "./_lib/asset-tools.mjs";
 
 main(() => {
   const args = parseArgs(process.argv.slice(2), {
     values: ["k-colors", "seed"],
+    booleans: ["strict"],
   });
   const [input, output] = args.positionals;
   if (!input || !output) {
@@ -28,11 +37,14 @@ main(() => {
   const kColors = getInt(args, "k-colors", 16);
   if (kColors <= 0) fail("--k-colors must be a positive integer");
 
-  const snapped = snapImage(input, {
-    ...DEFAULT_SNAP_CONFIG,
-    kColors,
-    kSeed: getInt(args, "seed", 42),
-  });
+  const config = { ...DEFAULT_SNAP_CONFIG, kColors, kSeed: getInt(args, "seed", 42) };
+  const snapped = snapImage(input, config);
   snapped.toFile(output);
   console.log(`Snapped ${input} -> ${output} (${snapped.width}x${snapped.height})`);
+
+  const warning = snapWarning(Bitmap.fromFile(input), snapped, config);
+  if (warning) {
+    console.error(`[pixel_snapper] warning: ${warning}`);
+    if (getFlag(args, "strict")) process.exit(1);
+  }
 });

--- a/plugins/asset-pipeline/skills/asset-pipeline/SKILL.md
+++ b/plugins/asset-pipeline/skills/asset-pipeline/SKILL.md
@@ -130,15 +130,23 @@ If a character looks like it's **floating above its shadow** or stands at differ
 
 Verify every PNG on disk appears in the manifest and vice versa.
 
+`missing` is art on disk the manifest never declares (it will never load);
+`extra` is art the manifest promises that nobody shipped (it 404s at runtime).
+Relative paths resolve through `meta.root`, in both Lua and JSON manifests.
+
 ```bash
 node .claude/skills/asset-pipeline/scripts/asset_manifest_check.mjs
 node .claude/skills/asset-pipeline/scripts/asset_manifest_check.mjs --manifest path/to/assets_index.lua --root assets
 node .claude/skills/asset-pipeline/scripts/asset_manifest_check.mjs --json tmp/coverage.json
+node .claude/skills/asset-pipeline/scripts/asset_manifest_check.mjs --strict   # exit 1 on any mismatch
 ```
+
+Pass `--strict` from a script or CI: without it the command reports the
+mismatch and still exits 0, which reads as a pass.
 
 ### Manifest Export (`asset_manifest_export_json.mjs`)
 
-Export `assets_index.lua` (Love2D-style) to a portable `assets_index.json`. By default it rewrites all `path` entries relative to the output folder and sets `meta.root` to `"."`, so the result can be copied/zipped and still work.
+Export `assets_index.lua` (Love2D-style) to a portable `assets_index.json`. By default it folds `meta.root` into every `path`, rewrites them relative to `--out`'s folder, and sets `meta.root` to `"."` — so the JSON works from wherever it lands. Write it next to the assets it describes if you want the result copyable/zippable; exporting to a `tmp/` sibling gives correct-but-`../`-prefixed paths. `--keep-paths` leaves the manifest's own paths and root untouched.
 
 ```bash
 node .claude/skills/asset-pipeline/scripts/asset_manifest_export_json.mjs --manifest path/to/assets_index.lua --out path/to/assets_index.json

--- a/plugins/asset-pipeline/skills/asset-pipeline/scripts/_lib/asset-tools.mjs
+++ b/plugins/asset-pipeline/skills/asset-pipeline/scripts/_lib/asset-tools.mjs
@@ -1785,9 +1785,17 @@ var MANIFEST_CANDIDATES = [
   "assets/asset_index.lua"
 ];
 var LUA_PATH_RE = /path\s*=\s*"([^"]+\.png)"/g;
-function resolveManifestPath(raw, manifestDir, jsonRoot) {
+var LUA_META_ROOT_RE = /meta\s*=\s*\{[^}]*\broot\s*=\s*"([^"]*)"/;
+function resolveManifestPath(raw, manifestDir, root) {
   if (isAbsolute3(raw)) return resolve5(raw);
-  return jsonRoot ? resolve5(manifestDir, jsonRoot, raw) : resolve5(manifestDir, raw);
+  return root ? resolve5(manifestDir, root, raw) : resolve5(manifestDir, raw);
+}
+function metaRootOf(payload) {
+  if (payload === null || typeof payload !== "object") return null;
+  const meta = payload.meta;
+  if (meta === null || typeof meta !== "object") return null;
+  const root = meta.root;
+  return typeof root === "string" && root ? root : null;
 }
 function collectJsonPaths(payload) {
   const paths = [];
@@ -1815,16 +1823,16 @@ function extractManifestPaths(manifestPath) {
     if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
       throw new Error("JSON manifest must be an object at top-level.");
     }
-    const meta = payload.meta;
-    const jsonRoot = meta !== null && typeof meta === "object" && typeof meta.root === "string" ? meta.root : null;
+    const jsonRoot = metaRootOf(payload);
     return new Set(
       collectJsonPaths(payload).map((p) => resolveManifestPath(p, manifestDir, jsonRoot))
     );
   }
   const text = readFileSync5(manifestPath, "utf8");
+  const luaRoot = LUA_META_ROOT_RE.exec(text)?.[1] ?? null;
   const out = /* @__PURE__ */ new Set();
   for (const match of text.matchAll(LUA_PATH_RE)) {
-    out.add(resolveManifestPath(match[1], manifestDir, null));
+    out.add(resolveManifestPath(match[1], manifestDir, luaRoot));
   }
   return out;
 }
@@ -1861,22 +1869,22 @@ function renameKeys(value) {
   }
   return out;
 }
-function rewritePaths(base, value) {
-  if (Array.isArray(value)) return value.map((item) => rewritePaths(base, item));
+function rewritePaths(base, sourceRoot, value) {
+  if (Array.isArray(value)) return value.map((item) => rewritePaths(base, sourceRoot, item));
   if (value === null || typeof value !== "object") return value;
   const out = {};
   for (const [key, nested] of Object.entries(value)) {
     if (key === "path" && typeof nested === "string" && nested.toLowerCase().endsWith(".png")) {
-      const absolute = isAbsolute3(nested) ? resolve5(nested) : resolve5(process.cwd(), nested);
+      const absolute = isAbsolute3(nested) ? resolve5(nested) : resolve5(sourceRoot, nested);
       const rel = relative3(resolve5(base), absolute);
-      out[key] = rel && !rel.startsWith("..") ? rel.split(/[/\\]/).join("/") : nested;
+      out[key] = rel ? rel.split(/[/\\]/).join("/") : nested;
     } else {
-      out[key] = rewritePaths(base, nested);
+      out[key] = rewritePaths(base, sourceRoot, nested);
     }
   }
   return out;
 }
-function exportManifest(manifestPath, packRelative) {
+function exportManifest(manifestPath, packRelative, outPath) {
   if (manifestPath.toLowerCase().endsWith(".json")) {
     const payload = JSON.parse(readFileSync5(manifestPath, "utf8"));
     if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
@@ -1890,7 +1898,10 @@ function exportManifest(manifestPath, packRelative) {
   }
   let normalized = renameKeys(parsed);
   if (packRelative) {
-    normalized = rewritePaths(resolve5(dirname5(manifestPath)), normalized);
+    const manifestDir = resolve5(dirname5(manifestPath));
+    const sourceRoot = resolve5(manifestDir, metaRootOf(normalized) ?? ".");
+    const base = outPath ? resolve5(dirname5(outPath)) : manifestDir;
+    normalized = rewritePaths(base, sourceRoot, normalized);
     const meta = normalized.meta;
     if (meta !== null && typeof meta === "object" && !Array.isArray(meta)) {
       meta.root = ".";

--- a/plugins/asset-pipeline/skills/asset-pipeline/scripts/asset_manifest_check.mjs
+++ b/plugins/asset-pipeline/skills/asset-pipeline/scripts/asset_manifest_check.mjs
@@ -6,6 +6,7 @@
  *   node asset_manifest_check.mjs
  *   node asset_manifest_check.mjs --manifest path/to/assets_index.lua --root assets
  *   node asset_manifest_check.mjs --manifest path/to/assets_index.lua --root assets --json tmp/check.json
+ *   node asset_manifest_check.mjs --strict     # exit 1 if anything is missing or extra
  */
 import { existsSync } from "node:fs";
 
@@ -14,6 +15,7 @@ import {
   checkManifest,
   defaultRoot,
   fail,
+  getFlag,
   getString,
   main,
   MANIFEST_CANDIDATES,
@@ -24,6 +26,7 @@ import {
 main(() => {
   const args = parseArgs(process.argv.slice(2), {
     values: ["json", "manifest", "root"],
+    booleans: ["strict"],
   });
   const root = defaultRoot(getString(args, "root"));
   if (!existsSync(root)) fail(`Root not found: ${root}`);
@@ -43,4 +46,6 @@ main(() => {
 
   const json = getString(args, "json");
   if (json) writeJsonFile(json, report);
+
+  if (getFlag(args, "strict") && report.missing.length + report.extra.length > 0) process.exit(1);
 });

--- a/plugins/asset-pipeline/skills/asset-pipeline/scripts/asset_manifest_export_json.mjs
+++ b/plugins/asset-pipeline/skills/asset-pipeline/scripts/asset_manifest_export_json.mjs
@@ -31,6 +31,6 @@ main(() => {
   if (!out) failUsage("--out is required (output JSON path)");
   if (!existsSync(manifest)) fail(`Manifest not found: ${manifest}`);
 
-  writeJsonFile(out, exportManifest(manifest, !getFlag(args, "keep-paths")));
+  writeJsonFile(out, exportManifest(manifest, !getFlag(args, "keep-paths"), out));
   console.log(`Wrote ${out}`);
 });

--- a/plugins/asset-pipeline/skills/pixel-snapper/SKILL.md
+++ b/plugins/asset-pipeline/skills/pixel-snapper/SKILL.md
@@ -22,7 +22,7 @@ Naive downscale (Lanczos/bilinear/nearest) averages neighbors → blur or aliasi
 - Native snapped output, or a nearest-neighbour upscale for inspection? Usually you want both.
 - Are the cells actually square? The snapper assumes one shared cell pitch for both axes.
 
-**Core principles**: output resolution is discovered, not specified · `k_colors` is the only user-facing knob (other tunables live in `DEFAULT_SNAP_CONFIG`) · always inspect the output by eye — dimensions are a sanity check, not a quality check · keep the source PNG so you can re-snap with a different `k_colors` later · **snapping needs resolution to find the grid — feed it a large source (≥~512px across the subject; a lone character ~1024²). Undersized inputs (256²) blur the grid away or trip the 64×64 fallback; the fix is to regenerate larger, not to upscale a small source first.**
+**Core principles**: output resolution is discovered, not specified · `k_colors` is the only user-facing knob (other tunables live in `DEFAULT_SNAP_CONFIG`) · always inspect the output by eye — dimensions are a sanity check, not a quality check · keep the source PNG so you can re-snap with a different `k_colors` later · **key the background out before snapping** — a wide flat matte gives the walker nothing but its own edges to lock onto, and the recovered "grid" collapses to a handful of pixels · **snapping needs resolution to find the grid — feed it a large source (≥~512px across the subject; a lone character ~1024²). Undersized inputs (256²) blur the grid away or trip the 64×64 fallback; the fix is to regenerate larger, not to upscale a small source first.**
 
 ## When to Use
 
@@ -65,7 +65,7 @@ See `references/usage-examples.md` for batch processing and verification recipes
 2. **Pick `k_colors`** — start 256 for AI renders; for quantized retro art try 16, 32, 64 ascending until detail survives without noise.
 3. **Run** — sanity-check printed dims against expectation (a "32×32 sprite" snaps near 32×32, not 5×5 or 800×800).
 4. **Inspect** the `iw*8` nearest-neighbour upscale.
-5. **Iterate** — common fixes: different `k_colors` (halve/double); non-square cells (snapper picks the smaller pitch → may need pre-resize); exactly 64×64 output = step-detection fallback fired (input may lack detectable pixel structure).
+5. **Iterate** — common fixes: different `k_colors` (halve/double); non-square cells (snapper picks the smaller pitch → may need pre-resize); exactly 64×64 output = step-detection fallback fired (input may lack detectable pixel structure). The script prints a warning for both collapse modes and `--strict` turns them into exit 1, so a batch can stop instead of writing a 2×2 file that looks like a success.
 6. **Save to `experiments/`**, never directly into `public/assets/`. Promote only after visual approval.
 
 ## Anti-Patterns

--- a/plugins/asset-pipeline/skills/pixel-snapper/scripts/_lib/asset-tools.mjs
+++ b/plugins/asset-pipeline/skills/pixel-snapper/scripts/_lib/asset-tools.mjs
@@ -82,6 +82,10 @@ function parseArgs(argv, options = {}) {
 function getString(args, key) {
   return args.options.get(key)?.at(-1);
 }
+function getFlag(args, key) {
+  const value = getString(args, key);
+  return value !== void 0 && value !== "false";
+}
 function getInt(args, key, fallback) {
   const raw = getString(args, key);
   if (raw === void 0) return fallback;
@@ -1217,6 +1221,17 @@ function snapImage(inputPath, config) {
   const rowCuts = sanitizeCuts(walk(rows, stepY, image.height, config), image.height);
   return resample(quantized, colCuts, rowCuts);
 }
+var DEGENERATE_SIDE = 8;
+function snapWarning(input, output, config) {
+  if (output.width < DEGENERATE_SIDE || output.height < DEGENERATE_SIDE) {
+    return `recovered grid collapsed to ${output.width}x${output.height} from ${input.width}x${input.height} \u2014 there was no pixel grid to find. Key the background out first (a flat matte hides the grid), or the source is not upscaled pixel art at all`;
+  }
+  const fallback = config.fallbackTargetSegments;
+  if (output.width === fallback && output.height === fallback) {
+    return `output is exactly ${fallback}x${fallback}: step detection found no structure and fell back to a fixed segment count, so these are not the source's own pixels`;
+  }
+  return null;
+}
 function snapSheet(image, cols, rows, config) {
   const { width: W, height: H } = image;
   if (W % cols !== 0 || H % rows !== 0) {
@@ -1297,11 +1312,13 @@ export {
   DEFAULT_SNAP_CONFIG,
   fail,
   failUsage,
+  getFlag,
   getInt,
   getString,
   main,
   parseArgs,
   readImageSize,
   snapImage,
-  snapSheet
+  snapSheet,
+  snapWarning
 };

--- a/plugins/asset-pipeline/skills/pixel-snapper/scripts/pixel_snapper.mjs
+++ b/plugins/asset-pipeline/skills/pixel-snapper/scripts/pixel_snapper.mjs
@@ -3,22 +3,31 @@
  * Recover the underlying low-resolution pixel-art grid from an upscaled or
  * AI-generated image. Port of Hugo-Dz/spritefusion-pixel-snapper.
  *
+ * Output resolution is discovered, not requested, so the only signal that the
+ * run went wrong is the dimensions — which is why an implausible result is
+ * reported here instead of being left for the caller to notice.
+ *
  * Usage:
  *   node pixel_snapper.mjs input.png output.png [--k-colors 256] [--seed 42]
+ *   node pixel_snapper.mjs input.png output.png --strict   # exit 1 on a bad snap
  */
 import {
+  Bitmap,
   DEFAULT_SNAP_CONFIG,
   fail,
   failUsage,
+  getFlag,
   getInt,
   main,
   parseArgs,
   snapImage,
+  snapWarning,
 } from "./_lib/asset-tools.mjs";
 
 main(() => {
   const args = parseArgs(process.argv.slice(2), {
     values: ["k-colors", "seed"],
+    booleans: ["strict"],
   });
   const [input, output] = args.positionals;
   if (!input || !output) {
@@ -28,11 +37,14 @@ main(() => {
   const kColors = getInt(args, "k-colors", 16);
   if (kColors <= 0) fail("--k-colors must be a positive integer");
 
-  const snapped = snapImage(input, {
-    ...DEFAULT_SNAP_CONFIG,
-    kColors,
-    kSeed: getInt(args, "seed", 42),
-  });
+  const config = { ...DEFAULT_SNAP_CONFIG, kColors, kSeed: getInt(args, "seed", 42) };
+  const snapped = snapImage(input, config);
   snapped.toFile(output);
   console.log(`Snapped ${input} -> ${output} (${snapped.width}x${snapped.height})`);
+
+  const warning = snapWarning(Bitmap.fromFile(input), snapped, config);
+  if (warning) {
+    console.error(`[pixel_snapper] warning: ${warning}`);
+    if (getFlag(args, "strict")) process.exit(1);
+  }
 });


### PR DESCRIPTION
End-to-end test of the `animated-spritesheets`, `pixel-snapper` and `asset-pipeline` skills exactly as a user receives them: `npm install -g vibedgames@latest` (0.4.0) → `vg init` → run the documented commands. Stubs named `python`, `python3`, `uv`, `jq`, `ffmpeg`, `ffprobe`, `convert`, `magick`, `sips`, `pip`, `pip3`, `aseprite` were placed first on `PATH`, each printing `TRIPWIRE: <name>` and exiting 127.

## The no-dependency claim holds

**Zero tripwires fired.** 21 scripts × (`--help` + a real invocation) with the stubs in front, all clean. `--help` works on all 21; a misspelled flag exits 2 with `unrecognized arguments` on all 21. Real outputs were produced and checked: a packed `spritesheet.png` + manifest, snapped PNGs, GIFs, tileset grid overlays, map renders, a hand-built `.aseprite` parsed to correct decoded cel bounds. The tilemap `--edit` browser UI serves, enforces its token (403 without), refuses a `../../` write, and renders headless.

One caveat, outside the three skills tested: `image-to-threejs` still runs on `uv` + Python 3.12, and its installed frontmatter `description` does not say so — the requirement only appears at line 48 of the body. An agent picking skills by description would not know. Left alone here; flagging it.

## Bugs found and fixed

Everything below exits **0** while producing wrong output — the failure mode with no fingerprint.

### 1. Lua `meta.root` ignored — the Love2D headline use case (`asset_manifest_check`, `asset_manifest_export_json`)

`meta.root` was read for JSON manifests and dropped for Lua ones. With `meta = { root = "assets" }`:

```
$ asset_manifest_check.mjs --manifest assets_index.lua --root assets
manifest paths: 2
actual pngs:    2
missing:        2
  MISSING assets/Spritesheets/knight_attack.png
  MISSING assets/Tilesets/knight_tiles.png
extra:          2
  EXTRA Spritesheets/knight_attack.png
  EXTRA Tilesets/knight_tiles.png
exit=0
```

Both files exist and are declared. The byte-identical JSON manifest reports `0 / 0`.

`asset_manifest_export_json` had the same blind spot plus a second: relative paths resolved against `process.cwd()`, so the export depended on where it was run from, and any path that escaped the base was left untouched next to `meta.root = "."` — a manifest pointing at files that were never there. It emitted `path: "Tilesets/knight_tiles.png"`, silently dropping `assets/`.

Fixed: `meta.root` is honoured for both formats; the export folds it in, rebases onto `--out`'s folder as the docs promise, and emits a truthful `../` rather than a wrong-but-tidy path. Existing tests missed all of this because they used absolute paths and Lua manifests without a root.

`asset_manifest_check` also exited 0 while reporting 726 missing files. Added `--strict`.

### 2. `sheet_qc` reports CLEAN on a sheet with the cell grid baked in

The headline finding. A real `nano-banana-pro/edit` pose board came back with the cell outlines inked, despite the prompt forbidding them. `process_sheet` sliced it, and every runtime frame carries a black rule. Verdict: `clean`, `border_frac: 0` on all eight frames.

It is worse than one missed defect. The rule joins each frame's alpha bounding box, so `size`, `baseline` and `facing` all measure the rectangle instead of the character — perfectly uniform, so every other check goes quiet too. The `clip` check can't see it either: `normalize_canvas` insets the frame and the rule travels inwards with it.

Added a hard `grid` check: a bbox edge ≥95% opaque across its full span with the line 3px inside ≤50% opaque is a drawn rule, not a silhouette. The thinness half is what spares a legitimately solid sprite, which is opaque well inside its own edge. Validated on the real sheet (8/8 flagged, both the snapped and `--no-pixel-snap` runs) with a synthetic control that must stay clean.

### 3. `pixel_snapper` writes a collapsed grid as if it succeeded

```
$ pixel_snapper.mjs cells/frame-02.png out.png --k-colors 256
Snapped cells/frame-02.png -> out.png (2x2)
exit=0
```

600×597 in, 2×2 out. The input is a sprite on a flat chroma matte — the canonical input this skill exists for — and the flat background leaves the walker nothing but its own few edges. Output resolution is discovered rather than requested, so the dimensions are the *only* signal, and the script printed them as success. SKILL.md tells the agent to eyeball them; nothing enforced it.

Now warns on both collapse modes (absurdly small, and the exact fallback square meaning step detection found no structure), with `--strict` to exit 1. A good snap stays silent. SKILL.md gains the actual fix: key the background out before snapping.

### 4. `vg generate --download x.png` writes JPEG into a `.png`

Step 0 of the documented `animated-spritesheets` path:

```
$ vg generate run fal-ai/flux/dev --prompt "..." --download anchor.png --json
"downloaded_files": [".../anchor.png"]

$ file anchor.png
anchor.png: JPEG image data, JFIF standard 1.01, ... 1024x1024
```

Every script in these skills is a PNG-only decoder by design — and with no Pillow, ImageMagick, ffmpeg or `sips` there is nothing to convert with. The agent gets `Not a PNG file (bad signature)` several commands later with nothing pointing back at the download.

The path is still honoured as asked (renaming would break whatever the caller wired it into); the mismatch is now reported — a warning on the human path, `download_format_mismatches` in `--json`. Verified against a live run. SKILL.md now says which endpoints return which format.

## Smaller

- `chroma_clean --help` listed subcommands and no flags, so `--input` / `--out` / `--out-dir` were undiscoverable from the CLI. Added.

## Not fixed, worth knowing

- **Tilemap editor palette at a non-16px tile size.** `paletteScale` is hardcoded to 3, so a 128×128 tileset renders the palette at 384px per tile in a ~310px panel — technically scrollable, practically unusable. Fine at the skill's documented 16×16 convention.
- **`missing` / `extra` read backwards** in `asset_manifest_check` output (`missing` = on disk but undeclared). The doc comment defines them deliberately; only the terminal output is ambiguous. Clarified in SKILL.md rather than renamed.

## Verification

`pnpm verify` green. Every fix re-run against the same real artifacts with the tripwire stubs still first on `PATH`. New tests: 3 for the manifest resolution, 2 for the grid check (including the no-false-positive control), 2 for the download mismatch.

Generation spend for this test: **$0.20** (one `flux/dev` anchor, one `nano-banana-pro/edit` board, one `flux/dev` run to verify the CLI fix live). Note the account ledger also shows three `nano-banana-pro` requests at 14:31, 14:34 and 14:35 UTC that this session did not issue — a concurrent session, worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAcHkLyFRN4qVyU8jfaemZ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four silent-wrong-output cases across `asset-tools`, `apps/cli`, and the published skills. Previously these paths exited 0 while producing bad artifacts; now they warn or fail in strict mode, and manifest paths resolve through `meta.root` as documented.

**Key changes**
- Manifest resolution (`asset_manifest_check`, `asset_manifest_export_json`):
  - Old: Lua `meta.root` ignored; export resolved relative paths via `process.cwd()` and dropped `../` escapes; checker exited 0 on mismatches.
  - New: `meta.root` honored for Lua and JSON; export folds `meta.root`, rebases paths onto `--out`’s folder, and emits `../` when true; `--strict` added to fail on any `missing`/`extra`. Tests cover both formats.
- Sheet QC (`sheet_qc`):
  - Old: Pose boards with inked cell grids sliced clean and reported `clean`.
  - New: Adds a `grid` hard warn by detecting ruled bbox edges; instructs to regenerate instead of trusting other metrics. No false positives on solid blocks.
- Pixel snapper (`pixel_snapper.mjs` and `packages/asset-tools`):
  - Old: Collapsed snaps (e.g., 2×2 or exact fallback square) wrote as success.
  - New: Prints a warning for collapse modes; `--strict` exits 1; docs tell users to key mattes first. Exposes `snapWarning`.
- CLI downloads (`vg generate`):
  - Old: `--download x.png` could write JPEG bytes into `.png` with no hint.
  - New: Warns on extension/bytes mismatch and includes `download_format_mismatches` in `--json`; still writes the requested path.
- Smaller: `chroma_clean.mjs --help` lists `--input`/`--out`/`--out-dir`.

**Rollout and migration**
- CI and scripts should pass `--strict` to `asset_manifest_check.mjs` and `pixel_snapper.mjs` to fail fast on bad outputs.
- Consumers of `vg generate --json` should handle the new `download_format_mismatches` array.
- If code enumerates QC checks, include the new `grid` check.
- If anything relied on `asset_manifest_export_json` suppressing `../`, expect paths rebased to the `--out` folder with `meta.root` set to `"."`.

<sup>Written for commit 522f5865dd55ec44f33f87e312041b5579682bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

