### PR TITLE
Fold 3D audit craft into the threejs skill (no new skill)

### DIFF
--- a/plugins/game-engines/skills/threejs/SKILL.md
+++ b/plugins/game-engines/skills/threejs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: threejs
-description: "Build 3D browser apps AND games with Three.js (r150+, ES modules): scene setup, geometries, materials, lighting, animation, GLTF models, physics (Rapier/cannon-es/arcade), character controllers, follow/third-person cameras, fixed-timestep loops, post-processing, and performance/debugging. Use for 'create a three.js scene/app/showcase', any 3D web content, and turning a scene into a game — 'add physics to my three.js game', 'third-person/character controller', 'follow camera', 'jump and gravity', 'collide with / pick up objects', 'structure my 3d game'. Trigger: threejs, three.js, 3D scene, WebGL scene, GLTF/GLB, OrbitControls, Rapier, cannon-es, 3D game, third-person controller. For 2D games use `phaser`; for engine-agnostic feel/balance/level craft use the game-craft skills."
+description: "Build 3D browser apps AND games with Three.js (r150+, ES modules): scene setup, geometries, materials, lighting, animation, GLTF models, physics (Rapier/cannon-es/arcade), character controllers, follow/third-person cameras, fixed-timestep loops, post-processing, and performance/debugging. Use for 'create a three.js scene/app/showcase', any 3D web content, and turning a scene into a game — 'add physics to my three.js game', 'third-person/character controller', 'follow camera', 'jump and gravity', 'collide with / pick up objects', 'structure my 3d game'. Also for auditing a 3D scene that already exists — 'my three.js game is slow', 'the framerate drops the longer I play', 'memory keeps climbing', 'why does it look washed out', 'the shadows are wrong', 'the canvas is blurry on mobile'. Trigger: threejs, three.js, React Three Fiber, R3F, react-three-fiber, drei, 3D scene, WebGL scene, GLTF/GLB, OrbitControls, Rapier, cannon-es, 3D game, third-person controller. For 2D games use `phaser`; for engine-agnostic feel/balance/level craft use the game-craft skills."
 ---
 
 # Three.js
@@ -27,18 +27,19 @@ Everything else — camera rigs, enemy waves, pathfinding, steering, minimaps, i
 
 Scene setup is inline below. Read the relevant reference before working on that area:
 
-| When you're working on...                                                          | Read first                              |
-| ---------------------------------------------------------------------------------- | --------------------------------------- |
-| Character locomotion / Rapier character collision / smoothing / seeded RNG         | `modules/summary.md`                    |
-| Turning a scene into a playable game (fixed-timestep loop, structure)              | `references/gameplay-systems.md`        |
-| Physics or collision (Rapier / cannon-es / arcade overlap)                         | `references/physics.md`                 |
-| Movement controllers + follow/third-person camera                                  | `references/controllers-and-camera.md`  |
-| Loading/caching/normalizing GLTF/GLB models                                        | `references/gltf-loading-guide.md`      |
-| Game loop, state machine, object pooling, screen effects                           | `references/game-patterns.md`           |
-| Dropping generated GLB models / SFX into a running scene                           | `references/generated-assets.md`        |
-| Post-processing, shaders, instancing, env maps, color management                   | `references/advanced-topics.md`         |
-| Material values, shader injection (onBeforeCompile), sky, cheap tricks, z-fighting | `references/graphics-recipes.md`        |
-| Black screen, low FPS, mobile issues, memory leaks, physics debugging              | `references/debugging-and-profiling.md` |
+| When you're working on...                                                                                        | Read first                              |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Character locomotion / Rapier character collision / smoothing / seeded RNG                                       | `modules/summary.md`                    |
+| Turning a scene into a playable game (fixed-timestep loop, structure)                                            | `references/gameplay-systems.md`        |
+| Physics or collision (Rapier / cannon-es / arcade overlap)                                                       | `references/physics.md`                 |
+| Movement controllers + follow/third-person camera                                                                | `references/controllers-and-camera.md`  |
+| Loading/caching/normalizing GLTF/GLB models                                                                      | `references/gltf-loading-guide.md`      |
+| Game loop, state machine, object pooling, screen effects                                                         | `references/game-patterns.md`           |
+| Dropping generated GLB models / SFX into a running scene                                                         | `references/generated-assets.md`        |
+| Post-processing, shaders, instancing, env maps, color management                                                 | `references/advanced-topics.md`         |
+| Material values, shader injection (onBeforeCompile), sky, cheap tricks, z-fighting, shadow acne, texture shimmer | `references/graphics-recipes.md`        |
+| Black screen, low FPS, mobile issues, memory leaks, physics debugging                                            | `references/debugging-and-profiling.md` |
+| Auditing a scene you didn't write, visual-defect sweeps, React Three Fiber (R3F)                                 | `references/debugging-and-profiling.md` |
 
 **Verify it actually renders.** `scripts/check-canvas.mjs` loads a build in headless Chromium and fails on a blank canvas or uncaught page error — run it in CI / before `vg deploy` (details in `references/debugging-and-profiling.md`).
 

--- a/plugins/game-engines/skills/threejs/references/debugging-and-profiling.md
+++ b/plugins/game-engines/skills/threejs/references/debugging-and-profiling.md
@@ -98,6 +98,93 @@ setInterval(() => {
 
 ---
 
+## Auditing a scene you didn't just write
+
+Debugging starts from a symptom. An audit doesn't: nothing is obviously broken, so the failure mode is fixing whatever you happened to read first. Rank by **where the code runs**.
+
+**Severity follows the render loop.** A line inside `setAnimationLoop`, a RAF callback, or an R3F `useFrame` runs 60 times a second; the same line in a menu handler runs once. Before judging anything, build a **hot-path map** — every frame-loop body, every pointer-move handler, and every function they call. A finding inside that map outranks a worse-looking one outside it.
+
+```bash
+rg -n 'setAnimationLoop|requestAnimationFrame|useFrame|frameloop=' src/   # where the loop lives
+rg -n 'new (THREE\.)?(Vector[234]|Quaternion|Matrix4|Euler|Color|Raycaster)\(' src/
+rg -n 'new (THREE\.)?\w*(Geometry|Material|Texture|RenderTarget)\(' src/  # each needs a dispose()
+```
+
+A grep hit is a lead, not a finding — confirm each at its `file:line`. Inside the hot-path map it's HIGH; outside it's usually noise.
+
+**HIGH — runs every frame, or leaks GPU memory**
+
+- Allocation inside the loop — hoist a module-scope scratch object and mutate it in place (§ Performance, "GC stutter")
+- Undisposed geometry / material / texture / render target, **including objects replaced mid-game**, not just torn down at exit (§ Memory leaks)
+- `scene.traverse` every frame, or raycasting the whole scene on every pointer move — cache the list, raycast a filtered target array
+- Physics bodies that outlive the entity that owned them (§ Physics & collision, #6)
+
+**MEDIUM — per-render or per-interaction waste**
+
+- Identical meshes drawn individually instead of through `InstancedMesh` (§ Performance, fixes table)
+- Uncapped device pixel ratio (§ Mobile-specific)
+- Assets loaded per instance instead of through one shared, cached loader ([`gltf-loading-guide.md`](gltf-loading-guide.md))
+- Debug tooling still in the production bundle — the `vg new --engine threejs` template ships `lil-gui` and `stats.js` on purpose, and shipping them is easy to miss
+
+**What no tool will flag — check these by hand**
+
+- `dispose()` coverage for every imperatively created GPU resource
+- Event listeners and `ResizeObserver`s on the canvas or window with no cleanup
+- Color space set on the renderer _and_ on every color texture ([`advanced-topics.md`](advanced-topics.md))
+- Shadows or post-processing enabled globally when only part of the scene needs them
+
+Do not "fix" authored feel. A camera that lags on purpose, a deliberately flat-lit style, a capped frame budget — those are design decisions. If it looks wrong but reads as deliberate, raise it as a question rather than patching it.
+
+### React Three Fiber
+
+`vg new --engine react-r3f` scaffolds R3F, where the same failures wear different clothes:
+
+| Vanilla Three.js                           | React Three Fiber                                                                                     |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Allocation inside `setAnimationLoop`       | Allocation inside `useFrame` — hoist to `useMemo` or module scope                                     |
+| _(no equivalent)_                          | `setState` inside `useFrame` re-renders the tree 60×/s — mutate refs, keep state for discrete changes |
+| Every `dispose()` is manual                | R3F owns anything in the declarative tree; imperatively created objects are still yours               |
+| Rebuilding a geometry each frame           | Geometry/material without `useMemo`, or inline `args` whose identity changes each render              |
+| `InstancedMesh`                            | `<Instances>`                                                                                         |
+| One shared, cached loader                  | `useLoader` / `useTexture` / `useGLTF`                                                                |
+| Stop calling `render()` when nothing moves | `frameloop="demand"` + `invalidate()` — for showcases and viewers, not games                          |
+
+Plain-array props (`position={[x, y, z]}`) are fine — R3F handles them. A fresh object as a prop (`new THREE.Vector3()` inline) is not.
+
+For the React half of an R3F app — the component tree outside the canvas — `npx react-doctor@latest --verbose` scans read-only and reports React-level problems. It sees nothing Three.js-specific, so it complements the list above rather than replacing it.
+
+---
+
+## Visual defects — sweep with evidence
+
+A scene can render, hit every budget, and still look wrong. These defects never reach the console, so hunt them deliberately — and against **frames**, never against source. `vg playtest` (see the `playtest` skill) drives a real browser:
+
+```bash
+vg playtest open http://localhost:5173
+vg playtest screenshot /tmp/first.png
+```
+
+Capture the first stable frame, then capture again after moving the camera and interacting: several rows below only fail at a grazing angle or after a transition. With no browser available, check the causes from source and label each finding **inferred, not observed** — reading code and guessing is how you "fix" a defect that was never there.
+
+A row fails only when the evidence shows the failure condition.
+
+| Area                   | Exercise it like this                                         | Fails when                                                                              | Usual cause                                                            |
+| ---------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Render sanity          | Load, wait for a stable frame                                 | Black canvas, WebGL context error, or content that never appears                        | § Black screen                                                         |
+| Geometry               | Move along seams, edges, boundaries                           | Gaps, missing faces, visible backfaces, two surfaces flickering at one depth            | Z-fighting → `graphics-recipes.md`; backfaces → material `side`        |
+| Transparency and depth | Cross depth order with overlapping or transmissive surfaces   | Wrong sort order, halos, flicker at grazing angles                                      | `depthWrite: false` + `renderOrder` (`graphics-recipes.md`)            |
+| Textures               | View mapped surfaces close, far, and at a grazing angle       | Missing, stretched, seams, moiré, or washed-out color                                   | Color space (`advanced-topics.md`); moiré → anisotropy                 |
+| Materials and lighting | Change light direction and view direction on lit surfaces     | Surfaces that ignore light direction; metals with nothing to reflect                    | `metalness: 1` needs `scene.environment` (`advanced-topics.md`)        |
+| Shadows                | Move casters, receivers, and the light through their range    | Acne, detached or floating shadows, flicker at rest, shadows outliving their caster     | `graphics-recipes.md` § Shadow Acne                                    |
+| Camera                 | Follow the subject through movement and transitions           | Subject leaves frame, camera clips into geometry, foreground blocks the play area       | [`controllers-and-camera.md`](controllers-and-camera.md)               |
+| Scale and contact      | Compare object scale and resting contact against surroundings | Objects float above, sink into, or intersect their support, or sit at implausible scale | Model normalization ([`gltf-loading-guide.md`](gltf-loading-guide.md)) |
+| Image stability        | Pan the camera slowly at the resolutions you support          | Silhouettes, thin geometry, or highlights that crawl, sparkle, or ghost                 | `graphics-recipes.md` § Texture Shimmer                                |
+| Resize and DPR         | Change viewport size, zoom, and device pixel ratio            | Distortion, blur, stretched output, or content leaving the viewport                     | Resize handler + `updateProjectionMatrix` (§ Mobile-specific)          |
+
+After fixing, re-shoot every failed row **from the same viewpoint and interaction** as the original evidence — a different angle proves nothing about the defect you were chasing.
+
+---
+
 ## Memory leaks
 
 Three.js does **not** garbage-collect GPU resources when you `scene.remove()`. Removing a mesh leaves its geometry, material, and textures resident. Watch `renderer.info.memory` climb across level reloads — if `geometries`/`textures` only ever grow, you're leaking.

--- a/plugins/game-engines/skills/threejs/references/graphics-recipes.md
+++ b/plugins/game-engines/skills/threejs/references/graphics-recipes.md
@@ -348,3 +348,56 @@ Two surfaces at the same depth (road markings on a road, a rug on a floor, poste
 4. **Fix depth precision itself** — if surfaces that aren't even coplanar shimmer at distance, the near/far ratio is the problem. Depth precision is spent overwhelmingly near the `near` plane: raising `near` from `0.01` to `0.5` buys far more precision than shrinking `far` ever will. Never set `near: 0` (breaks the depth buffer entirely). `logarithmicDepthBuffer: true` on the renderer is the last resort for huge view distances — it costs performance and breaks materials that read the depth buffer (soft particles, some post-processing).
 
 Debugging tip: if the flicker only happens while the camera is moving and far from the surfaces, it's precision (#4). If it's stable-distance and always the same pair of surfaces, they're coplanar (#1–#3).
+
+---
+
+## Shadow Acne, Peter-Panning & Shadow Flicker
+
+Shadows have three distinct failure looks, and they pull in opposite directions — fixing one by feel usually creates another.
+
+1. **Acne** — dark stripes or moiré crawling across lit surfaces. The surface is shadowing itself: its depth and the shadow map's depth land within one texel of each other. Raise `bias` slightly negative, or better, use `normalBias`, which offsets along the surface normal and doesn't detach contact:
+
+   ```javascript
+   light.shadow.bias = -0.0005; // tiny — -0.01 is already far too much
+   light.shadow.normalBias = 0.02; // scale to world units; the better first knob
+   ```
+
+2. **Peter-panning** — the shadow detaches and the object looks like it floats. This is over-corrected acne: `bias` pushed too far negative. Back it off and lean on `normalBias` instead. If you must keep a large bias, thicken thin casters — a plane casts a shadow no thicker than its geometry.
+
+3. **Flicker at rest, or shadows that swim as the camera moves** — the shadow camera frustum is far larger than what it needs to cover, so each texel spans too much world space. Shrink the directional light's orthographic frustum to the play area, not the whole world:
+
+   ```javascript
+   const c = light.shadow.camera; // OrthographicCamera for DirectionalLight
+   c.left = -20;
+   c.right = 20;
+   c.top = 20;
+   c.bottom = -20;
+   c.near = 1;
+   c.far = 60;
+   c.updateProjectionMatrix();
+   light.shadow.mapSize.set(2048, 2048);
+   ```
+
+   Halving the frustum buys the same sharpness as doubling `mapSize`, and costs nothing. Use `CameraHelper(light.shadow.camera)` to see what you're actually covering — most "blurry shadows" are a frustum ten times bigger than the scene.
+
+A shadow that outlives the object casting it is not a shadow bug: the mesh was removed from the scene graph but its geometry was never disposed, or a pooled object was hidden with `visible = false` (which still casts). Set `castShadow = false` when parking a pooled object.
+
+---
+
+## Texture Shimmer, Crawl & Moiré
+
+Surfaces that sparkle or crawl while the camera pans — tiled floors, distant detail, thin railings, specular highlights on edges. Three separate causes:
+
+1. **Missing anisotropy** — the default is `1`, which blurs and aliases any texture viewed at a grazing angle. Ground planes and roads are the usual victims:
+
+   ```javascript
+   texture.anisotropy = renderer.capabilities.getMaxAnisotropy(); // clamp to 4–8 on mobile
+   ```
+
+   Set it on every texture of a surface the camera sees edge-on. It is nearly free compared to how much aliasing it removes.
+
+2. **Antialiasing off** — `new THREE.WebGLRenderer({ antialias: true })`. Note that `antialias` is ignored once you render through an `EffectComposer`; a post chain needs its own AA pass (SMAA/FXAA) instead, and losing edge AA the moment post-processing was added is a common regression.
+
+3. **Geometry too thin to survive rasterization** — a railing one pixel wide at distance will sparkle no matter the texture settings, because it lands on a different pixel each frame. Thicken the form, or swap to a LOD that removes it entirely past a distance.
+
+Highlights that crawl on curved surfaces are usually neither: they're a too-smooth `roughness` on low-poly geometry. Raise `roughness` slightly or add normal-map detail to break the specular up.

--- a/plugins/tooling/skills/playtest/SKILL.md
+++ b/plugins/tooling/skills/playtest/SKILL.md
@@ -119,6 +119,8 @@ vg playtest diff snapshot --baseline /tmp/before.txt   # accessibility-tree diff
 
 A baseline taken without freezing the scene first is a flake generator — the freeze checklist and the "when not to take a baseline at all" judgment are in `references/canvas-determinism.md`.
 
+A diff catches a change; it can't tell you the frame was wrong to begin with. For 3D, pair the screenshots with the visual-defect rubric in the `threejs` skill (`references/debugging-and-profiling.md` § Visual defects) — z-fighting, shadow acne, wrong color space, and DPR blur all render "successfully" and pass every smoke check.
+
 ## Anti-Patterns
 
 ❌ **Sleep-driven steps** — `wait 2000` then click


### PR DESCRIPTION
## What

Takes the material from [`improve-threejs`](https://github.com/millionco/react-doctor/tree/main/skills/improve-threejs) in `millionco/react-doctor` and integrates it into the skills that already own each topic. No new skill is added — the earlier version of this PR added one beside `threejs`, and this replaces it.

## Where each piece landed

**`threejs/references/debugging-and-profiling.md`**

- **"Auditing a scene you didn't just write."** Debugging starts from a symptom; an audit doesn't, so the failure mode is fixing whatever you read first. Adds the hot-path map, the HIGH/MEDIUM triage ranked by where code runs, and the by-hand checks no tool reports. Every item routes into the section that already covers the fix (§ Performance, § Memory leaks, § Physics) instead of restating it.
- **React Three Fiber.** `vg new --engine react-r3f` is a shipped preset that routes to the `threejs` skill, and the repo had **zero** R3F content anywhere. Adds a vanilla→R3F mapping of the same failures — `useFrame` allocation, `setState` in the loop, `useMemo` and `args` identity, `<Instances>`, `useGLTF`, `frameloop="demand"` — plus `react-doctor` scoped to the React half it can actually see.
- **"Visual defects — sweep with evidence."** The 10-row rubric, run against `vg playtest` frames rather than source, with each usual cause pointing at the existing reference.

**`threejs/references/graphics-recipes.md`** — the two visual-defect families with no coverage at all:

- Shadow acne / peter-panning / shadow flicker — `bias` vs `normalBias`, and frustum sizing (halving the frustum buys what doubling `mapSize` does, for free).
- Texture shimmer / crawl / moiré — anisotropy, AA silently lost once you render through an `EffectComposer`, geometry too thin to rasterize.

**`threejs/SKILL.md`** — routing rows for the new sections, and the description now carries the audit triggers ("my three.js game is slow", "why does it look washed out") and R3F/drei trigger words, so the `react-r3f` preset resolves here.

**`playtest/SKILL.md`** — one line: a visual diff catches a *change*, not a frame that was wrong to begin with; pair the screenshots with the 3D rubric.

## What was deliberately not copied

Z-fighting (already a full section with four ranked fixes), color management, DPR capping, the `disposeObject` walker, and transparency sorting were all already covered. Those rubric rows link to the existing material rather than duplicating it.

The upstream skill is React-Doctor-first; here the scanner is one optional input for R3F projects, since the primary preset is vanilla Three.js and a React scanner sees nothing in a vanilla scene.

## Testing

- `oxfmt --check` clean across 1069 files.
- `scripts/check-skill-refs.ts` clean — 114 markdown files, no broken cross-references.
- The `threejs` and `playtest` skills reload with the edited frontmatter/content.

## Note on provenance

Because this is integrated prose rather than a vendored file, there's no separate `LICENSE` in the tree. Upstream is a Modified MIT license (its restrictions cover ML training data, and selling the software as a product deriving substantially from it) — flagging it so you can decide whether you want an attribution line somewhere; say the word and I'll add one.